### PR TITLE
chore(ci): align docs SQL checks with MatrixOne 3.0-dev

### DIFF
--- a/.github/workflows/check-sql-syntax.yml
+++ b/.github/workflows/check-sql-syntax.yml
@@ -7,6 +7,10 @@ on:
       - 'scripts/doc-validator/**'
   workflow_dispatch:
 
+env:
+  MO_TARGET_BRANCH: 3.0-dev
+  DOCS_BASE_BRANCH: main
+
 jobs:
   check-sql-syntax:
     name: SQL Syntax Check
@@ -61,6 +65,8 @@ jobs:
 
       - name: Run SQL Syntax Check
         run: |
+          BASE_BRANCH="${{ github.base_ref || env.DOCS_BASE_BRANCH }}"
           echo "🔍 Starting SQL Syntax Check"
           echo "============================================================"
-          pnpm run check:sql-syntax:changed
+          echo "🧾 Diff base branch: ${BASE_BRANCH}"
+          pnpm run check:sql-syntax:changed -- --base-branch "${BASE_BRANCH}"

--- a/.github/workflows/check-sql-syntax.yml
+++ b/.github/workflows/check-sql-syntax.yml
@@ -40,6 +40,21 @@ jobs:
         with:
           go-version: '1.22'
 
+      - name: Sync MatrixOne parser to target branch
+        working-directory: scripts/doc-validator/syntax-checker
+        run: |
+          TARGET_BRANCH="${{ env.MO_TARGET_BRANCH }}"
+          echo "🎯 Target MatrixOne branch: ${TARGET_BRANCH}"
+          if ! [[ "${TARGET_BRANCH}" =~ ^[0-9]+\.[0-9]+-dev$ ]]; then
+            echo "❌ Invalid target branch: ${TARGET_BRANCH}"
+            echo "Expected release branch format: x.y-dev (example: 3.0-dev)"
+            exit 1
+          fi
+          go get github.com/matrixorigin/matrixone@${TARGET_BRANCH}
+          go mod tidy
+          CURRENT=$(go list -m github.com/matrixorigin/matrixone | awk '{print $2}')
+          echo "✅ Resolved MatrixOne parser version: ${CURRENT}"
+
       - name: Get pnpm store directory
         shell: bash
         run: |
@@ -61,6 +76,18 @@ jobs:
           echo "📋 Checking syntax checker build status..."
           if [ -f "scripts/doc-validator/syntax-checker/.build-status.json" ]; then
             cat scripts/doc-validator/syntax-checker/.build-status.json
+            node -e '
+              const fs = require("node:fs")
+              const status = JSON.parse(fs.readFileSync("scripts/doc-validator/syntax-checker/.build-status.json", "utf8"))
+              if (status.mode !== "native") {
+                console.error("❌ syntax-checker is not running in native mode:", status)
+                process.exit(1)
+              }
+              console.log("✅ syntax-checker native mode confirmed")
+            '
+          else
+            echo "❌ Missing build status file"
+            exit 1
           fi
 
       - name: Run SQL Syntax Check

--- a/.github/workflows/update-mo-parser.yml
+++ b/.github/workflows/update-mo-parser.yml
@@ -5,7 +5,15 @@ on:
   #   # 每 3 天运行一次 (UTC 时间 00:00)
   #   - cron: '0 0 */3 * *'
   workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Target MatrixOne release branch (leave empty to use MO_TARGET_BRANCH)'
+        required: false
+        type: string
     # 支持手动触发（自动调度已关闭）
+
+env:
+  MO_TARGET_BRANCH: 3.0-dev
 
 jobs:
   update-parser:
@@ -31,11 +39,21 @@ jobs:
           echo "version=$CURRENT" >> $GITHUB_OUTPUT
           echo "📌 Current MO version: $CURRENT"
 
-      - name: Update to latest MO main branch
+      - name: Update to target MO release branch
+        id: target
         working-directory: scripts/doc-validator/syntax-checker
         run: |
-          echo "🔄 Updating MatrixOne parser to latest main..."
-          go get github.com/matrixorigin/matrixone@main
+          TARGET_BRANCH="${{ github.event.inputs.branch || env.MO_TARGET_BRANCH }}"
+
+          if ! [[ "${TARGET_BRANCH}" =~ ^[0-9]+\.[0-9]+-dev$ ]]; then
+            echo "❌ Invalid target branch: ${TARGET_BRANCH}"
+            echo "Expected release branch format: x.y-dev (example: 3.0-dev)"
+            exit 1
+          fi
+
+          echo "target_branch=${TARGET_BRANCH}" >> $GITHUB_OUTPUT
+          echo "🔄 Updating MatrixOne parser to ${TARGET_BRANCH}..."
+          go get github.com/matrixorigin/matrixone@${TARGET_BRANCH}
           go mod tidy
 
       - name: Get new MO version
@@ -81,7 +99,7 @@ jobs:
           body: |
             ## 🔄 Auto-update MatrixOne SQL Parser
 
-            This PR updates the MatrixOne SQL parser to the latest version from the main branch.
+            This PR updates the MatrixOne SQL parser to the latest version from the target release branch `${{ steps.target.outputs.target_branch }}`.
 
             ### Changes
             - **Previous version**: `${{ steps.current.outputs.version }}`

--- a/.github/workflows/validate-sql-execution.yml
+++ b/.github/workflows/validate-sql-execution.yml
@@ -8,12 +8,14 @@ on:
   workflow_dispatch:
     inputs:
       branch:
-        description: 'Target branch for image selection (leave empty for auto-detect)'
+        description: 'Target branch for image selection (leave empty to use MO_TARGET_BRANCH)'
         required: false
         type: string
 
 env:
   TENCENT_TCR_REPO: ccr.ccs.tencentyun.com/matrixone-dev/matrixone
+  MO_TARGET_BRANCH: 3.0-dev
+  DOCS_BASE_BRANCH: main
 
 jobs:
   validate-sql:
@@ -61,14 +63,26 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y mysql-client
 
-      - name: Run SQL Validation with Branch Fallback
+      - name: Run SQL Validation on Target Branch
         run: |
-          echo "🔍 Starting SQL Execution Validation with Branch Fallback"
+          TARGET_BRANCH="${{ github.event.inputs.branch || env.MO_TARGET_BRANCH }}"
+          BASE_BRANCH="${{ github.base_ref || env.DOCS_BASE_BRANCH }}"
+
+          if ! [[ "${TARGET_BRANCH}" =~ ^[0-9]+\.[0-9]+-dev$ ]]; then
+            echo "❌ Invalid target branch: ${TARGET_BRANCH}"
+            echo "Expected release branch format: x.y-dev (example: 3.0-dev)"
+            exit 1
+          fi
+
+          echo "🔍 Starting SQL Execution Validation for target branch"
           echo "============================================================"
+          echo "🎯 MatrixOne target branch: ${TARGET_BRANCH}"
+          echo "🧾 Diff base branch: ${BASE_BRANCH}"
+          echo ""
 
           # Get sorted commit list
-          echo "📋 Fetching commit list from main and dev branches..."
-          COMMITS=$(bash ./scripts/mo-test-env.sh get-commits)
+          echo "📋 Fetching commit list from target branch..."
+          COMMITS=$(bash ./scripts/mo-test-env.sh get-commits "${TARGET_BRANCH}")
 
           if [ -z "$COMMITS" ]; then
             echo "❌ Failed to fetch commits"
@@ -81,11 +95,18 @@ jobs:
           done
           echo ""
 
-          # Track which branches have been tested
-          TESTED_MAIN=false
-          TESTED_DEV=false
-          LAST_FAILED_BRANCH=""
           TEST_PASSED=false
+          IMAGE_START_FAIL_COUNT=0
+          SQL_VALIDATE_FAIL_COUNT=0
+
+          # Assert all candidate commits belong to target branch
+          while IFS= read -r line; do
+            COMMIT_BRANCH=$(echo "$line" | cut -d' ' -f2)
+            if [ -n "$COMMIT_BRANCH" ] && [ "$COMMIT_BRANCH" != "$TARGET_BRANCH" ]; then
+              echo "❌ Unexpected commit branch in candidate list: $COMMIT_BRANCH (expected: $TARGET_BRANCH)"
+              exit 1
+            fi
+          done <<< "$COMMITS"
 
           # Iterate through commits
           while IFS= read -r line; do
@@ -93,12 +114,6 @@ jobs:
             BRANCH=$(echo "$line" | cut -d' ' -f2)
 
             if [ -z "$SHA" ]; then
-              continue
-            fi
-
-            # Skip if this branch type already failed and we're looking at the same branch
-            if [ -n "$LAST_FAILED_BRANCH" ] && [ "$BRANCH" = "$LAST_FAILED_BRANCH" ]; then
-              echo "⏭️  Skipping $SHA ($BRANCH) - already tested this branch"
               continue
             fi
 
@@ -113,6 +128,7 @@ jobs:
             echo "🚀 Starting MatrixOne with $IMAGE..."
             if ! bash ./scripts/mo-test-env.sh start-image "$IMAGE"; then
               echo "⚠️  Failed to start database with $SHA, trying next..."
+              IMAGE_START_FAIL_COUNT=$((IMAGE_START_FAIL_COUNT + 1))
               continue
             fi
 
@@ -136,13 +152,14 @@ jobs:
             if [ "$DB_READY" = false ]; then
               echo "⚠️  Database failed to start with $SHA, trying next..."
               pnpm run db:stop || true
+              IMAGE_START_FAIL_COUNT=$((IMAGE_START_FAIL_COUNT + 1))
               continue
             fi
 
             # Run SQL validation
             echo ""
             echo "🔍 Running SQL Execution Validation..."
-            if pnpm run check:sql-exec:changed; then
+            if pnpm run check:sql-exec:changed -- --base-branch "${BASE_BRANCH}"; then
               echo ""
               echo "============================================================"
               echo "✅ SQL Validation PASSED with $SHA ($BRANCH)"
@@ -153,26 +170,8 @@ jobs:
             else
               echo ""
               echo "⚠️  SQL Validation FAILED with $SHA ($BRANCH)"
-
-              # Mark this branch as tested
-              if [ "$BRANCH" = "main" ]; then
-                TESTED_MAIN=true
-              else
-                TESTED_DEV=true
-              fi
-              LAST_FAILED_BRANCH="$BRANCH"
-
-              # Check if both branches have been tested
-              if [ "$TESTED_MAIN" = true ] && [ "$TESTED_DEV" = true ]; then
-                echo ""
-                echo "============================================================"
-                echo "❌ Both main and dev branches have been tested and failed"
-                echo "============================================================"
-                pnpm run db:stop || true
-                exit 1
-              fi
-
-              echo "🔄 Will try another branch..."
+              echo "🔄 Will try another commit from ${TARGET_BRANCH}..."
+              SQL_VALIDATE_FAIL_COUNT=$((SQL_VALIDATE_FAIL_COUNT + 1))
               pnpm run db:stop || true
             fi
           done <<< "$COMMITS"
@@ -181,6 +180,8 @@ jobs:
             echo ""
             echo "============================================================"
             echo "❌ No available commit passed the SQL validation"
+            echo "   Image/database start failures: ${IMAGE_START_FAIL_COUNT}"
+            echo "   SQL validation failures: ${SQL_VALIDATE_FAIL_COUNT}"
             echo "============================================================"
             exit 1
           fi

--- a/scripts/doc-validator/index.js
+++ b/scripts/doc-validator/index.js
@@ -36,6 +36,7 @@ async function main() {
     .option('-c, --changed-only', 'Only check changed files', false)
     .option('-l, --limit <number>', 'Limit the number of files to check (for quick testing)', parseInt)
     .option('--check <type>', 'Check type: syntax|execution|all', 'syntax')
+    .option('--base-branch <branch>', 'Base branch for changed-only diff', 'main')
     .option('--db-host <host>', 'Database host', config.defaultDbConfig.host)
     .option('--db-port <port>', 'Database port', config.defaultDbConfig.port)
     .option('--db-user <user>', 'Database user', config.defaultDbConfig.user)
@@ -67,7 +68,13 @@ async function main() {
     }
 
     console.log('📝 Check mode: Changed files only')
-    filesToCheck = getChangedFiles('main')
+    console.log(`🌿 Diff base branch: ${options.baseBranch}`)
+    try {
+      filesToCheck = getChangedFiles(options.baseBranch)
+    } catch (error) {
+      console.error(`❌ Error: Unable to determine changed files: ${error.message}`)
+      process.exit(1)
+    }
 
     if (filesToCheck.length === 0) {
       console.log('✅ No changed Markdown files')

--- a/scripts/doc-validator/utils/git.js
+++ b/scripts/doc-validator/utils/git.js
@@ -2,7 +2,16 @@
  * Git Utility Functions
  */
 
-import { execSync } from 'node:child_process'
+import { execSync, execFileSync } from 'node:child_process'
+
+function normalizeAndValidateBranch(baseBranch = 'main') {
+    const normalizedBaseBranch = baseBranch && baseBranch.trim() ? baseBranch.trim() : 'main'
+    // Keep branch refs strict to avoid shell/meta injection and invalid refs.
+    if (!/^[A-Za-z0-9._/-]+$/.test(normalizedBaseBranch) || normalizedBaseBranch.startsWith('-')) {
+        throw new Error(`Invalid base branch: ${normalizedBaseBranch}`)
+    }
+    return normalizedBaseBranch
+}
 
 /**
  * Get list of changed files relative to a specified branch
@@ -11,30 +20,32 @@ import { execSync } from 'node:child_process'
  * @returns {Array<string>} List of changed file paths
  */
 export function getChangedFiles(baseBranch = 'main', pattern = '*.md') {
+    const normalizedBaseBranch = normalizeAndValidateBranch(baseBranch)
+    const remoteRef = `origin/${normalizedBaseBranch}`
+
+    // Ensure getting the latest remote branch information
     try {
-        // Ensure getting the latest remote branch information
-        try {
-            execSync(`git fetch origin ${baseBranch}`, { stdio: 'pipe' })
-        } catch (e) {
-            // If fetch fails, continue using local branch
-            console.warn(`Warning: Could not fetch origin/${baseBranch}, using local branch`)
-        }
-
-        // Get changed files
-        const command = `git diff --name-only origin/${baseBranch}...HEAD`
-        const output = execSync(command, { encoding: 'utf-8' })
-
-        // Filter files
-        const files = output
-            .split('\n')
-            .filter(file => file.trim())
-            .filter(file => file.endsWith('.md'))
-
-        return files
-    } catch (error) {
-        console.error('Error getting changed files:', error.message)
-        return []
+        execFileSync('git', ['fetch', 'origin', normalizedBaseBranch], { stdio: 'pipe' })
+    } catch (e) {
+        // If fetch fails, continue using local branch
+        console.warn(`Warning: Could not fetch ${remoteRef}, using local branch`)
     }
+
+    // Get changed files
+    let output
+    try {
+        output = execFileSync('git', ['diff', '--name-only', `${remoteRef}...HEAD`], { encoding: 'utf-8' })
+    } catch (error) {
+        throw new Error(`Failed to diff against ${remoteRef}: ${error.message}`)
+    }
+
+    // Filter files
+    const files = output
+        .split('\n')
+        .filter(file => file.trim())
+        .filter(file => file.endsWith('.md'))
+
+    return files
 }
 
 /**
@@ -74,8 +85,9 @@ export function isGitRepository() {
  */
 export function getFileDiff(filePath, baseBranch = 'main') {
     try {
-        const command = `git diff origin/${baseBranch}...HEAD -- ${filePath}`
-        const diff = execSync(command, { encoding: 'utf-8' })
+        const normalizedBaseBranch = normalizeAndValidateBranch(baseBranch)
+        const remoteRef = `origin/${normalizedBaseBranch}`
+        const diff = execFileSync('git', ['diff', `${remoteRef}...HEAD`, '--', filePath], { encoding: 'utf-8' })
         return diff
     } catch (error) {
         console.error(`Error getting diff for ${filePath}:`, error.message)

--- a/scripts/mo-test-env.sh
+++ b/scripts/mo-test-env.sh
@@ -468,8 +468,26 @@ test_mo() {
 
 # Get sorted commit list for CI use
 # Output format: sha branch (one per line, sorted by time descending)
+# If target branch is provided, only fetch from that branch
 get_commits() {
+    local target_branch="$1"
     local all_commits=""
+
+    if [ -n "$target_branch" ]; then
+        local target_commits
+        target_commits=$(fetch_branch_commits "$target_branch" 2>/dev/null)
+
+        if [ -z "$target_commits" ]; then
+            echo "Failed to fetch commits from target branch: ${target_branch}" >&2
+            return 1
+        fi
+
+        echo "$target_commits" | sort -rk1 | sort -uk2,2 | sort -rk1 | \
+            while read -r date sha branch; do
+                echo "$sha $branch"
+            done
+        return 0
+    fi
 
     # Fetch from main branch (silently)
     local main_commits
@@ -580,7 +598,8 @@ case "${ACTION}" in
         ;;
     get-commits)
         # Get sorted commit list (used by CI)
-        get_commits
+        # Optional branch argument: ./mo-test-env.sh get-commits 3.0-dev
+        get_commits "$VERSION_ARG"
         ;;
     stop)
         stop_mo
@@ -594,14 +613,14 @@ case "${ACTION}" in
     *)
         echo "MatrixOne Test Environment"
         echo ""
-        echo "Usage: $0 {start|stop|status|test|get-commits|start-image} [version/image]"
+        echo "Usage: $0 {start|stop|status|test|get-commits|start-image} [version/image/branch]"
         echo ""
         echo "Commands:"
         echo "  start [version]  Start MatrixOne container"
         echo "                   - Without version: try latest commit from Tencent TCR, fallback to Docker Hub nightly"
         echo "                   - With version: try release, fallback to nightly"
         echo "  start-image IMG  Start with a specific Docker image (for CI use)"
-        echo "  get-commits      Get sorted commit list from main and dev branches"
+        echo "  get-commits [BR] Get sorted commit list for branch BR (or main+dev if omitted)"
         echo "  stop             Stop and remove container"
         echo "  status           Show container status"
         echo "  test             Test database connection"
@@ -610,7 +629,8 @@ case "${ACTION}" in
         echo "  $0 start              # Latest commit from Tencent TCR or Docker Hub nightly"
         echo "  $0 start 3.0.4        # Release 3.0.4 or fallback to nightly"
         echo "  $0 start-image ccr.ccs.tencentyun.com/matrixone-dev/matrixone:commit-abc1234"
-        echo "  $0 get-commits        # List available commits"
+        echo "  $0 get-commits        # List available commits from main+dev"
+        echo "  $0 get-commits 3.0-dev # List available commits from 3.0-dev only"
         echo "  $0 stop"
         echo "  $0 test"
         exit 1


### PR DESCRIPTION
## What type of PR is this?

- [x] Enhancement
- [ ] Displaying
- [ ] Typo
- [ ] Doc Request

## Which issue(s) this PR fixes:

issue #N/A

## What this PR does / why we need it:

MatrixOne production release for 3.x is based on the `3.0-dev` branch (e.g. `v3.0.9`), so SQL syntax in matrixorigin.io docs must be validated against `3.0-dev` semantics instead of `main`.

Today, docs PR checks can still be influenced by `main` behavior, and some docs examples have already mixed in `main`-only syntax. This creates a mismatch between published docs and released database behavior.

This PR makes CI validation branch-aware and release-aligned so docs SQL checks enforce `3.0-dev` compatibility by default.

### Key changes

- Add release target defaults in workflows:
  - `MO_TARGET_BRANCH=3.0-dev` (MatrixOne semantic target)
  - `DOCS_BASE_BRANCH=main` (docs repo diff baseline fallback)

- Update SQL execution validation workflow to enforce release-branch semantics:
  - resolve target branch from dispatch input or `MO_TARGET_BRANCH`
  - validate branch format (`x.y-dev`)
  - fetch candidate commits only from target branch (`get-commits <target-branch>`)
  - assert candidate commit branch consistency
  - pass docs diff base branch explicitly (`--base-branch`)
  - improve diagnostics by splitting image/start failures vs SQL validation failures

- Update SQL syntax workflow to use explicit docs diff baseline:
  - pass `--base-branch` using `github.base_ref` fallback to `DOCS_BASE_BRANCH`

- Update parser update workflow to follow release branch:
  - support optional dispatch input for target branch
  - validate branch format
  - run `go get github.com/matrixorigin/matrixone@<target-branch>`
  - include resolved target branch in PR body

- Harden validator and git utilities:
  - add `--base-branch` support to doc-validator changed-only mode
  - fail fast when changed-file resolution fails
  - validate branch refs and use safer `execFileSync` argument calls
  - surface git diff failures explicitly instead of silent fallback

- Extend commit helper script:
  - `mo-test-env.sh get-commits` supports optional single-branch mode
  - preserves previous fallback behavior when branch is omitted

### Why this matters

With this change, docs PR CI checks SQL against the same branch family used for released MatrixOne (`3.0-dev`), reducing the risk of publishing `main`-only syntax into release docs and improving consistency between product behavior and official documentation.