### PR TITLE
build(mkdocs): bump `mkdocs-material` to `9.1.21`

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -30,7 +30,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: '3.10'
       - name: Intialiaze Python Env
         run: |
           git rev-parse --abbrev-ref HEAD

--- a/.github/workflows/pre-cd.yml
+++ b/.github/workflows/pre-cd.yml
@@ -17,9 +17,9 @@ jobs:
           ref: ${{ github.event.inputs.version }}
           
           
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
-          python-version: '3.9.4'
+          python-version: '3.10.9'
       - name: Intialiaze Python Env
         run: |
           git rev-parse --abbrev-ref HEAD

--- a/.github/workflows/test_ci.yml
+++ b/.github/workflows/test_ci.yml
@@ -30,7 +30,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: '3.10'
       - name: Intialiaze Python Env
         run: |
           git rev-parse --abbrev-ref HEAD

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-alpine
+FROM python:3.10-alpine
 
 ADD . /matrixorigin.io
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,10 +4,6 @@ repo_url: https://github.com/matrixorigin/matrixorigin.io
 theme:
   name: material
   logo: assets/new-logo.png
-  icon:
-    admonition:
-      note: fontawesome/solid/sticky-note
-      info: fontawesome/solid/info-circle
   features:
     - navigation.instant
     - navigation.tracking
@@ -17,6 +13,9 @@ theme:
     scheme: mo
   font:
     text: Ubuntu
+plugins:
+  - search:
+      separator: '[\s\-,:!=\[\]()"/]+|(?!\b)(?=[A-Z][a-z])|\.(?!\d)|&[lg]t;'
 edit_uri: edit/main/docs/
 extra_css:
   - stylesheets/extra.css

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-mkdocs-material==8.2.8
+mkdocs-material==9.1.21
 mike==1.1.2


### PR DESCRIPTION
## What type of PR is this?

- [x] Enhancement
- [ ] Displaying
- [ ] Typo
- [ ] Doc Request

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:

For detailed information, please see https://github.com/matrixorigin/matrixorigin.io.cn/pull/655
- Bump `mkdocs-material` to `9.1.21`
- Customize the separator for indexing and query tokenization in site search with:
    - `[\s\-,:!=\[\]()"/]+|(?!\b)(?=[A-Z][a-z])|\.(?!\d)|&[lg]t;`
- Update the version of python to `3.10` in CI
