### PR TITLE
[docs-sync] MatrixOne v3.0.10 文档同步 (io)

### DIFF
--- a/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-diff-en.md
+++ b/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-diff-en.md
@@ -15,6 +15,7 @@ The system automatically identifies the Lowest Common Ancestor (LCA) between two
 ```
 DATA BRANCH DIFF target_table [{ SNAPSHOT = 'snapshot_name' }] 
     AGAINST base_table [{ SNAPSHOT = 'snapshot_name' }] 
+    [COLUMNS (col_name [, col_name ...])]
     [OUTPUT output_option]
 ```
 
@@ -24,9 +25,21 @@ DATA BRANCH DIFF target_table [{ SNAPSHOT = 'snapshot_name' }]
 output_option:
     COUNT                           -- Return only the count of different rows
   | LIMIT number                    -- Limit the number of returned difference rows
+  | SUMMARY                         -- Return a summary (counts by INSERT/DELETE/UPDATE)
   | FILE 'directory_path'           -- Export differences as SQL file
   | AS table_name                   -- Save differences to a table (not yet supported)
 ```
+
+### COLUMNS Projection
+
+`COLUMNS (...)` restricts the diff output to the listed columns only.
+Column names are matched case-insensitively; duplicate names in the
+list are deduplicated. When `COLUMNS` is omitted, the diff returns
+every visible column, preserving the previous behavior.
+
+`COLUMNS` may be combined with `OUTPUT LIMIT`, `OUTPUT COUNT`, or
+`OUTPUT SUMMARY`; counts and summaries are unaffected by the projection
+(they describe how many rows differ, not which columns are shown).
 
 ## Arguments
 
@@ -37,8 +50,10 @@ output_option:
 | `target_table` | Target table (the table to compare) |
 | `base_table` | Base table (the table used as comparison baseline) |
 | `SNAPSHOT = 'snapshot_name'` | Optional parameter to specify using data at a snapshot point for comparison |
+| `COLUMNS (col_name, ...)` | Optional. Project only the listed columns in the diff output. Names are case-insensitive; duplicates are deduplicated. Does not affect `OUTPUT COUNT` or `OUTPUT SUMMARY` results. |
 | `OUTPUT COUNT` | Return only the count of differences |
 | `OUTPUT LIMIT number` | Limit the number of returned difference rows |
+| `OUTPUT SUMMARY` | Return a summary of the diff instead of the rows themselves |
 | `OUTPUT FILE 'path'` | Export differences as SQL file to specified directory, supports local path or Stage path (e.g., `stage://stage_name/`) |
 
 ### Output Column Description
@@ -431,6 +446,74 @@ DROP TABLE test.orders;
 DROP TABLE test.orders_branch;
 -- Expected-Rows: 0
 DROP DATABASE test;
+```
+
+### Example 9: Project Selected Columns (COLUMNS)
+
+Use `COLUMNS` to restrict the diff output to specific columns. The
+projection does not change the set of differing rows — it only changes
+which columns are rendered per row.
+
+<!-- validator-ignore -->
+```sql
+-- Expected-Rows: 0
+CREATE DATABASE test_diff_columns;
+-- Expected-Rows: 0
+USE test_diff_columns;
+
+-- Expected-Rows: 0
+CREATE TABLE c1(
+    id INT PRIMARY KEY,
+    name VARCHAR(30),
+    balance DECIMAL(12,2),
+    created_at TIMESTAMP,
+    birthday DATE
+);
+-- Expected-Rows: 0
+INSERT INTO c1 VALUES
+    (1, 'alice', 1000.50, '2024-01-01 10:00:00', '1990-03-15'),
+    (2, 'bob',   2000.75, '2024-01-02 11:00:00', '1985-07-20'),
+    (3, 'carol', 3000.00, '2024-01-03 12:00:00', '1992-11-08');
+
+-- Expected-Rows: 0
+CREATE SNAPSHOT c1_sp0 FOR TABLE test_diff_columns c1;
+
+-- Expected-Rows: 0
+DATA BRANCH CREATE TABLE c1_br FROM c1{SNAPSHOT="c1_sp0"};
+-- Expected-Rows: 1
+UPDATE c1_br SET balance = 1500.50, name = 'alice_v2' WHERE id = 1;
+-- Expected-Rows: 1
+DELETE FROM c1_br WHERE id = 2;
+-- Expected-Rows: 0
+INSERT INTO c1_br VALUES (4, 'dave', 4000.00, '2024-02-01 09:00:00', '1988-12-25');
+
+-- Project only the name and balance columns
+DATA BRANCH DIFF c1_br AGAINST c1{SNAPSHOT="c1_sp0"} COLUMNS (name, balance);
+
+-- COLUMNS combined with OUTPUT COUNT: counts are unaffected
+DATA BRANCH DIFF c1_br AGAINST c1{SNAPSHOT="c1_sp0"} COLUMNS (name) OUTPUT COUNT;
+
+-- Expected-Rows: 0
+DROP SNAPSHOT c1_sp0;
+-- Expected-Rows: 0
+DROP TABLE c1;
+-- Expected-Rows: 0
+DROP TABLE c1_br;
+-- Expected-Rows: 0
+DROP DATABASE test_diff_columns;
+```
+
+### Example 10: Diff Summary (OUTPUT SUMMARY)
+
+`OUTPUT SUMMARY` returns aggregate information about the diff instead
+of the individual rows. This is useful for quickly checking how much
+data has changed between two branches without materializing the full
+row set.
+
+<!-- validator-ignore -->
+```sql
+-- Expected-Success: true
+DATA BRANCH DIFF c1_br AGAINST c1{SNAPSHOT="c1_sp0"} OUTPUT SUMMARY;
 ```
 
 ## Notes

--- a/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-pick-en.md
+++ b/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-pick-en.md
@@ -1,0 +1,305 @@
+# DATA BRANCH PICK
+
+## Description
+
+The `DATA BRANCH PICK` statement cherry-picks a selected set of rows from
+a source branch table into a destination branch table. Compared with
+`DATA BRANCH MERGE`, which applies every diff between two branches,
+`PICK` only applies the rows the user selects — either by listing their
+primary keys (`KEYS`) or by bounding them with a snapshot range
+(`BETWEEN SNAPSHOT`).
+
+Under the hood the system reuses the diff pipeline that
+`DATA BRANCH DIFF` / `DATA BRANCH MERGE` use. It automatically detects
+the Lowest Common Ancestor (LCA) between the two tables, computes the
+effective INSERT / DELETE / UPDATE set for the picked keys, and applies
+them to the destination table under the chosen conflict policy.
+
+## Syntax
+
+```
+DATA BRANCH PICK source_table INTO destination_table
+    KEYS ( key_list | select_stmt )
+    [WHEN CONFLICT conflict_option]
+
+DATA BRANCH PICK source_table INTO destination_table
+    BETWEEN SNAPSHOT from_snapshot AND to_snapshot
+    [KEYS ( key_list | select_stmt )]
+    [WHEN CONFLICT conflict_option]
+```
+
+### KEYS clause
+
+```
+KEYS ( expr [, expr ...] )          -- literal primary-key values
+KEYS ( select_stmt )                -- subquery yielding primary-key rows
+```
+
+For a composite primary key, each literal key must be written as a
+tuple matching the PK column order, and a subquery must return the same
+number of columns as the PK.
+
+### BETWEEN SNAPSHOT clause
+
+```
+BETWEEN SNAPSHOT snapshot_name AND snapshot_name
+```
+
+Snapshot names may be supplied either as identifiers or as quoted
+string literals. The range identifies the source-side window from which
+rows are picked.
+
+### Conflict handling options
+
+```
+conflict_option:
+    FAIL                            -- Error and abort on conflict (default)
+  | SKIP                            -- Skip conflicting rows, keep destination value
+  | ACCEPT                          -- Overwrite destination with source value
+```
+
+## Arguments
+
+| Parameter | Description |
+|-----------|-------------|
+| `source_table` | Source branch table to pick from. May include a `{SNAPSHOT = 'snapshot_name'}` option to pin the source at a specific snapshot. |
+| `destination_table` | Destination branch table that receives the picked rows. A destination-side snapshot option is not allowed. |
+| `KEYS ( key_list )` | Literal primary-key values. Scalar values for a single-column PK; tuples `(v1, v2, ...)` for a composite PK. |
+| `KEYS ( select_stmt )` | Subquery returning primary-key columns. For a single-column PK the subquery must return one column; for a composite PK it must return exactly the PK columns in order. |
+| `BETWEEN SNAPSHOT from_snapshot AND to_snapshot` | Restrict picked rows to the source-side changes that fall between two snapshots. May be combined with `KEYS` to pick only those rows whose PK is in the KEYS set. |
+| `WHEN CONFLICT FAIL` | Default. Error out if a picked row conflicts with the destination. |
+| `WHEN CONFLICT SKIP` | Keep the destination value for conflicting keys. |
+| `WHEN CONFLICT ACCEPT` | Overwrite the destination value with the source value for conflicting keys. |
+
+### Conflict definition
+
+A conflict is reported for a picked key when the same primary key
+exists on both sides with different values — for example, when both
+branches inserted the same PK with different column values or both
+branches updated the same PK to different values. Picking a key that
+was deleted on one side and modified on the other is also a conflict.
+
+## Usage Notes
+
+- `DATA BRANCH PICK` is not supported inside an explicit transaction
+  (`BEGIN ... COMMIT`). The statement must be issued in auto-commit
+  mode.
+- The statement requires either a `KEYS` clause, a
+  `BETWEEN SNAPSHOT ... AND ...` clause, or both. Neither clause alone
+  being present is an error.
+- `BETWEEN SNAPSHOT` cannot be combined with a `{SNAPSHOT = ...}`
+  option on the source table — pick one of the two ways to pin the
+  source.
+- A snapshot option on the destination table is not supported and will
+  be rejected.
+- Subqueries passed in `KEYS` must not return `NULL` for a
+  primary-key column.
+- When no `WHEN CONFLICT` clause is specified, the default is
+  `WHEN CONFLICT FAIL`.
+- Privileges: the executor must hold the privileges required to read
+  the source table and modify the destination table.
+
+## Examples
+
+### Example 1: Pick by primary key
+
+Cherry-pick a single row from one branch into another.
+
+```sql
+CREATE DATABASE test;
+USE test;
+
+CREATE TABLE t1 (a INT, b INT, PRIMARY KEY(a));
+INSERT INTO t1 VALUES (1,1),(3,3),(5,5);
+
+CREATE TABLE t2 (a INT, b INT, PRIMARY KEY(a));
+INSERT INTO t2 VALUES (1,1),(2,2),(4,4);
+
+DATA BRANCH PICK t2 INTO t1 KEYS(2);
+SELECT * FROM t1 ORDER BY a;
++------+------+
+| a    | b    |
++------+------+
+|    1 |    1 |
+|    2 |    2 |
+|    3 |    3 |
+|    5 |    5 |
++------+------+
+
+DATA BRANCH PICK t2 INTO t1 KEYS(4);
+SELECT * FROM t1 ORDER BY a;
++------+------+
+| a    | b    |
++------+------+
+|    1 |    1 |
+|    2 |    2 |
+|    3 |    3 |
+|    4 |    4 |
+|    5 |    5 |
++------+------+
+
+DROP TABLE t1;
+DROP TABLE t2;
+```
+
+### Example 2: Pick with conflict handling
+
+Both branches insert the same primary key with different values. The
+default `WHEN CONFLICT FAIL` aborts; `WHEN CONFLICT SKIP` keeps the
+destination value; `WHEN CONFLICT ACCEPT` overwrites with the source
+value.
+
+```sql
+CREATE TABLE t0 (a INT, b INT, PRIMARY KEY(a));
+INSERT INTO t0 VALUES (1,1),(2,2);
+
+DATA BRANCH CREATE TABLE t1 FROM t0;
+INSERT INTO t1 VALUES (3,30);
+
+DATA BRANCH CREATE TABLE t2 FROM t0;
+INSERT INTO t2 VALUES (3,40);
+
+-- default is FAIL: this statement errors out
+DATA BRANCH PICK t2 INTO t1 KEYS(3);
+
+DATA BRANCH PICK t2 INTO t1 KEYS(3) WHEN CONFLICT SKIP;
+SELECT * FROM t1 ORDER BY a;
++------+------+
+| a    | b    |
++------+------+
+|    1 |    1 |
+|    2 |    2 |
+|    3 |   30 |
++------+------+
+
+DATA BRANCH PICK t2 INTO t1 KEYS(3) WHEN CONFLICT ACCEPT;
+SELECT * FROM t1 ORDER BY a;
++------+------+
+| a    | b    |
++------+------+
+|    1 |    1 |
+|    2 |    2 |
+|    3 |   40 |
++------+------+
+
+DROP TABLE t0;
+DROP TABLE t1;
+DROP TABLE t2;
+```
+
+### Example 3: Pick via subquery (composite primary key)
+
+Use a subquery to drive the set of picked keys. For a composite PK the
+subquery must return the same number of columns as the PK, in order.
+
+```sql
+CREATE TABLE t0 (a INT, b INT, c VARCHAR(20), PRIMARY KEY(a, b));
+INSERT INTO t0 VALUES (1,1,'base'),(2,2,'base');
+
+DATA BRANCH CREATE TABLE t1 FROM t0;
+DATA BRANCH CREATE TABLE t2 FROM t0;
+
+INSERT INTO t2 VALUES (3,3,'new'),(4,4,'new'),(5,5,'new'),(6,6,'new');
+
+DATA BRANCH PICK t2 INTO t1
+    KEYS(SELECT a, b FROM t2 WHERE a >= 4 AND a % 2 = 0);
+
+SELECT * FROM t1 ORDER BY a, b;
++------+------+------+
+| a    | b    | c    |
++------+------+------+
+|    1 |    1 | base |
+|    2 |    2 | base |
+|    4 |    4 | new  |
+|    6 |    6 | new  |
++------+------+------+
+
+DROP TABLE t0;
+DROP TABLE t1;
+DROP TABLE t2;
+```
+
+### Example 4: Pick rows between two snapshots
+
+`BETWEEN SNAPSHOT` restricts the pick to changes that happened on the
+source side between two snapshots. Snapshot names may be supplied as
+identifiers or as string literals.
+
+```sql
+CREATE TABLE t0 (a INT, b INT, PRIMARY KEY(a));
+INSERT INTO t0 VALUES (1,1);
+
+DATA BRANCH CREATE TABLE t1 FROM t0;
+
+CREATE SNAPSHOT sp_from FOR ACCOUNT sys;
+INSERT INTO t1 VALUES (2,2),(3,3);
+CREATE SNAPSHOT sp_to FOR ACCOUNT sys;
+INSERT INTO t1 VALUES (4,4);
+
+-- only pick rows inserted on t1 between sp_from and sp_to
+DATA BRANCH PICK t1 INTO t0 BETWEEN SNAPSHOT 'sp_from' AND 'sp_to';
+SELECT * FROM t0 ORDER BY a;
++------+------+
+| a    | b    |
++------+------+
+|    1 |    1 |
+|    2 |    2 |
+|    3 |    3 |
++------+------+
+
+DROP SNAPSHOT sp_from;
+DROP SNAPSHOT sp_to;
+DROP TABLE t0;
+DROP TABLE t1;
+```
+
+### Example 5: Combine BETWEEN SNAPSHOT with KEYS
+
+`BETWEEN SNAPSHOT` and `KEYS` can be combined to pick only the rows in
+the snapshot range whose primary keys are in the KEYS set.
+
+```sql
+CREATE TABLE t0 (a INT, b INT, PRIMARY KEY(a));
+INSERT INTO t0 VALUES (1,1),(2,2),(3,3);
+
+DATA BRANCH CREATE TABLE t1 FROM t0;
+
+CREATE SNAPSHOT sp1 FOR ACCOUNT sys;
+INSERT INTO t1 VALUES (4,4),(5,5),(6,6);
+CREATE SNAPSHOT sp2 FOR ACCOUNT sys;
+INSERT INTO t1 VALUES (7,7);
+
+-- only pk=5, among {4,5,6} inserted between sp1 and sp2
+DATA BRANCH PICK t1 INTO t0 BETWEEN SNAPSHOT 'sp1' AND 'sp2' KEYS(5);
+SELECT * FROM t0 ORDER BY a;
++------+------+
+| a    | b    |
++------+------+
+|    1 |    1 |
+|    2 |    2 |
+|    3 |    3 |
+|    5 |    5 |
++------+------+
+
+DROP SNAPSHOT sp1;
+DROP SNAPSHOT sp2;
+DROP TABLE t0;
+DROP TABLE t1;
+```
+
+## Notes
+
+1. **KEYS or BETWEEN SNAPSHOT is required.** The server will refuse a
+   `DATA BRANCH PICK` that has neither.
+2. **Explicit transactions are not supported.** Issue `DATA BRANCH PICK`
+   in auto-commit mode; a statement inside `BEGIN ... COMMIT` is
+   rejected.
+3. **Source-snapshot exclusivity.** `BETWEEN SNAPSHOT` cannot be
+   combined with a `{SNAPSHOT = ...}` option on the source table.
+4. **Destination snapshot not supported.** The destination table must
+   reference the live table — a `{SNAPSHOT = ...}` option is rejected.
+5. **NULL keys are not accepted.** A subquery in `KEYS` must not
+   produce `NULL` for any primary-key column.
+6. **Default conflict policy is FAIL.** Supply
+   `WHEN CONFLICT SKIP` or `WHEN CONFLICT ACCEPT` explicitly if you
+   want a non-failing behavior.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -367,6 +367,7 @@ nav:
                   - DELETE BRANCH: MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-delete-en.md
                   - DIFF BRANCH: MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-diff-en.md
                   - MERGE BRANCH: MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-merge-en.md
+                  - PICK BRANCH: MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-pick-en.md
                   - ALTER TABLE: MatrixOne/Reference/SQL-Reference/Data-Definition-Language/alter-table.md
                   - ALTER TABLE ... ALTER REINDEX: MatrixOne/Reference/SQL-Reference/Data-Definition-Language/alter-reindex.md
                   - ALTER PITR: MatrixOne/Reference/SQL-Reference/Data-Definition-Language/alter-pitr.md


### PR DESCRIPTION
# MatrixOne 文档自动同步 (io)

## 基本信息

- Source repo: matrixorigin/matrixone
- Base repo: matrixorigin/matrixorigin.io
- Head: ULookup:docs-sync/matrixone-v3.0.10 (from fork ULookup/matrixorigin.io)
- Docs key: io
- From tag: v3.0.9
- To tag: v3.0.10
- Target branch: main
- Generated by: MatrixOne Docs Sync Agent

## Tags

- From: v3.0.9
- To: v3.0.10

## User-visible Changes

本次同步覆盖以下用户可见变更（两个文档仓共享；语言按仓区分）：

1. **新语句 `DATA BRANCH PICK`**：支持按主键 cherry-pick 行或按
   `BETWEEN SNAPSHOT` 快照区间挑选源端变更到目标分支表，支持
   `WHEN CONFLICT FAIL|SKIP|ACCEPT` 三种冲突策略；不支持显式事务；
   不支持目标表快照选项；`BETWEEN SNAPSHOT` 与源表快照选项互斥；
   子查询 KEYS 不允许 NULL 主键列。源码证据：
   `pkg/frontend/data_branch_pick.go`、
   `pkg/sql/parsers/dialect/mysql/mysql_sql.y`（`DATA BRANCH PICK ...`
   产生式）、`test/distributed/cases/git4data/branch/pick/pick_1..12.sql`。

2. **`DATA BRANCH DIFF` 新增 `COLUMNS` 投影**：在 `AGAINST base_table`
   之后、`OUTPUT` 之前可加 `COLUMNS (col [, col ...])`，仅投影指定列；
   大小写不敏感、去重；不影响 `OUTPUT COUNT` / `OUTPUT SUMMARY`。
   证据：`pkg/sql/parsers/dialect/mysql/mysql_sql.y`（`diff_columns_opt`）、
   `test/distributed/cases/git4data/branch/diff/diff_11.sql`。

3. **`DATA BRANCH DIFF` 新增 `OUTPUT SUMMARY`**：返回差异摘要，替代
   完整差异行输出。证据：`diff_output_opt` 的 parser 规则 +
   `diff_9.sql` / `diff_11.sql` 中 `output summary` 的用例。

4. **Release Notes v26.3.0.10**：两个文档仓均已存在
   `Release-Notes/v26.3.0.10.md`，内容覆盖本次 tag 的用户可见变更
   （Data branch、SQL tasks & full-text、角色模型、统计/订阅、
   bugfix 分组）；无需本轮新增。

内部/跳过类（不写入 SQL Reference）：

- `data_branch_fullscan`：内部组件，无独立 SQL 入口。
- `sql_task` / `rewrite_rule`：本轮属于较大范围新特性，其语法面较广
  且部分细节需要产品同学复核（尤其 `CREATE TASK ... AS BEGIN ... END`
  的语义说明、`mo_task.sql_task` / `sql_task_run` 对外暴露程度、
  `enable_remap_hint` 与 `mo_role_rule` 是否作为公开 API）。为避免
  编造，不在 SQL Reference 中新增专页，仅在 Release Notes 中概述。
- 其他 bugfix / 内部优化：仅在 Release Notes 中列出。

## Repo: io (matrixorigin/matrixorigin.io) [push: ULookup/matrixorigin.io]

### Docs Updated

- `docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-diff-en.md`
  - 语法块加入 `[COLUMNS (col_name [, col_name ...])]` 以及
    `OUTPUT SUMMARY`。
  - 新增 `COLUMNS Projection` 小节说明大小写不敏感 / 去重 / 与
    `OUTPUT COUNT|SUMMARY` 组合后不影响计数/摘要。
  - Arguments 表新增 `COLUMNS (col_name, ...)` 与
    `OUTPUT SUMMARY` 两行。
  - 新增 `Example 9: Project Selected Columns (COLUMNS)` 与
    `Example 10: Diff Summary (OUTPUT SUMMARY)`，示例基于
    `diff_11.sql`。

### Docs Added

- `docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-pick-en.md`
  - 新增 `DATA BRANCH PICK` 专页，英文正文。
  - 包含 Description / Syntax（KEYS、BETWEEN SNAPSHOT 两种形式 +
    可选 `WHEN CONFLICT`）/ Arguments / Usage Notes（显式事务禁用、
    必须至少带 KEYS 或 BETWEEN SNAPSHOT、BETWEEN 与源端快照互斥、
    目标侧快照不支持、子查询 KEYS 禁止 NULL、默认冲突策略 FAIL）/
    5 个 Examples（按主键 pick、冲突 FAIL/SKIP/ACCEPT、复合主键子查询
    pick、BETWEEN SNAPSHOT、BETWEEN+KEYS 组合）/ Notes。
  - 示例严格基于 `pick_1.sql` / `pick_2.sql` / `pick_10.sql` /
    `pick_11.sql` 的测试用例，可在测试中找到来源。

### Navigation Updated

- `mkdocs.yml`：在 `Data Definition Language` 下紧随 `MERGE BRANCH`
  追加一条 `- PICK BRANCH: ...data-branch-pick-en.md`，保持与
  Data Branch 家族相邻。

### Release Notes

- `docs/MatrixOne/Release-Notes/v26.3.0.10.md` 已存在（英文），内容
  覆盖 Data branch、SQL tasks & full-text、角色模型、统计/订阅、
  bugfix 分组。本轮无需新增或改动。
- 注意：io 仓 `mkdocs.yml` 中 Release Notes 导航段目前尚未列入
  `v26.x`，该状态在本次 tag 之前既已如此，Agent 未修改（避免在
  未知策略下引入导航改动）。

### Skipped Changes

### Skipped: SQL Task 语句族（CREATE / ALTER / DROP / EXECUTE / SHOW TASK）

- Repo: io
- Source files: `pkg/sql/parsers/dialect/mysql/mysql_sql.y`（新增
  `create_sql_task_stmt`、`alter_sql_task_stmt`、`drop_sql_task_stmt`、
  `show_sql_tasks_stmt`、`show_sql_task_runs_stmt`），
  `pkg/sql/parsers/tree/sql_task.go`，`pkg/frontend/sql_task_handler.go`，
  `pkg/taskservice/sql_task*.go`，`test/distributed/cases/task/sql_task.sql`。
- Reason: 该特性有完整 source 包，但面向外部的行为细节（例如
  `CREATE TASK ... AS BEGIN ... END` 的 body 分隔符策略、
  `mo_task.sql_task` / `mo_task.sql_task_run` 系统表是否为公开接口、
  `ALTER TASK ... SET SCHEDULE` 对 cron 表达式的格式要求、权限模型）
  尚未有对应的英文 SQL Reference 文档基调可参考，强行新增会有编造
  文档的风险。Release Notes 中已有条目概述。
- Suggested human action: 由产品/文档同事与后端 owner 对齐
  CREATE TASK 的正式语法形态与可见系统表清单后，再在 DDL 章节
  新增专页（建议与 `CREATE CDC`、`CREATE DYNAMIC TABLE` 相邻）。

### Skipped: 角色重写规则（ALTER ROLE ADD/DROP RULE、SHOW RULES ON ROLE、enable_remap_hint）

- Repo: io
- Source files: `pkg/frontend/rewrite_rule.go`、
  `pkg/sql/parsers/dialect/mysql/mysql_sql.y`
  （`alter_role_stmt` 新增 `ADD RULE "..." ON TABLE db.tbl` /
  `DROP RULE ON TABLE db.tbl`，`show_rules_on_role_stmt`），
  `test/distributed/cases/zz_accesscontrol/role_rule.sql`。
- Reason: 该特性依赖会话变量 `enable_remap_hint` 与内部表
  `mo_catalog.mo_role_rule`，规则以 `/*+ {"rewrites": {...}} */` 形式
  注入 SQL。对外语义（规则作用范围、多规则合并顺序、与现有
  `GRANT` 权限模型的交互、跨会话缓存失效）在现有 io 文档中尚无
  对等章节，贸然补齐会引入假设。Release Notes 已收录 "Authorization:
  add a role rule capability (#23823)(#23851)" 条目。
- Suggested human action: 产品/安全 owner 确认该特性是否对外公开后，
  在 DCL 下新增 `ALTER ROLE ... RULE` 与 `SHOW RULES ON ROLE` 专页。

### Risks

- DATA BRANCH PICK 文档为新增页，示例完全基于测试用例，不涉及真实
  线上表数据；但示例执行次序中存在 `DROP TABLE` 等破坏性语句，
  审稿人请确认其仍与测试保持一致。
- data-branch-diff-en.md 中 `OUTPUT SUMMARY` 的返回格式未从源码中
  读出确定形态，文档仅表述其语义（摘要，不返回具体行），未示例
  具体列/行；若产品希望展示摘要表格列名，需要人工补充。
- 本轮未新增 `CREATE TASK` / `ALTER ROLE ... RULE` 专页，存在文档覆
  盖率落后于功能落地的风险；Release Notes 已做兜底说明。
