### PR TITLE
enforce consistent 4-space indentation for nested lists and fences

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -5,6 +5,13 @@ default: false
 heading-style:
   style: atx
 
+## MD005
+list-indent: 4
+
+## MD007
+ul-indent:
+  indent: 4
+
 # MD009
 no-trailing-spaces: true
 

--- a/docs/MatrixOne/Contribution-Guide/How-to-Contribute/report-an-issue.md
+++ b/docs/MatrixOne/Contribution-Guide/How-to-Contribute/report-an-issue.md
@@ -79,8 +79,8 @@ Before asking a question, make sure you have:
 
 - Searched open and closed [GitHub issues](https://github.com/matrixorigin/matrixone/issues)
 - Read the documentation:
-  - [MatrixOne Readme](https://github.com/matrixorigin/matrixone)
-  - [MatrixOne Doc](https://docs.matrixorigin.cn/en/)
+    - [MatrixOne Readme](https://github.com/matrixorigin/matrixone)
+    - [MatrixOne Doc](https://docs.matrixorigin.cn/en/)
 
 ## **Issue Labels**
 

--- a/docs/MatrixOne/Performance-Tuning/explain/explain-overview.md
+++ b/docs/MatrixOne/Performance-Tuning/explain/explain-overview.md
@@ -47,8 +47,8 @@ EXPLAIN SELECT * FROM t WHERE a = 1;
 
 - QUERY PLAN: the name of an operator.
 
-   + Filter Cond:Filter conditions
-   + Table Scan:scans the table
+    + Filter Cond:Filter conditions
+    + Table Scan:scans the table
 
 - **Project** is the parent node of the executive order in the query process. The structure of the Project is tree-like, and the child node "flows into" the parent node after the calculation is completed. The parent, child, and sibling nodes may execute parts of the query in parallel.
 

--- a/docs/MatrixOne/Performance-Tuning/explain/explain-subqueries.md
+++ b/docs/MatrixOne/Performance-Tuning/explain/explain-subqueries.md
@@ -6,23 +6,23 @@ From the execution of SQL statements, subquery generally has the following two t
 
 - **Self-contained Subquery**: In a database nested query, the inner query is entirely independent of the outer query.
 
-     For example: ``select * from t1 where t1.id in (select t2.id from t2 where t2.id>=3);``, the execution sequence is as follows:
+    For example: ``select * from t1 where t1.id in (select t2.id from t2 where t2.id>=3);``, the execution sequence is as follows:
 
-     + Execute the inner query first: `(select t2.id from t2 where t2.id>=3)`.
+    + Execute the inner query first: `(select t2.id from t2 where t2.id>=3)`.
 
-     + The result of the inner query is carried into the outer layer, and then the outer query is executed.
+    + The result of the inner query is carried into the outer layer, and then the outer query is executed.
 
 - **Correlated Subquery**: In Correlated Subquery nested in databases, the inner and outer queries would not be independent, and the inner queries would depend on the outer queries.
 
-     For example: ``SELECT * FROM t1 WHERE id in (SELECT id FROM t2 WHERE t1.ti = t2.ti and t2.id>=4);``, generally, the execution sequence is as follows:
+    For example: ``SELECT * FROM t1 WHERE id in (SELECT id FROM t2 WHERE t1.ti = t2.ti and t2.id>=4);``, generally, the execution sequence is as follows:
 
-     + Queries a record from the outer query: `SELECT * FROM t1 WHERE id`.
+    + Queries a record from the outer query: `SELECT * FROM t1 WHERE id`.
 
-     + Put the queried records into the inner query, then put the records that meet the conditions into the outer query.
+    + Put the queried records into the inner query, then put the records that meet the conditions into the outer query.
 
-     + Repeat the above steps.
+    + Repeat the above steps.
 
-     However, MatrixOne will rewrite the SQL statement as an equivalent `JOIN` statement: `select t1.* from t1 join t2 on t1.id=t2.id where t2.id>=4;`
+    However, MatrixOne will rewrite the SQL statement as an equivalent `JOIN` statement: `select t1.* from t1 join t2 on t1.id=t2.id where t2.id>=4;`
 
 ## Example
 

--- a/docs/MatrixOne/Reference/Functions-and-Operators/Aggregate-Functions/sleep.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/Aggregate-Functions/sleep.md
@@ -23,29 +23,29 @@ SLEEP(duration)
 
 - When SLEEP() returns 1 (with interruption or time out), the query returns no error.
 
-   For example:
+    For example:
 
-   1. In session 1, execute the following command to query the current connection_id and execute the `SLEEP()` function:
+    1. In session 1, execute the following command to query the current connection_id and execute the `SLEEP()` function:
 
-       ```sql
-       mysql> select connection_id();
-       +-----------------+
-       | connection_id() |
-       +-----------------+
-       |            1476 |
-       +-----------------+
-       1 row in set (0.03 sec)
-       mysql> select sleep(200);
-       ```
+        ```sql
+        mysql> select connection_id();
+        +-----------------+
+        | connection_id() |
+        +-----------------+
+        |            1476 |
+        +-----------------+
+        1 row in set (0.03 sec)
+        mysql> select sleep(200);
+        ```
 
-   2. At this point, open a new session, interrupt session 1, and run the following command.
+    2. At this point, open a new session, interrupt session 1, and run the following command.
 
-       ```sql
-       mysql> kill 1463;
-       Query OK, 0 rows affected (0.00 sec)
-       ```
+        ```sql
+        mysql> kill 1463;
+        Query OK, 0 rows affected (0.00 sec)
+        ```
 
-    3. Checke the query result of session 1:
+    3. Check the query result of session 1:
 
         ```
         mysql> select sleep(200);
@@ -59,10 +59,10 @@ SLEEP(duration)
 
 - When SLEEP() returns an error (part of a query is uninterrupted). For example:
 
-   ```sql
-   mysql> SELECT 1 FROM t1 WHERE SLEEP(1000);
-   ERROR 20101 (HY000): internal error: pipeline closed unexpectedly
-   ```
+    ```sql
+    mysql> SELECT 1 FROM t1 WHERE SLEEP(1000);
+    ERROR 20101 (HY000): internal error: pipeline closed unexpectedly
+    ```
 
 ## **Examples**
 

--- a/docs/MatrixOne/Reference/Functions-and-Operators/Json/json-functions.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/Json/json-functions.md
@@ -31,11 +31,11 @@ Path syntax uses a leading $ character to represent the JSON document under cons
 
 - Paths can contain * or ** wildcards:
 
-   + .[*] evaluates to the values of all members in a JSON object.
+    + .[*] evaluates to the values of all members in a JSON object.
 
-   + [*] evaluates to the values of all elements in a JSON array.
+    + [*] evaluates to the values of all elements in a JSON array.
 
-   + prefix**suffix evaluates to all paths that begin with the named prefix and end with the named suffix.
+    + prefix**suffix evaluates to all paths that begin with the named prefix and end with the named suffix.
 
 - A path that does not exist in the document (evaluates to nonexistent data) evaluates to NULL.
 

--- a/docs/MatrixOne/Reference/Operators/interval.md
+++ b/docs/MatrixOne/Reference/Operators/interval.md
@@ -8,13 +8,13 @@
 
 - Temporal arithmetic also can be performed in expressions using INTERVAL together with the `+` or `-` operator:
 
-```
-date + INTERVAL expr unit
-date - INTERVAL expr unit
-```
+    ```
+    date + INTERVAL expr unit
+    date - INTERVAL expr unit
+    ```
 
-  + INTERVAL expr unit is permitted on either side of the `+` operator if the expression on the other side is a date or datetime value.
-  + For the `-` operator, INTERVAL expr unit is permitted only on the right side, because it makes no sense to subtract a date or datetime value from an interval.
+    + INTERVAL expr unit is permitted on either side of the `+` operator if the expression on the other side is a date or datetime value.
+    + For the `-` operator, INTERVAL expr unit is permitted only on the right side, because it makes no sense to subtract a date or datetime value from an interval.
 
 ## **Syntax**
 

--- a/docs/MatrixOne/Reference/Operators/operators/cast-functions-and-operators/convert.md
+++ b/docs/MatrixOne/Reference/Operators/operators/cast-functions-and-operators/convert.md
@@ -27,9 +27,9 @@ Or:
 
 Currently, `convert` can support following conversion:
 
- * Conversion between numeric types, mainly including SIGNED, UNSIGNED, FLOAT, and DOUBLE type.
- * Numeric types to character CHAR type.
- * Numeric character types to numerical types(negative into SIGNED).
+* Conversion between numeric types, mainly including SIGNED, UNSIGNED, FLOAT, and DOUBLE type.
+* Numeric types to character CHAR type.
+* Numeric character types to numerical types(negative into SIGNED).
 
 ## **Examples**
 

--- a/docs/MatrixOne/Reference/Operators/operators/flow-control-functions/function_if.md
+++ b/docs/MatrixOne/Reference/Operators/operators/flow-control-functions/function_if.md
@@ -16,13 +16,13 @@ The `IF()` function returns a value if a condition is `TRUE`, or another value i
 
 - The default return type of IF() (which may matter when it is stored into a temporary table) is calculated as follows:
 
-  + If expr2 or expr3 produce a string, the result is a string.
+    + If expr2 or expr3 produce a string, the result is a string.
 
-  + If expr2 and expr3 are both strings, the result is case-sensitive if either string is case-sensitive.
+    + If expr2 and expr3 are both strings, the result is case-sensitive if either string is case-sensitive.
 
-  + If expr2 or expr3 produce a floating-point value, the result is a floating-point value.
+    + If expr2 or expr3 produce a floating-point value, the result is a floating-point value.
 
-  + If expr2 or expr3 produce an integer, the result is an integer.
+    + If expr2 or expr3 produce an integer, the result is an integer.
 
 ## **Examples**
 

--- a/docs/MatrixOne/Reference/SQL-Reference/Data-Control-Language/grant.md
+++ b/docs/MatrixOne/Reference/SQL-Reference/Data-Control-Language/grant.md
@@ -53,11 +53,11 @@ The `GRANT` statement enables *account* to grant privileges and roles, which can
 
 - The `ON` clause distinguishes whether the statement grants privileges or roles:
 
-   + With `ON`, the statement grants privileges.
+    + With `ON`, the statement grants privileges.
 
-   + Without `ON`, the statement grants roles.
+    + Without `ON`, the statement grants roles.
 
-   + It is permitted to assign both privileges and roles to an account, but you must use separate GRANT statements, each with syntax appropriate to what is to be granted.
+    + It is permitted to assign both privileges and roles to an account, but you must use separate GRANT statements, each with syntax appropriate to what is to be granted.
 
 To grant a privilege with `GRANT`, you must have the `GRANT OPTION` privilege, and you must have the privileges that you are granting.
 

--- a/docs/MatrixOne/Reference/SQL-Reference/Data-Manipulation-Language/update.md
+++ b/docs/MatrixOne/Reference/SQL-Reference/Data-Manipulation-Language/update.md
@@ -42,7 +42,7 @@ mysql> select * from t1;
 +------+------+
 ```
 
-- - **Multiple-table Examples**
+- **Multiple-table Examples**
 
 ```sql
 drop table if exists t1;

--- a/docs/MatrixOne/Reference/System-tables.md
+++ b/docs/MatrixOne/Reference/System-tables.md
@@ -378,10 +378,10 @@ The description of columns in the `COLUMNS` table is as follows:
 - `COLLATION_NAME`: The name of the collation of a string column.
 - `COLUMN_TYPE`: The column type.
 - `COLUMN_KEY`: Whether this column is indexed. This field might have the following values:
-  - `Empty`: This column is not indexed, or this column is indexed and is the second column in a multi-column non-unique index.
-  - `PRI`: This column is the primary key or one of multiple primary keys.
-  - `UNI`: This column is the first column of the unique index.
-  - `MUL`: The column is the first column of a non-unique index, in which a given value is allowed to occur for multiple times.
+    - `Empty`: This column is not indexed, or this column is indexed and is the second column in a multi-column non-unique index.
+    - `PRI`: This column is the primary key or one of multiple primary keys.
+    - `UNI`: This column is the first column of the unique index.
+    - `MUL`: The column is the first column of a non-unique index, in which a given value is allowed to occur for multiple times.
 - `EXTRA`: Any additional information of the given column.
 - `PRIVILEGES`: The privilege that the current user has on this column.
 - `COLUMN_COMMENT`: Comments contained in the column definition.

--- a/docs/MatrixOne/Security/about-privilege-management.md
+++ b/docs/MatrixOne/Security/about-privilege-management.md
@@ -101,7 +101,7 @@ In MatrixOne, the behavior details of roles are as follows:
 - A role can be granted to multiple users.
 - A role can pass its privileges to another role.
 
-   + Use all the privileges of a role to another role; for example, pass all the privileges of role1 to role2, then role2 inherits the privileges of role1,
+    + Use all the privileges of a role to another role; for example, pass all the privileges of role1 to role2, then role2 inherits the privileges of role1,
 
 - Roles and users only take effect within their respective Account, including the Sys Account.
 

--- a/docs/MatrixOne/Security/best-practice.md
+++ b/docs/MatrixOne/Security/best-practice.md
@@ -6,28 +6,28 @@ The following are typical roles and recommended minimum permissions in MatrixOne
 
 **Database Administrator**
 
-   + Main job functions: manage all configuration information in the tenant, user permissions, backup and recovery, performance tuning, troubleshooting
-   + Reference grant role: the default administrator role accountadmin generated when creating a tenant.
-   + Refer to granting permissions: user management (`CREATE USER`, `ALTER USER`, `DROP USER`), authority management (`MANAGE GRANTS`)
++ Main job functions: manage all configuration information in the tenant, user permissions, backup and recovery, performance tuning, troubleshooting
++ Reference grant role: the default administrator role accountadmin generated when creating a tenant.
++ Refer to granting permissions: user management (`CREATE USER`, `ALTER USER`, `DROP USER`), authority management (`MANAGE GRANTS`)
 
 ## **Engineer responsible for data management**
 
 **Data Operation and Maintenance Engineer**
 
-   + Main job function: manage all data and metadata information in the tenant, and authorize data permissions
-   + Refer to Granting Permissions: Tenant-Level Data Management (`ALL ON ACCOUNT`)
++ Main job function: manage all data and metadata information in the tenant, and authorize data permissions
++ Refer to Granting Permissions: Tenant-Level Data Management (`ALL ON ACCOUNT`)
 
 **App Developer**
 
-   + Main job function: operate specific databases under the development environment tenant, and have read-only permission from the system tenant
-   + Refer to grant permissions: database level data management (`ALL ON DATABASE`), system database read-only (`SELECT ON DATABASE`)
++ Main job function: operate specific databases under the development environment tenant, and have read-only permission from the system tenant
++ Refer to grant permissions: database level data management (`ALL ON DATABASE`), system database read-only (`SELECT ON DATABASE`)
 
 **Application System Management Engineer**
 
-   + Main job function: operate specific databases under the production environment tenant
-   + Refer to Granting Permissions: Data Management at the Database Level (`ALL ON DATABASE`)
++ Main job function: operate specific databases under the production environment tenant
++ Refer to Granting Permissions: Data Management at the Database Level (`ALL ON DATABASE`)
 
 **System Monitoring Engineer**
 
-   + Main job function: monitor all system statistics and error messages under the tenant
-   + Refer to grant permissions: read-only permissions for all system databases (`SELECT ON DATABASE`)
++ Main job function: monitor all system statistics and error messages under the tenant
++ Refer to grant permissions: read-only permissions for all system databases (`SELECT ON DATABASE`)

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -8,3 +8,17 @@
 .md-header__inner .md-header__button.md-logo img {
   height: 0.8rem;
 }
+
+/* 二级无序列表 marker 使用空心圆 */
+.md-typeset ul ul {
+  list-style-type: circle;
+}
+
+/* 三级及以下无序列表 marker 使用短横线 */
+.md-typeset ul ul ul {
+  list-style-type: none;
+}
+.md-typeset ul ul ul li::before {
+  content: "-";
+  margin-right: 0.5em;
+}


### PR DESCRIPTION
## What type of PR is this?

- [x] Enhancement
- [ ] Displaying
- [ ] Typo
- [ ] Doc Request

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:

### 4-space Indentation

According to John Gruber's [Markdown](https://daringfireball.net/projects/markdown/syntax#list), which is implemented by [Python-Markdown](https://python-markdown.github.io/),  the Markdown renderer used by MkDocs:

> List items may consist of multiple paragraphs. Each subsequent paragraph in a list item must be **indented by either 4 spaces or one tab**...

This PR introduces the necessary changes to ensure that proper 4-space indentation is enforced for such cases, resulting in correctly rendered nested lists and code fences.

For example:
- Lists
    <img width="1133" alt="image" src="https://github.com/matrixorigin/matrixorigin.io/assets/86586270/7f177a06-e234-4268-8365-5ebc8ec0e58e">
- Fences:
    <img width="1316" alt="image" src="https://github.com/matrixorigin/matrixorigin.io/assets/86586270/1a8e04f8-7e07-48dd-a734-e41026461711">

### Nested List Marker

Modify the presentation of unordered lists to use different marker styles based on their nesting levels. Specifically, utilize a hollow circle as the marker for second-level unordered lists, while using a dash for lower levels.

![image](https://github.com/matrixorigin/matrixorigin.io/assets/86586270/aa0ade0e-20d3-4227-a492-501424ad343e)

