### PR TITLE
[docs-sync] MatrixOne v3.0.10 文档同步 (io)

### DIFF
--- a/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-diff-en.md
+++ b/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-diff-en.md
@@ -15,8 +15,19 @@ The system automatically identifies the Lowest Common Ancestor (LCA) between two
 ```
 DATA BRANCH DIFF target_table [{ SNAPSHOT = 'snapshot_name' }] 
     AGAINST base_table [{ SNAPSHOT = 'snapshot_name' }] 
+    [COLUMNS ( column_list )]
     [OUTPUT output_option]
 ```
+
+### Column Projection
+
+```
+COLUMNS ( col_name [, col_name ...] )   -- Restrict the diff output to the listed columns
+```
+
+`COLUMNS` narrows the comparison to the listed columns. Primary-key columns are always included in the result, regardless of whether they appear in `column_list`. A row is reported as `UPDATE` only when one of the projected columns differs; differences in columns outside `column_list` are ignored.
+
+`COLUMNS` cannot be used together with `OUTPUT FILE`.
 
 ### Output Options
 
@@ -432,6 +443,43 @@ DROP TABLE test.orders_branch;
 -- Expected-Rows: 0
 DROP DATABASE test;
 ```
+
+### Example 9: Project a Subset of Columns
+
+Use `COLUMNS` to limit the comparison to specific non-primary-key columns. Differences in other columns are ignored.
+
+<!-- validator-ignore -->
+```sql
+-- Expected-Rows: 0
+CREATE TABLE test.t0 (a INT PRIMARY KEY, b INT, c INT);
+-- Expected-Rows: 0
+INSERT INTO test.t0 VALUES (1, 1, 1), (2, 2, 2), (3, 3, 3);
+
+-- Expected-Rows: 0
+DATA BRANCH CREATE TABLE test.t1 FROM test.t0;
+-- Expected-Rows: 1
+UPDATE test.t1 SET b = 99 WHERE a = 1;
+-- Expected-Rows: 1
+UPDATE test.t1 SET c = 99 WHERE a = 2;
+
+-- Only project column b: the change on a=2 (which only touched c) is ignored.
+-- Expected-Rows: 2
+DATA BRANCH DIFF test.t1 AGAINST test.t0 COLUMNS (b);
++--------------------+--------+------+------+
+| diff t1 against t0 | flag   | a    | b    |
++--------------------+--------+------+------+
+| t1                 | UPDATE |    1 |   99 |
+| t0                 | UPDATE |    1 |    1 |
++--------------------+--------+------+------+
+
+-- Expected-Rows: 0
+DROP TABLE test.t0;
+-- Expected-Rows: 0
+DROP TABLE test.t1;
+```
+
+!!! note
+    `COLUMNS` cannot be combined with `OUTPUT FILE`; use `OUTPUT LIMIT` or `OUTPUT COUNT` with projected columns instead.
 
 ## Notes
 

--- a/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-pick.md
+++ b/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-pick.md
@@ -1,0 +1,337 @@
+# DATA BRANCH PICK
+
+## Description
+
+The `DATA BRANCH PICK` statement cherry-picks a targeted subset of rows from a source table into a destination table, identified either by primary-key values (via `KEYS`) or by a snapshot time window (via `BETWEEN SNAPSHOT`). It is similar in spirit to Git's `cherry-pick`: instead of merging every difference between two branches, only the rows you explicitly select are applied to the destination.
+
+For each picked key, `DATA BRANCH PICK` computes the difference between source and destination (using the same lowest-common-ancestor logic as `DATA BRANCH DIFF`), filters it to the picked keys, and applies the surviving insert/update/delete operations to the destination table.
+
+## Syntax
+
+```
+DATA BRANCH PICK source_table [{ SNAPSHOT = 'snapshot_name' }]
+    INTO destination_table
+    [ BETWEEN SNAPSHOT from_snapshot AND to_snapshot ]
+    [ KEYS ( value_list | subquery ) ]
+    [ WHEN CONFLICT conflict_option ]
+```
+
+At least one of `BETWEEN SNAPSHOT ... AND ...` or `KEYS (...)` must be specified.
+
+### KEYS clause
+
+```
+KEYS ( value_list )        -- explicit primary-key values
+KEYS ( subquery )          -- any SELECT returning primary-key columns
+```
+
+- For a single-column primary key, `value_list` is a comma-separated list of literal values, e.g. `KEYS (1, 2, 3)`.
+- For a composite primary key, `value_list` contains tuples whose column order matches the primary-key definition, e.g. `KEYS ((100, 'A100'), (101, 'B200'))`.
+- A subquery must project exactly the primary-key columns, in the same order. Rows whose keys contain `NULL` are rejected.
+
+### Conflict options
+
+```
+conflict_option:
+    FAIL       -- abort the statement on any conflict (default)
+  | SKIP       -- keep the destination row unchanged on conflict
+  | ACCEPT     -- overwrite the destination row with the source value
+```
+
+A conflict occurs when the picked primary key exists in both tables with different non-key values (an UPDATE conflict), or when both sides independently inserted a row with the same primary key but different values (an INSERT conflict).
+
+## Arguments
+
+| Parameter | Description |
+|-----------|-------------|
+| `source_table` | The branch/table to pick rows from. |
+| `destination_table` | The branch/table that receives the picked rows. |
+| `{ SNAPSHOT = 'snapshot_name' }` on `source_table` | Optional: pick rows as they existed in the source at that snapshot. |
+| `BETWEEN SNAPSHOT from_snapshot AND to_snapshot` | Optional: restrict the pick to rows that changed in `source_table` between two of its snapshots. Can be combined with `KEYS`. |
+| `KEYS (...)` | Primary keys of the rows to pick — either explicit values/tuples or a `SELECT` subquery. |
+| `WHEN CONFLICT FAIL \| SKIP \| ACCEPT` | Behavior when a picked key conflicts with an existing row in `destination_table`. Defaults to `FAIL`. |
+
+## Usage Notes
+
+### Requirements and restrictions
+
+- **Primary key required**: `destination_table` must have a primary key. A table without a primary key cannot be the target of `DATA BRANCH PICK`.
+- **Not allowed in explicit transactions**: `DATA BRANCH PICK` cannot run inside a `BEGIN ... COMMIT` block.
+- **Destination snapshot not allowed**: specifying `{ SNAPSHOT = ... }` on `destination_table` is rejected.
+- **`BETWEEN SNAPSHOT` excludes source snapshot**: `BETWEEN SNAPSHOT ... AND ...` cannot be combined with `{ SNAPSHOT = ... }` on `source_table`.
+- **KEYS subquery must not return NULL**: if a subquery returns a `NULL` in any primary-key column, the statement fails.
+- **Privileges**: the caller needs read privileges on `source_table` and modify privileges on `destination_table`.
+
+### What gets applied
+
+For each picked primary key:
+
+- If the row exists only in `source_table`, it is inserted into `destination_table`.
+- If the row exists in both tables with the same non-key values, nothing changes.
+- If the row exists in both tables with different non-key values, the conflict option decides the outcome.
+- If the row exists only in `destination_table` and the source side deleted it (relative to the lowest common ancestor), the row is deleted from `destination_table` under `ACCEPT`; it is preserved under `SKIP`; `FAIL` aborts.
+
+Keys that are not present in either side are treated as no-ops.
+
+## Examples
+
+### Example 1: Pick specific rows (no common ancestor)
+
+<!-- validator-ignore -->
+```sql
+-- Expected-Rows: 0
+CREATE DATABASE test;
+-- Expected-Rows: 0
+USE test;
+
+-- Expected-Rows: 0
+CREATE TABLE test.t1 (a INT PRIMARY KEY, b INT);
+-- Expected-Rows: 0
+INSERT INTO test.t1 VALUES (1, 1), (3, 3), (5, 5);
+
+-- Expected-Rows: 0
+CREATE TABLE test.t2 (a INT PRIMARY KEY, b INT);
+-- Expected-Rows: 0
+INSERT INTO test.t2 VALUES (1, 1), (2, 2), (4, 4);
+
+-- Expected-Rows: 0
+DATA BRANCH PICK test.t2 INTO test.t1 KEYS (2);
+SELECT * FROM test.t1 ORDER BY a;
++---+---+
+| a | b |
++---+---+
+| 1 | 1 |
+| 2 | 2 |
+| 3 | 3 |
+| 5 | 5 |
++---+---+
+
+-- Expected-Rows: 0
+DROP TABLE test.t1;
+-- Expected-Rows: 0
+DROP TABLE test.t2;
+```
+
+### Example 2: Pick multiple rows from a branch (with common ancestor)
+
+<!-- validator-ignore -->
+```sql
+-- Expected-Rows: 0
+CREATE TABLE test.t0 (a INT PRIMARY KEY, b INT);
+-- Expected-Rows: 0
+INSERT INTO test.t0 VALUES (1, 1), (2, 2), (3, 3);
+
+-- Expected-Rows: 0
+DATA BRANCH CREATE TABLE test.t1 FROM test.t0;
+
+-- Expected-Rows: 0
+DATA BRANCH CREATE TABLE test.t2 FROM test.t0;
+-- Expected-Rows: 0
+INSERT INTO test.t2 VALUES (5, 5), (6, 6), (7, 7);
+
+-- Pick pk=5 and pk=7 from t2 into t1 (skip pk=6)
+-- Expected-Rows: 0
+DATA BRANCH PICK test.t2 INTO test.t1 KEYS (5, 7);
+SELECT * FROM test.t1 ORDER BY a;
+
+-- Expected-Rows: 0
+DROP TABLE test.t0;
+-- Expected-Rows: 0
+DROP TABLE test.t1;
+-- Expected-Rows: 0
+DROP TABLE test.t2;
+```
+
+### Example 3: Pick using a subquery
+
+<!-- validator-ignore -->
+```sql
+-- Expected-Rows: 0
+CREATE TABLE test.src (a INT PRIMARY KEY, b INT);
+-- Expected-Rows: 0
+INSERT INTO test.src VALUES (1, 10), (2, 20), (3, 30), (4, 40);
+
+-- Expected-Rows: 0
+CREATE TABLE test.dst (a INT PRIMARY KEY, b INT);
+
+-- A driver table that lists which keys to pick
+-- Expected-Rows: 0
+CREATE TABLE test.pick_list (k INT PRIMARY KEY);
+-- Expected-Rows: 0
+INSERT INTO test.pick_list VALUES (1), (3);
+
+-- Expected-Rows: 0
+DATA BRANCH PICK test.src INTO test.dst KEYS (SELECT k FROM test.pick_list);
+SELECT * FROM test.dst ORDER BY a;
+
+-- Expected-Rows: 0
+DROP TABLE test.src;
+-- Expected-Rows: 0
+DROP TABLE test.dst;
+-- Expected-Rows: 0
+DROP TABLE test.pick_list;
+```
+
+### Example 4: Conflict handling (FAIL / SKIP / ACCEPT)
+
+<!-- validator-ignore -->
+```sql
+-- Expected-Rows: 0
+CREATE TABLE test.t0 (a INT PRIMARY KEY, b INT);
+-- Expected-Rows: 0
+INSERT INTO test.t0 VALUES (1, 1), (2, 2);
+
+-- Expected-Rows: 0
+DATA BRANCH CREATE TABLE test.t1 FROM test.t0;
+-- Expected-Rows: 0
+INSERT INTO test.t1 VALUES (3, 30);
+
+-- Expected-Rows: 0
+DATA BRANCH CREATE TABLE test.t2 FROM test.t0;
+-- Expected-Rows: 0
+INSERT INTO test.t2 VALUES (3, 40);
+
+-- Default FAIL: both branches inserted pk=3 with different values, abort
+-- Expected-Success: false
+DATA BRANCH PICK test.t2 INTO test.t1 KEYS (3);
+
+-- SKIP keeps t1's value (b = 30)
+-- Expected-Rows: 0
+DATA BRANCH PICK test.t2 INTO test.t1 KEYS (3) WHEN CONFLICT SKIP;
+
+-- ACCEPT overwrites with t2's value (b = 40)
+-- Expected-Rows: 0
+DATA BRANCH PICK test.t2 INTO test.t1 KEYS (3) WHEN CONFLICT ACCEPT;
+
+-- Expected-Rows: 0
+DROP TABLE test.t0;
+-- Expected-Rows: 0
+DROP TABLE test.t1;
+-- Expected-Rows: 0
+DROP TABLE test.t2;
+```
+
+### Example 5: Pick from a source snapshot
+
+<!-- validator-ignore -->
+```sql
+-- Expected-Rows: 0
+CREATE TABLE test.t0 (a INT PRIMARY KEY, b INT);
+-- Expected-Rows: 0
+INSERT INTO test.t0 VALUES (1, 1), (2, 2), (3, 3);
+
+-- Expected-Rows: 0
+DATA BRANCH CREATE TABLE test.t1 FROM test.t0;
+
+-- Expected-Rows: 0
+DATA BRANCH CREATE TABLE test.t2 FROM test.t0;
+-- Expected-Rows: 0
+INSERT INTO test.t2 VALUES (4, 4), (5, 5);
+
+-- Freeze t2's state, then change it further
+-- Expected-Rows: 0
+CREATE SNAPSHOT sp_src FOR ACCOUNT sys;
+-- Expected-Rows: 1
+UPDATE test.t2 SET b = 50 WHERE a = 5;
+-- Expected-Rows: 0
+INSERT INTO test.t2 VALUES (6, 6);
+
+-- Pick from the frozen view: pk=5 gets the snapshot value (b = 5), not (b = 50);
+-- pk=6 is absent at snapshot time, so picking it is a no-op.
+-- Expected-Rows: 0
+DATA BRANCH PICK test.t2 {SNAPSHOT='sp_src'} INTO test.t1 KEYS (4, 5, 6);
+SELECT * FROM test.t1 ORDER BY a;
+
+-- Expected-Rows: 0
+DROP SNAPSHOT sp_src;
+-- Expected-Rows: 0
+DROP TABLE test.t0;
+-- Expected-Rows: 0
+DROP TABLE test.t1;
+-- Expected-Rows: 0
+DROP TABLE test.t2;
+```
+
+### Example 6: Pick changes within a snapshot window
+
+<!-- validator-ignore -->
+```sql
+-- Expected-Rows: 0
+CREATE TABLE test.t0 (a INT PRIMARY KEY, b INT);
+-- Expected-Rows: 0
+INSERT INTO test.t0 VALUES (1, 1);
+
+-- Expected-Rows: 0
+DATA BRANCH CREATE TABLE test.t1 FROM test.t0;
+
+-- Expected-Rows: 0
+CREATE SNAPSHOT sp_from FOR ACCOUNT sys;
+-- Expected-Rows: 0
+INSERT INTO test.t1 VALUES (2, 2), (3, 3);
+-- Expected-Rows: 0
+CREATE SNAPSHOT sp_to FOR ACCOUNT sys;
+-- Expected-Rows: 0
+INSERT INTO test.t1 VALUES (4, 4);
+
+-- Expected-Rows: 0
+CREATE TABLE test.t2 (a INT PRIMARY KEY, b INT);
+
+-- Pick only rows changed between sp_from and sp_to (pk=2, pk=3; pk=4 is outside the window)
+-- Expected-Rows: 0
+DATA BRANCH PICK test.t1 INTO test.t2 BETWEEN SNAPSHOT sp_from AND sp_to;
+SELECT * FROM test.t2 ORDER BY a;
+
+-- Expected-Rows: 0
+DROP SNAPSHOT sp_from;
+-- Expected-Rows: 0
+DROP SNAPSHOT sp_to;
+-- Expected-Rows: 0
+DROP TABLE test.t0;
+-- Expected-Rows: 0
+DROP TABLE test.t1;
+-- Expected-Rows: 0
+DROP TABLE test.t2;
+```
+
+### Example 7: Composite primary key
+
+<!-- validator-ignore -->
+```sql
+-- Expected-Rows: 0
+CREATE TABLE test.orders (
+    tenant_id  INT,
+    order_code VARCHAR(8),
+    amount     DECIMAL(12, 2),
+    PRIMARY KEY (tenant_id, order_code)
+);
+-- Expected-Rows: 0
+INSERT INTO test.orders VALUES
+    (100, 'A100', 120.50),
+    (100, 'A101',  80.00),
+    (101, 'B200', 305.75);
+
+-- Expected-Rows: 0
+DATA BRANCH CREATE TABLE test.orders_branch FROM test.orders;
+-- Expected-Rows: 0
+INSERT INTO test.orders_branch VALUES
+    (102, 'C300', 512.25),
+    (103, 'D400',  42.00);
+
+-- Pick only (102, 'C300')
+-- Expected-Rows: 0
+DATA BRANCH PICK test.orders_branch INTO test.orders
+    KEYS ((102, 'C300'));
+SELECT * FROM test.orders ORDER BY tenant_id, order_code;
+
+-- Expected-Rows: 0
+DROP TABLE test.orders;
+-- Expected-Rows: 0
+DROP TABLE test.orders_branch;
+```
+
+## Notes
+
+1. **Difference from `DATA BRANCH MERGE`**: `MERGE` applies the entire delta between two branches; `PICK` applies only the subset you list with `KEYS` or that falls inside the `BETWEEN SNAPSHOT` window.
+2. **Default conflict behavior is `FAIL`**: callers that expect to iterate on conflicts should pass `WHEN CONFLICT SKIP` or `WHEN CONFLICT ACCEPT` explicitly.
+3. **Table structure consistency**: `source_table` and `destination_table` must share the same column set and types (same as `DATA BRANCH DIFF` / `DATA BRANCH MERGE`).
+4. **Implicit transaction only**: because `DATA BRANCH PICK` cannot run inside an explicit transaction, wrap it in its own session step rather than grouping it with surrounding statements under `BEGIN`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -367,6 +367,7 @@ nav:
                   - DELETE BRANCH: MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-delete-en.md
                   - DIFF BRANCH: MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-diff-en.md
                   - MERGE BRANCH: MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-merge-en.md
+                  - PICK BRANCH: MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-pick.md
                   - ALTER TABLE: MatrixOne/Reference/SQL-Reference/Data-Definition-Language/alter-table.md
                   - ALTER TABLE ... ALTER REINDEX: MatrixOne/Reference/SQL-Reference/Data-Definition-Language/alter-reindex.md
                   - ALTER PITR: MatrixOne/Reference/SQL-Reference/Data-Definition-Language/alter-pitr.md


### PR DESCRIPTION
# MatrixOne 文档自动同步 (io)

## 基本信息

- Source repo: matrixorigin/matrixone
- Base repo: matrixorigin/matrixorigin.io
- Head: ULookup:docs-sync/matrixone-v3.0.10 (from fork ULookup/matrixorigin.io)
- Docs key: io
- From tag: v3.0.9
- To tag: v3.0.10
- Target branch: main
- Generated by: MatrixOne Docs Sync Agent

## Tags

- From: v3.0.9
- To: v3.0.10

## User-visible Changes

本次 v3.0.9 → v3.0.10 的源码 diff 中，仅有两项可直接落到用户 SQL 参考文档的
变更：

1. **新增 `DATA BRANCH PICK` 语句**：按主键（`KEYS`）或快照窗口
   （`BETWEEN SNAPSHOT ... AND ...`）将源表中指定的行 cherry-pick 到目标表，
   支持 `WHEN CONFLICT FAIL | SKIP | ACCEPT` 三种冲突处理策略。
   - 源码证据：`pkg/sql/parsers/dialect/mysql/mysql_sql.y` 新增 `PICK` token
     以及 `DATA BRANCH PICK table_name INTO table_name
     [BETWEEN SNAPSHOT ... AND ...] [KEYS (...)] [WHEN CONFLICT ...]` 语法；
     `pkg/sql/parsers/tree/data_branch.go` 新增 `DataBranchPick` / `PickKeys`；
     `pkg/frontend/data_branch_pick.go` 的 `handleBranchPick` 在显式事务、
     目标表无主键、缺少 `KEYS`/`BETWEEN SNAPSHOT`、目标表带 SNAPSHOT 等场景
     均返回明确错误。
   - 测试证据：`test/distributed/cases/git4data/branch/pick/pick_*.sql` 覆盖
     KEYS、KEYS 子查询、复合主键、BETWEEN SNAPSHOT、FAIL/SKIP/ACCEPT 等用法。

2. **`DATA BRANCH DIFF` 新增 `COLUMNS` 投影**：允许在 `AGAINST base_table`
   之后指定 `COLUMNS (col, ...)`，只比较投影列，并且明确禁止与 `OUTPUT FILE`
   同时使用。
   - 源码证据：`pkg/sql/parsers/dialect/mysql/mysql_sql.y` 新增
     `diff_columns_opt`；`pkg/sql/parsers/tree/data_branch.go` 在
     `DataBranchDiff` 上新增 `Columns IdentifierList` 字段；运行时存在
     错误 `DATA BRANCH DIFF COLUMNS is not supported with OUTPUT FILE`。
   - 测试证据：`TestDataBranchDiffColumns` 覆盖 `columns (id, name)`、
     `columns (a, b, c) output limit 10`、`columns (x) output file '/tmp/'`
     等多种写法。

两仓的 Release Notes (`v26.3.0.10.md`) 已由上游预先提交到仓内，本次同步
保持原有 Release Notes 内容不变，仅按仓补齐 `DATA BRANCH PICK` 专页和
`DATA BRANCH DIFF` 的 `COLUMNS` 投影说明。

除上述两项之外，v3.0.10 还包含 SQL Task（`CREATE TASK` / `ALTER TASK` /
`SHOW TASKS` / `SHOW TASK RUNS` / `EXECUTE TASK` 等）以及
`ALTER ROLE ... ADD/DROP RULE` + `SHOW RULES ON ROLE` 这两组较大的新功能，
以及一批内部修复。这些变更的语义和外观超出 diff 所能单独确认的范围，已在
各仓 Skipped Changes 中标注，需要由人工主导补写专题文档；详见下文 Skipped
Changes 章节。

## Repo: io (matrixorigin/matrixorigin.io) [push: ULookup/matrixorigin.io]

### Docs Updated

- `docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-diff-en.md`
  - 语法块增加 `[COLUMNS ( column_list )]`。
  - 新增 `Column Projection` 小节，说明语义与和 `OUTPUT FILE` 的互斥关系。
  - 新增 `Example 9: Project a Subset of Columns` 示例。

### Docs Added

- `docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-pick.md`
  - 覆盖语法、`KEYS (values | subquery)`、`BETWEEN SNAPSHOT`、`WHEN CONFLICT
    FAIL|SKIP|ACCEPT`、权限 / 主键 / 显式事务限制、以及 7 个示例（无共同祖先、
    有共同祖先、子查询、冲突处理、源表快照、快照窗口、复合主键）。
  - 文件名使用中性英文命名 `data-branch-pick.md`（cn 仓共用同名文件以与该仓
    现有风格一致；两仓文件内容语言不同）。

### Navigation Updated

- `mkdocs.yml`：在现有 `DIFF BRANCH` / `MERGE BRANCH` 条目之后新增
  `PICK BRANCH: MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-pick.md`
  入口；未改动其他导航项。

### Release Notes

- 仓内已存在 `docs/MatrixOne/Release-Notes/v26.3.0.10.md`（英文，风格与历史
  版本一致），其内容已涵盖本次 diff 的用户可见改动（包括 DATA BRANCH PICK、
  DATA BRANCH DIFF 的 COLUMNS 投影、SQL 任务流水线、角色规则、statistics view
  升级、SHOW ACCOUNTS 优化、以及多项 bug 修复）。
- 本次同步 **未修改** Release Notes 文件，仅补齐 SQL 参考文档；Release Notes
  文件命名也沿用仓内既有的 `v26.3.0.10.md` 约定，未按 git tag 改名。

### Skipped Changes

#### Skipped: SQL Task scheduler（CREATE / ALTER / DROP / SHOW TASK / SHOW TASK RUNS / EXECUTE TASK）

- Repo: io
- Source files: `pkg/sql/parsers/dialect/mysql/mysql_sql.y` (grammar for
  `create_sql_task_stmt`, `alter_sql_task_stmt`, `drop_sql_task_stmt`,
  `show_sql_tasks_stmt`, `show_sql_task_runs_stmt`, `sql_task_schedule_opt`,
  `sql_task_timezone_opt`, `sql_task_when_opt`, `sql_task_retry_opt`,
  `sql_task_timeout_opt`); `pkg/sql/parsers/tree/sql_task.go`;
  `pkg/frontend/sql_task_handler.go`; `pkg/taskservice/sql_task*.go`;
  `pkg/taskservice/mysql_task_storage.go`;
  `test/distributed/cases/task/sql_task.sql`.
- Reason: 这是一个覆盖 parser、frontend、taskservice、storage，以及新内部
  表 `mo_task.sql_task` / `mo_task.sql_task_run` 的完整子系统。`SHOW TASKS`
  / `SHOW TASK RUNS` 的输出列、`SCHEDULE` 的 cron 语法细节、`TIMEZONE` /
  `TIMEOUT` / `WHEN` / `RETRY` 的用户可见语义和最佳实践，仅凭 diff 无法稳妥
  确认；需要由产品 / 内核团队主导补写专题。
- Suggested human action: 规划一个专门的 Task 章节（建议落在
  `docs/MatrixOne/Reference/SQL-Reference/` 下的新目录），补齐 `CREATE TASK`
  / `ALTER TASK` / `DROP TASK` / `SHOW TASKS` / `SHOW TASK RUNS` /
  `EXECUTE TASK` 的英文参考页及教程。Release Notes 已以 "SQL task pipeline"
  条目提示该能力存在。

#### Skipped: ALTER ROLE ... ADD/DROP RULE 和 SHOW RULES ON ROLE

- Repo: io
- Source files:
  - `pkg/sql/parsers/dialect/mysql/mysql_sql.y`
    （`ALTER ROLE role_name ADD RULE STRING ON TABLE ident '.' ident`、
    `ALTER ROLE role_name DROP RULE ON TABLE ident '.' ident`、
    `SHOW RULES ON ROLE role_name`）。
  - `pkg/frontend/rewrite_rule.go`、`pkg/frontend/authenticate.go`。
  - `pkg/bootstrap/versions/v3_0_1/tenant_upgrade_list.go`（新 catalog 表
    `mo_catalog.mo_role_rule`）。
  - `test/distributed/cases/zz_accesscontrol/role_rule.sql`。
- Reason: rewrite rule 的语义（`rule_sql` 如何重写用户查询、何时生效、与
  GRANT 的优先级关系、跨租户行为）需要由权限 / 安全团队主导产品定义，
  diff 本身不足以写出稳妥的用户指引。
- Suggested human action: 与权限团队确认 rule 的触发条件与优先级后，在两仓
  `docs/MatrixOne/Reference/SQL-Reference/Data-Control-Language/` 下各自
  新增 `ALTER ROLE`（扩展）、`SHOW RULES ON ROLE` 参考页，并在权限管理章节
  交叉引用。

#### Skipped: 3.0.1 / 3.0.2 bootstrap upgrade entries

- Repo: io
- Source files: `pkg/bootstrap/upgrade.go`、`pkg/bootstrap/versions/v3_0_1/*`、
  `pkg/bootstrap/versions/v3_0_2/*`。
- Reason: 属于升级框架内部记录（创建 `mo_catalog.mo_role_rule`、
  `mo_task.sql_task` / `sql_task_run` 内部表，并重新应用
  `information_schema.STATISTICS` 视图修复），不是独立的用户可见语义变化。
  对应的 user-visible 影响已由 `mo_role_rule` / SQL Task / statistics view
  三项在其他跳过项中覆盖。
- Suggested human action: 保持仅在 Release Notes 中提及，不新增专门页面。

### Risks

- **PICK 示例语义未在 docs-sync-agent 运行环境中执行**：新增的
  `data-branch-pick.md` 示例源自源码 diff 中描述的行为和 `pick_1.sql` /
  `pick_2.sql` / `pick_10.sql` 等测试用例，但并未实际跑 MatrixOne；审阅时
  请由熟悉 data branch 的工程师核对示例输出。
- **`DATA BRANCH PICK` 权限提示**：本次写入的权限说明基于
  `authenticatePickTablePrivileges` 里对源表 select / 目标表 modify 的校验
  逻辑；如果产品侧对外表述采用不同措辞（例如特定的 `PrivilegeType` 名称），
  建议审阅时统一一次。
- **Release Notes 不在本次修改范围内**：仓内已存在的 `v26.3.0.10.md` 被视为
  上游既有产物，agent 未改动；若其内容需要调整，请人工审阅。
