### PR TITLE
fix the broken links of jsonline doc

### DIFF
--- a/docs/MatrixOne/Develop/import-data/bulk-load/load-jsonline.md
+++ b/docs/MatrixOne/Develop/import-data/bulk-load/load-jsonline.md
@@ -44,8 +44,8 @@ load data infile {'filepath'='data.txt', 'format'='jsonline','jsondata'='object'
 
 1. Prepare the data files. You can also download and use the *.jl* file we prepared. The following steps are illustrated with sample data.
 
-    - Example data file 1：*[jsonline_object.jl](https://github.com/matrixorigin/matrixone/blob/main/test/resources/load_data/jsonline_object.jl)*
-    - Example data file  2：*[jsonline_array.jl](https://github.com/matrixorigin/matrixone/blob/main/test/resources/load_data/jsonline_array.jl)*
+    - Example data file 1：*[jsonline_object.jl](https://github.com/matrixorigin/matrixone/blob/main/test/distributed/resources/load_data/jsonline_object.jl)*
+    - Example data file  2：*[jsonline_array.jl](https://github.com/matrixorigin/matrixone/blob/main/test/distributed/resources/load_data/jsonline_array.jl)*
 
 2. Open your terminal, enter into the directory where the *.jl* file resides, and run the following command line to display the contents of the file:
 


### PR DESCRIPTION
## What type of PR is this?

- [x] Enhancement
- [ ] Displaying
- [ ] Typo
- [ ] Doc Request

## Which issue(s) this PR fixes:
The link of json file failed，this PR will fix this bug
issue #204 

## What this PR does / why we need it:
