### PR TITLE
docs: fix order when get stable version to build

### DIFF
--- a/docs/MatrixOne/Get-Started/install-standalone-matrixone.md
+++ b/docs/MatrixOne/Get-Started/install-standalone-matrixone.md
@@ -84,8 +84,8 @@ __Tips__: When using MatrixOne source code to build MatrixOne, there is no much 
 
          ```
          git clone https://github.com/matrixorigin/matrixone.git
+         cd matrixone         
          git checkout 0.6.0
-         cd matrixone
          ```
 
      2. Run `make config` and `make build` to compile the MatrixOne file:


### PR DESCRIPTION
We should enter the directory first then checkout to the stable version.

## What type of PR is this?

- [x] Enhancement
- [ ] Displaying
- [ ] Typo
- [ ] Doc Request

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:
We should enter the directory first then checkout to the stable version.