### PR TITLE
[docs-sync] MatrixOne v3.0.10 文档同步 (io)

### DIFF
--- a/docs/MatrixOne/Reference/SQL-Reference/Data-Control-Language/alter-role-rule.md
+++ b/docs/MatrixOne/Reference/SQL-Reference/Data-Control-Language/alter-role-rule.md
@@ -1,0 +1,180 @@
+# ALTER ROLE ... ADD/DROP RULE
+
+## Description
+
+`ALTER ROLE role_name ADD RULE 'sql_text' ON TABLE db.tbl` registers a
+per-role SQL rewrite rule in the `mo_catalog.mo_role_rule` catalog
+table. `ALTER ROLE role_name DROP RULE ON TABLE db.tbl` removes the
+rule previously registered for the given role and `db.tbl`.
+
+Registered rules cooperate with the existing session variable
+`enable_remap_hint`: when a session runs with the role that owns a
+rule and `enable_remap_hint = 1`, the server prepends a JSON hint
+(`/*+ {"rewrites": {...}} */`) to each SQL statement, which is then
+consumed by the rewrite pipeline. Turning off `enable_remap_hint` (or
+using a role with no rules) disables the injection.
+
+This documents the `rewrite_rule` feature.
+
+## Syntax
+
+```
+ALTER ROLE role_name ADD RULE 'sql_text' ON TABLE db_name '.' tbl_name ;
+
+ALTER ROLE role_name DROP RULE ON TABLE db_name '.' tbl_name ;
+```
+
+## Arguments
+
+| Parameter | Description |
+|-----------|-------------|
+| `role_name` | Role that owns the rule. The role must already exist; otherwise the server returns `internal error: there is no role <role_name>`. |
+| `'sql_text'` | The rewrite rule body. Passed as a quoted string literal; stored verbatim in `mo_catalog.mo_role_rule.rule`. |
+| `db_name.tbl_name` | Target table scope for the rule. The rule key (`rule_name` column) is derived as the concatenation `db_name + "." + tbl_name`. |
+
+## Usage Notes
+
+- **Upsert semantics for ADD RULE.** Re-running
+  `ALTER ROLE role_name ADD RULE ... ON TABLE db.tbl` with the same
+  `(role, db.tbl)` overwrites the previous rule body rather than
+  creating a duplicate row.
+- **DROP RULE requires the rule to exist.** If no row exists for
+  `(role, db.tbl)` the server returns
+  `internal error: rule '<db.tbl>' does not exist for role '<role>'`.
+- **DROP RULE requires the role to exist.** Dropping a rule for a
+  non-existent role returns
+  `internal error: there is no role <role_name>`.
+- **Session cache invalidation.** After a successful ADD or DROP the
+  current session's in-memory rewrite-rule cache is invalidated;
+  other sessions using the same role will pick up the new rule set
+  after they refresh their cache (for example by re-executing
+  `SET ROLE`).
+- **Hint injection is gated by `enable_remap_hint`.** The rules only
+  affect query execution when the session variable
+  `enable_remap_hint` is truthy (e.g. `1`).
+
+## Examples
+
+The examples below mirror the behavior covered by the
+`role_rule.sql` regression test: creating a role and a rule,
+overwriting the rule, merging multiple rules, dropping, and the
+error cases for non-existent roles/rules.
+
+### Example 1: Add a rule and verify via SHOW RULES
+
+```sql
+CREATE ROLE test_rule_role;
+
+ALTER ROLE test_rule_role
+    ADD RULE "select * from db1.t1 where age > 28"
+    ON TABLE db1.t1;
+
+SHOW RULES ON ROLE test_rule_role;
++-----------+-------------------------------------+
+| rule_name | rule                                |
++-----------+-------------------------------------+
+| db1.t1    | select * from db1.t1 where age > 28 |
++-----------+-------------------------------------+
+```
+
+### Example 2: ADD RULE is an upsert on (role, db.tbl)
+
+Re-running ADD RULE for the same role and table overwrites the
+previous rule body.
+
+```sql
+ALTER ROLE test_rule_role
+    ADD RULE "select * from db1.t1 where age > 50"
+    ON TABLE db1.t1;
+
+SHOW RULES ON ROLE test_rule_role;
++-----------+-------------------------------------+
+| rule_name | rule                                |
++-----------+-------------------------------------+
+| db1.t1    | select * from db1.t1 where age > 50 |
++-----------+-------------------------------------+
+```
+
+### Example 3: Multiple rules for the same role
+
+Different `(db.tbl)` keys coexist.
+
+```sql
+ALTER ROLE test_rule_role
+    ADD RULE "select id from db2.t2_new"
+    ON TABLE db2.t2;
+
+SHOW RULES ON ROLE test_rule_role;
++-----------+-------------------------------------+
+| rule_name | rule                                |
++-----------+-------------------------------------+
+| db1.t1    | select * from db1.t1 where age > 50 |
+| db2.t2    | select id from db2.t2_new           |
++-----------+-------------------------------------+
+```
+
+### Example 4: DROP RULE
+
+```sql
+ALTER ROLE test_rule_role DROP RULE ON TABLE db1.t1;
+
+SHOW RULES ON ROLE test_rule_role;
++-----------+---------------------------+
+| rule_name | rule                      |
++-----------+---------------------------+
+| db2.t2    | select id from db2.t2_new |
++-----------+---------------------------+
+```
+
+### Example 5: Error cases
+
+Non-existent role on ADD or DROP:
+
+```sql
+ALTER ROLE non_existent_role
+    ADD RULE "select * from db1.t1"
+    ON TABLE db1.t1;
+-- ERROR: internal error: there is no role non_existent_role
+
+ALTER ROLE non_existent_role DROP RULE ON TABLE db1.t1;
+-- ERROR: internal error: there is no role non_existent_role
+```
+
+Non-existent rule on DROP:
+
+```sql
+ALTER ROLE test_rule_role DROP RULE ON TABLE no_such.rule;
+-- ERROR: internal error: rule 'no_such.rule' does not exist for role 'test_rule_role'
+```
+
+### Example 6: End-to-end hint injection via enable_remap_hint
+
+With the rule registered and `enable_remap_hint = 1` on the session,
+queries issued under the role are rewritten transparently.
+
+```sql
+ALTER ROLE test_rule_role
+    ADD RULE "select * from db1.t1 where age > 28"
+    ON TABLE db1.t1;
+
+CREATE USER test_rule_user IDENTIFIED BY '123456' DEFAULT ROLE test_rule_role;
+GRANT connect ON ACCOUNT * TO test_rule_role;
+GRANT select ON TABLE *.* TO test_rule_role;
+
+-- Then, logged in as test_rule_user with test_rule_role active:
+SET enable_remap_hint = 1;
+SELECT * FROM db1.t1;
+-- The filter "age > 28" is injected via a /*+ {"rewrites": {...}} */
+-- hint and applied during execution.
+```
+
+## Notes
+
+1. The catalog table `mo_catalog.mo_role_rule` is the backing store;
+   `(role_id, rule_name)` forms the logical key, where `rule_name`
+   is `db.tbl`.
+2. Only the current session's cache is invalidated on ADD/DROP.
+   Other sessions using the same role continue to serve the old
+   rule set until they refresh (for example via `SET ROLE`).
+3. See also: [SHOW RULES ON ROLE](show-rules-on-role.md) for
+   inspecting registered rules.

--- a/docs/MatrixOne/Reference/SQL-Reference/Data-Control-Language/show-rules-on-role.md
+++ b/docs/MatrixOne/Reference/SQL-Reference/Data-Control-Language/show-rules-on-role.md
@@ -1,0 +1,101 @@
+# SHOW RULES ON ROLE
+
+## Description
+
+`SHOW RULES ON ROLE role_name` lists every SQL rewrite rule
+registered for the given role in `mo_catalog.mo_role_rule`. Each row
+pairs the scope key (`rule_name`, which is `db.tbl`) with the raw
+rule body. This documents the `rewrite_rule` feature; rules are
+created and removed with
+[`ALTER ROLE ... ADD/DROP RULE`](alter-role-rule.md).
+
+## Syntax
+
+```
+SHOW RULES ON ROLE role_name ;
+```
+
+## Arguments
+
+| Parameter | Description |
+|-----------|-------------|
+| `role_name` | Role to inspect. The role must exist; otherwise the server returns `internal error: there is no role <role_name>`. |
+
+### Output columns
+
+| Column | Description |
+|--------|-------------|
+| `rule_name` | The `db.tbl` scope key the rule applies to. |
+| `rule` | The rule body as supplied to `ALTER ROLE ... ADD RULE`. |
+
+## Usage Notes
+
+- Returns an empty result set (with the `rule_name` / `rule` header)
+  when the role exists but has no rules registered.
+- Does not require the `enable_remap_hint` session variable. `SHOW
+  RULES ON ROLE` always queries `mo_catalog.mo_role_rule` and does
+  not perform rewriting itself.
+- Fails with `internal error: there is no role <role_name>` if the
+  role does not exist.
+
+## Examples
+
+### Example 1: One rule per role
+
+```sql
+CREATE ROLE test_rule_role;
+
+ALTER ROLE test_rule_role
+    ADD RULE "select * from db1.t1 where age > 28"
+    ON TABLE db1.t1;
+
+SHOW RULES ON ROLE test_rule_role;
++-----------+-------------------------------------+
+| rule_name | rule                                |
++-----------+-------------------------------------+
+| db1.t1    | select * from db1.t1 where age > 28 |
++-----------+-------------------------------------+
+```
+
+### Example 2: Multiple rules for the same role
+
+```sql
+ALTER ROLE test_rule_role
+    ADD RULE "select id from db2.t2_new"
+    ON TABLE db2.t2;
+
+SHOW RULES ON ROLE test_rule_role;
++-----------+-------------------------------------+
+| rule_name | rule                                |
++-----------+-------------------------------------+
+| db1.t1    | select * from db1.t1 where age > 50 |
+| db2.t2    | select id from db2.t2_new           |
++-----------+-------------------------------------+
+```
+
+### Example 3: Empty result set
+
+After dropping all rules for a role, `SHOW RULES ON ROLE` returns
+just the header row.
+
+```sql
+ALTER ROLE test_rule_role DROP RULE ON TABLE db2.t2;
+
+SHOW RULES ON ROLE test_rule_role;
++-----------+------+
+| rule_name | rule |
++-----------+------+
+```
+
+### Example 4: Non-existent role
+
+```sql
+SHOW RULES ON ROLE non_existent_role;
+-- ERROR: internal error: there is no role non_existent_role
+```
+
+## Notes
+
+1. `SHOW RULES ON ROLE` is purely a read path — it does not modify
+   the catalog or invalidate any cache.
+2. See also: [ALTER ROLE ... ADD/DROP RULE](alter-role-rule.md).

--- a/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-diff-en.md
+++ b/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-diff-en.md
@@ -15,6 +15,7 @@ The system automatically identifies the Lowest Common Ancestor (LCA) between two
 ```
 DATA BRANCH DIFF target_table [{ SNAPSHOT = 'snapshot_name' }] 
     AGAINST base_table [{ SNAPSHOT = 'snapshot_name' }] 
+    [COLUMNS (col_name [, col_name ...])]
     [OUTPUT output_option]
 ```
 
@@ -24,9 +25,22 @@ DATA BRANCH DIFF target_table [{ SNAPSHOT = 'snapshot_name' }]
 output_option:
     COUNT                           -- Return only the count of different rows
   | LIMIT number                    -- Limit the number of returned difference rows
+  | SUMMARY                         -- Return a summary (counts by INSERT/DELETE/UPDATE)
   | FILE 'directory_path'           -- Export differences as SQL file
   | AS table_name                   -- Save differences to a table (not yet supported)
 ```
+
+### COLUMNS Projection
+
+`COLUMNS (...)` restricts the diff output to the listed columns only.
+Column names are matched case-insensitively; duplicate names in the
+list are deduplicated. When `COLUMNS` is omitted, the diff returns
+every visible column, preserving the previous behavior.
+
+`COLUMNS` may be combined with `OUTPUT LIMIT`, `OUTPUT COUNT`, or
+`OUTPUT SUMMARY`; counts and summaries are unaffected by the
+projection (they describe how many rows differ, not which columns
+are shown).
 
 ## Arguments
 
@@ -37,8 +51,10 @@ output_option:
 | `target_table` | Target table (the table to compare) |
 | `base_table` | Base table (the table used as comparison baseline) |
 | `SNAPSHOT = 'snapshot_name'` | Optional parameter to specify using data at a snapshot point for comparison |
+| `COLUMNS (col_name, ...)` | Optional. Project only the listed columns in the diff output. Names are case-insensitive; duplicates are deduplicated. Does not affect `OUTPUT COUNT` or `OUTPUT SUMMARY` results. |
 | `OUTPUT COUNT` | Return only the count of differences |
 | `OUTPUT LIMIT number` | Limit the number of returned difference rows |
+| `OUTPUT SUMMARY` | Return a summary of the diff instead of the rows themselves |
 | `OUTPUT FILE 'path'` | Export differences as SQL file to specified directory, supports local path or Stage path (e.g., `stage://stage_name/`) |
 
 ### Output Column Description
@@ -431,6 +447,61 @@ DROP TABLE test.orders;
 DROP TABLE test.orders_branch;
 -- Expected-Rows: 0
 DROP DATABASE test;
+```
+
+### Example 9: Project Selected Columns (COLUMNS)
+
+Use `COLUMNS` to restrict the diff output to specific columns. The
+projection does not change the set of differing rows — it only
+changes which columns are rendered per row.
+
+<!-- validator-ignore -->
+```sql
+-- Expected-Rows: 0
+CREATE DATABASE test_diff_columns;
+-- Expected-Rows: 0
+USE test_diff_columns;
+
+-- Expected-Rows: 0
+CREATE TABLE c1(
+    id INT PRIMARY KEY,
+    name VARCHAR(30),
+    balance DECIMAL(12,2),
+    created_at TIMESTAMP,
+    birthday DATE
+);
+-- Expected-Rows: 0
+INSERT INTO c1 VALUES
+    (1, 'alice', 1000.50, '2024-01-01 10:00:00', '1990-03-15'),
+    (2, 'bob',   2000.75, '2024-01-02 11:00:00', '1985-07-20'),
+    (3, 'carol', 3000.00, '2024-01-03 12:00:00', '1992-11-08');
+
+-- Expected-Rows: 0
+CREATE SNAPSHOT c1_sp0 FOR TABLE test_diff_columns c1;
+
+-- Expected-Rows: 0
+DATA BRANCH CREATE TABLE c1_br FROM c1{SNAPSHOT="c1_sp0"};
+-- Expected-Rows: 1
+UPDATE c1_br SET balance = 1500.50, name = 'alice_v2' WHERE id = 1;
+-- Expected-Rows: 1
+DELETE FROM c1_br WHERE id = 2;
+-- Expected-Rows: 0
+INSERT INTO c1_br VALUES (4, 'dave', 4000.00, '2024-02-01 09:00:00', '1988-12-25');
+
+-- Project only the name and balance columns
+DATA BRANCH DIFF c1_br AGAINST c1{SNAPSHOT="c1_sp0"} COLUMNS (name, balance);
+
+-- COLUMNS combined with OUTPUT COUNT: counts are unaffected
+DATA BRANCH DIFF c1_br AGAINST c1{SNAPSHOT="c1_sp0"} COLUMNS (name) OUTPUT COUNT;
+
+-- Expected-Rows: 0
+DROP SNAPSHOT c1_sp0;
+-- Expected-Rows: 0
+DROP TABLE c1;
+-- Expected-Rows: 0
+DROP TABLE c1_br;
+-- Expected-Rows: 0
+DROP DATABASE test_diff_columns;
 ```
 
 ## Notes

--- a/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-fullscan-en.md
+++ b/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-fullscan-en.md
@@ -1,0 +1,212 @@
+# DATA BRANCH DIFF/MERGE Full-Scan Fallback
+
+## Description
+
+`DATA BRANCH DIFF` and `DATA BRANCH MERGE` normally compare the two
+branch tables incrementally by walking a per-row commit-timestamp
+change stream. When that stream is not available for the two tables,
+the server transparently falls back to a **full-table scan** path
+(the `data_branch_fullscan` code path): both tables are read from the
+current transaction view into a hashmap keyed by primary key, and the
+resulting INSERT / DELETE / UPDATE set is computed by probing one
+hashmap against the other.
+
+The fallback has the same INSERT / DELETE / UPDATE semantics as the
+incremental path; it just trades incremental efficiency for a scan of
+each side's current rows. No syntax change is involved: the same
+`DATA BRANCH DIFF` / `DATA BRANCH MERGE` statements trigger it
+automatically when needed.
+
+This page documents the `data_branch_fullscan` feature and its
+observable effects.
+
+## Syntax
+
+No new SQL syntax. The fallback is activated inside the existing
+statements:
+
+```
+DATA BRANCH DIFF target_table [{ SNAPSHOT = 'snapshot_name' }]
+    AGAINST base_table [{ SNAPSHOT = 'snapshot_name' }]
+    [COLUMNS (col_name [, col_name ...])]
+    [OUTPUT output_option];
+
+DATA BRANCH MERGE source_table [{ SNAPSHOT = 'snapshot_name' }]
+    INTO destination_table [{ SNAPSHOT = 'snapshot_name' }]
+    [WHEN CONFLICT conflict_option];
+```
+
+See [DATA BRANCH DIFF](data-branch-diff-en.md) and
+[DATA BRANCH MERGE](data-branch-merge-en.md) for full syntax.
+
+## Arguments
+
+No new arguments. The fallback uses the same target / base tables,
+snapshot options, `COLUMNS` projection, conflict options, and
+`OUTPUT` options as the incremental path.
+
+The fallback path is decided entirely by the server based on the
+error returned from the incremental pipeline:
+
+| Trigger | Meaning |
+|---------|---------|
+| `ErrNoCommitTSColumn` | The underlying storage objects do not carry a per-row commit-timestamp column (for example, TN-merged objects produced on the 3.0-dev codebase). Row-level time filtering is impossible, so the fallback compares the live snapshots directly. |
+| `ErrFileNotFound` | Object files referenced by the incremental change handle have been garbage-collected, but the two tables are still reachable through live objects in the current view. The fallback rereads the live rows. |
+
+All other errors from the incremental path continue to propagate
+unchanged.
+
+## Usage Notes
+
+- **No user action required.** If the server can use the incremental
+  path, it does; if it cannot and the fallback applies, the same
+  statement succeeds without the caller changing anything.
+- **Same diff semantics.** For each PK the fallback produces the
+  same INSERT / DELETE / UPDATE classification as the incremental
+  path:
+    - Target-only row → INSERT on the target side.
+    - Base-only row → INSERT on the base side.
+    - Same PK on both sides with different column values → UPDATE.
+    - Same PK on both sides with identical values → no diff row.
+- **Server logs identify the fallback.** Each fallback attempt is
+  logged at info level as
+  `DataBranch-DiffOnBase falling back to full-table-scan` or
+  `DataBranch-HashDiff falling back to full-table-scan`, followed by
+  `DataBranch-FullScanDiff-Start` and, at completion,
+  `DataBranch-FullScanDiff-Done`. Use these log lines to confirm
+  which path executed the statement.
+- **Performance characteristics.** Because both tables are scanned
+  end-to-end, fallback latency and memory use scale with the total
+  number of live rows in each side, not with the incremental change
+  set. Plan accordingly when running large diffs immediately after
+  operations (checkpoint + GC, or dropping and recreating via
+  snapshot) that strip the per-row commit-ts metadata.
+
+## Examples
+
+### Example 1: Diff after flush + checkpoint + GC
+
+Produce diffs between two branches after the underlying objects have
+been flushed, checkpointed, and garbage-collected. The incremental
+change stream no longer has the per-row commit-ts metadata it needs,
+so the server falls back to the full-table scan path and still
+returns correct diff / merge results.
+
+```sql
+CREATE DATABASE test_gc_diff;
+USE test_gc_diff;
+
+CREATE TABLE c_src (a INT PRIMARY KEY, b INT);
+INSERT INTO c_src SELECT result, result FROM generate_series(1, 200000) g;
+
+DATA BRANCH CREATE TABLE c_tar FROM c_src;
+UPDATE c_tar SET b = b + 1 WHERE a mod 1119 = 0;
+
+-- Diff before GC: returns the updated rows.
+DATA BRANCH DIFF c_tar AGAINST c_src OUTPUT SUMMARY;
+
+-- Flush + checkpoint + GC.
+SELECT mo_ctl('dn', 'flush', 'test_gc_diff.c_tar');
+SELECT mo_ctl('dn', 'flush', 'test_gc_diff.c_src');
+SELECT mo_ctl('dn', 'globalcheckpoint', '');
+SELECT mo_ctl('dn', 'globalcheckpoint', '');
+SELECT mo_ctl('dn', 'diskcleaner', 'force_gc');
+SELECT mo_ctl('dn', 'globalcheckpoint', '');
+SELECT mo_ctl('dn', 'diskcleaner', 'force_gc');
+
+-- Diff after GC: the server falls back to the full-table-scan path
+-- and still reports the same updated rows.
+DATA BRANCH DIFF c_tar AGAINST c_src OUTPUT SUMMARY;
+DATA BRANCH DIFF c_tar AGAINST c_src OUTPUT COUNT;
+
+DROP TABLE c_src;
+DROP TABLE c_tar;
+DROP DATABASE test_gc_diff;
+```
+
+### Example 2: Merge then diff after GC preserves INSERT classification
+
+After merging a branch's inserts back into the base, the fallback
+path must continue to classify those rows as regular INSERTs on the
+target side (not as "vanished" rows) even after GC rotates the
+underlying object files.
+
+```sql
+CREATE TABLE t1 (a INT PRIMARY KEY, b INT);
+INSERT INTO t1 VALUES (1,1), (2,2), (3,3);
+
+DATA BRANCH CREATE TABLE t2 FROM t1;
+INSERT INTO t2 VALUES (4,4), (5,5);
+
+DATA BRANCH DIFF  t2 AGAINST t1;
+DATA BRANCH MERGE t2 INTO    t1;
+DATA BRANCH DIFF  t2 AGAINST t1;
+
+UPDATE t1 SET b = b + 1 WHERE a = 4;
+DATA BRANCH DIFF t2 AGAINST t1;
+
+-- Flush + checkpoint + GC.
+SELECT mo_ctl('dn', 'flush', 'test.t2');
+SELECT mo_ctl('dn', 'flush', 'test.t1');
+SELECT mo_ctl('dn', 'globalcheckpoint', '');
+SELECT mo_ctl('dn', 'globalcheckpoint', '');
+SELECT mo_ctl('dn', 'diskcleaner', 'force_gc');
+
+-- Same diff is still reported via the fallback path.
+DATA BRANCH DIFF t2 AGAINST t1;
+
+DROP TABLE t1;
+DROP TABLE t2;
+```
+
+### Example 3: Diff via snapshots after the source tables are dropped
+
+If both sides were snapshotted, DIFF via `{SNAPSHOT = '...'}` still
+succeeds even after the live tables are dropped. The snapshot-driven
+read path exercises the same
+`data_branch_fullscan` infrastructure for object selection.
+
+```sql
+CREATE DATABASE sp_diff;
+USE sp_diff;
+
+CREATE TABLE c_base (a INT PRIMARY KEY, b INT);
+INSERT INTO c_base SELECT result, result FROM generate_series(1, 100) g;
+SELECT mo_ctl('dn', 'flush', 'sp_diff.c_base');
+CREATE SNAPSHOT sp_c_base FOR ACCOUNT sys;
+
+DATA BRANCH CREATE TABLE c_tar FROM c_base;
+UPDATE c_tar SET b = b + 1 WHERE a mod 7 = 0;
+SELECT mo_ctl('dn', 'flush', 'sp_diff.c_tar');
+CREATE SNAPSHOT sp_c_tar FOR ACCOUNT sys;
+
+-- Diff before drop.
+DATA BRANCH DIFF c_tar AGAINST c_base OUTPUT SUMMARY;
+
+DROP TABLE c_tar;
+DROP TABLE c_base;
+
+-- Diff via snapshots, after both live tables are gone.
+DATA BRANCH DIFF
+    c_tar{snapshot = 'sp_c_tar'}
+    AGAINST
+    c_base{snapshot = 'sp_c_base'}
+    OUTPUT SUMMARY;
+
+DROP SNAPSHOT sp_c_tar;
+DROP SNAPSHOT sp_c_base;
+DROP DATABASE sp_diff;
+```
+
+## Notes
+
+1. The fallback is an implementation detail of `DATA BRANCH DIFF` /
+   `DATA BRANCH MERGE`; it is not exposed as a separate SQL
+   statement.
+2. The decision is all-or-nothing per statement: once the server
+   decides to fall back, the full diff is produced by the full-scan
+   path. The incremental and fallback paths are never mixed for the
+   same statement invocation.
+3. When `COLUMNS (...)` is used on a fallback diff, the projection
+   is applied to the scan output exactly as it is in the incremental
+   path.

--- a/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-pick-en.md
+++ b/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-pick-en.md
@@ -1,0 +1,308 @@
+# DATA BRANCH PICK
+
+## Description
+
+The `DATA BRANCH PICK` statement cherry-picks a selected set of rows
+from a source branch table into a destination branch table. Compared
+with `DATA BRANCH MERGE`, which applies every diff between two
+branches, `PICK` only applies the rows the user selects — either by
+listing their primary keys (`KEYS`) or by bounding them with a
+snapshot range (`BETWEEN SNAPSHOT`).
+
+Internally the statement reuses the `DATA BRANCH DIFF` /
+`DATA BRANCH MERGE` pipeline: the system detects the Lowest Common
+Ancestor (LCA) between the two tables, computes the effective INSERT /
+DELETE / UPDATE set for the picked keys, and applies them to the
+destination under the chosen conflict policy. This is the
+`data_branch_pick` feature.
+
+## Syntax
+
+```
+DATA BRANCH PICK source_table INTO destination_table
+    KEYS ( key_list | select_stmt )
+    [WHEN CONFLICT conflict_option]
+
+DATA BRANCH PICK source_table INTO destination_table
+    BETWEEN SNAPSHOT from_snapshot AND to_snapshot
+    [KEYS ( key_list | select_stmt )]
+    [WHEN CONFLICT conflict_option]
+```
+
+### KEYS clause
+
+```
+KEYS ( expr [, expr ...] )          -- literal primary-key values
+KEYS ( select_stmt )                -- subquery yielding primary-key rows
+```
+
+For a composite primary key, each literal key must be written as a
+tuple matching the PK column order, and a subquery must return the
+same number of columns as the PK.
+
+### BETWEEN SNAPSHOT clause
+
+```
+BETWEEN SNAPSHOT snapshot_name AND snapshot_name
+```
+
+Snapshot names may be supplied either as identifiers or as quoted
+string literals. The range identifies the source-side window from
+which rows are picked.
+
+### Conflict handling options
+
+```
+conflict_option:
+    FAIL                            -- Error and abort on conflict (default)
+  | SKIP                            -- Skip conflicting rows, keep destination value
+  | ACCEPT                          -- Overwrite destination with source value
+```
+
+## Arguments
+
+| Parameter | Description |
+|-----------|-------------|
+| `source_table` | Source branch table to pick from. May include a `{SNAPSHOT = 'snapshot_name'}` option to pin the source at a specific snapshot. |
+| `destination_table` | Destination branch table that receives the picked rows. A destination-side snapshot option is not allowed. |
+| `KEYS ( key_list )` | Literal primary-key values. Scalar values for a single-column PK; tuples `(v1, v2, ...)` for a composite PK. |
+| `KEYS ( select_stmt )` | Subquery returning primary-key columns. For a single-column PK the subquery must return one column; for a composite PK it must return exactly the PK columns in order. |
+| `BETWEEN SNAPSHOT from_snapshot AND to_snapshot` | Restrict picked rows to the source-side changes that fall between two snapshots. May be combined with `KEYS` to pick only those rows whose PK is in the KEYS set. |
+| `WHEN CONFLICT FAIL` | Default. Error out if a picked row conflicts with the destination. |
+| `WHEN CONFLICT SKIP` | Keep the destination value for conflicting keys. |
+| `WHEN CONFLICT ACCEPT` | Overwrite the destination value with the source value for conflicting keys. |
+
+### Conflict definition
+
+A conflict is reported for a picked key when the same primary key
+exists on both sides with different values — for example, when both
+branches inserted the same PK with different column values, or both
+branches updated the same PK to different values. Picking a key that
+was deleted on one side and modified on the other is also a conflict.
+
+## Usage Notes
+
+- `DATA BRANCH PICK` is not supported inside an explicit transaction
+  (`BEGIN ... COMMIT`). The statement must be issued in auto-commit
+  mode.
+- The statement requires either a `KEYS` clause, a
+  `BETWEEN SNAPSHOT ... AND ...` clause, or both. Neither clause
+  being present is an error.
+- `BETWEEN SNAPSHOT` cannot be combined with a `{SNAPSHOT = ...}`
+  option on the source table — pick one of the two ways to pin the
+  source.
+- A snapshot option on the destination table is not supported and
+  will be rejected.
+- Subqueries passed in `KEYS` must not return `NULL` for a
+  primary-key column.
+- When no `WHEN CONFLICT` clause is specified, the default is
+  `WHEN CONFLICT FAIL`.
+- Privileges: the executor must hold the privileges required to read
+  the source table and modify the destination table.
+
+## Examples
+
+### Example 1: Pick by primary key
+
+Cherry-pick a single row from one branch into another.
+
+```sql
+CREATE DATABASE test;
+USE test;
+
+CREATE TABLE t1 (a INT, b INT, PRIMARY KEY(a));
+INSERT INTO t1 VALUES (1,1),(3,3),(5,5);
+
+CREATE TABLE t2 (a INT, b INT, PRIMARY KEY(a));
+INSERT INTO t2 VALUES (1,1),(2,2),(4,4);
+
+DATA BRANCH PICK t2 INTO t1 KEYS(2);
+SELECT * FROM t1 ORDER BY a;
++------+------+
+| a    | b    |
++------+------+
+|    1 |    1 |
+|    2 |    2 |
+|    3 |    3 |
+|    5 |    5 |
++------+------+
+
+DATA BRANCH PICK t2 INTO t1 KEYS(4);
+SELECT * FROM t1 ORDER BY a;
++------+------+
+| a    | b    |
++------+------+
+|    1 |    1 |
+|    2 |    2 |
+|    3 |    3 |
+|    4 |    4 |
+|    5 |    5 |
++------+------+
+
+DROP TABLE t1;
+DROP TABLE t2;
+```
+
+### Example 2: Pick with conflict handling
+
+Both branches insert the same primary key with different values. The
+default `WHEN CONFLICT FAIL` aborts; `WHEN CONFLICT SKIP` keeps the
+destination value; `WHEN CONFLICT ACCEPT` overwrites with the source
+value.
+
+```sql
+CREATE TABLE t0 (a INT, b INT, PRIMARY KEY(a));
+INSERT INTO t0 VALUES (1,1),(2,2);
+
+DATA BRANCH CREATE TABLE t1 FROM t0;
+INSERT INTO t1 VALUES (3,30);
+
+DATA BRANCH CREATE TABLE t2 FROM t0;
+INSERT INTO t2 VALUES (3,40);
+
+-- default is FAIL: this statement errors out
+DATA BRANCH PICK t2 INTO t1 KEYS(3);
+
+DATA BRANCH PICK t2 INTO t1 KEYS(3) WHEN CONFLICT SKIP;
+SELECT * FROM t1 ORDER BY a;
++------+------+
+| a    | b    |
++------+------+
+|    1 |    1 |
+|    2 |    2 |
+|    3 |   30 |
++------+------+
+
+DATA BRANCH PICK t2 INTO t1 KEYS(3) WHEN CONFLICT ACCEPT;
+SELECT * FROM t1 ORDER BY a;
++------+------+
+| a    | b    |
++------+------+
+|    1 |    1 |
+|    2 |    2 |
+|    3 |   40 |
++------+------+
+
+DROP TABLE t0;
+DROP TABLE t1;
+DROP TABLE t2;
+```
+
+### Example 3: Pick via subquery (composite primary key)
+
+Use a subquery to drive the set of picked keys. For a composite PK
+the subquery must return the same number of columns as the PK, in
+order.
+
+```sql
+CREATE TABLE t0 (a INT, b INT, c VARCHAR(20), PRIMARY KEY(a, b));
+INSERT INTO t0 VALUES (1,1,'base'),(2,2,'base');
+
+DATA BRANCH CREATE TABLE t1 FROM t0;
+DATA BRANCH CREATE TABLE t2 FROM t0;
+
+INSERT INTO t2 VALUES (3,3,'new'),(4,4,'new'),(5,5,'new'),(6,6,'new');
+
+DATA BRANCH PICK t2 INTO t1
+    KEYS(SELECT a, b FROM t2 WHERE a >= 4 AND a % 2 = 0);
+
+SELECT * FROM t1 ORDER BY a, b;
++------+------+------+
+| a    | b    | c    |
++------+------+------+
+|    1 |    1 | base |
+|    2 |    2 | base |
+|    4 |    4 | new  |
+|    6 |    6 | new  |
++------+------+------+
+
+DROP TABLE t0;
+DROP TABLE t1;
+DROP TABLE t2;
+```
+
+### Example 4: Pick rows between two snapshots
+
+`BETWEEN SNAPSHOT` restricts the pick to changes that happened on the
+source side between two snapshots. Snapshot names may be supplied as
+identifiers or as string literals.
+
+```sql
+CREATE TABLE t0 (a INT, b INT, PRIMARY KEY(a));
+INSERT INTO t0 VALUES (1,1);
+
+DATA BRANCH CREATE TABLE t1 FROM t0;
+
+CREATE SNAPSHOT sp_from FOR ACCOUNT sys;
+INSERT INTO t1 VALUES (2,2),(3,3);
+CREATE SNAPSHOT sp_to FOR ACCOUNT sys;
+INSERT INTO t1 VALUES (4,4);
+
+-- only pick rows inserted on t1 between sp_from and sp_to
+DATA BRANCH PICK t1 INTO t0 BETWEEN SNAPSHOT 'sp_from' AND 'sp_to';
+SELECT * FROM t0 ORDER BY a;
++------+------+
+| a    | b    |
++------+------+
+|    1 |    1 |
+|    2 |    2 |
+|    3 |    3 |
++------+------+
+
+DROP SNAPSHOT sp_from;
+DROP SNAPSHOT sp_to;
+DROP TABLE t0;
+DROP TABLE t1;
+```
+
+### Example 5: Combine BETWEEN SNAPSHOT with KEYS
+
+`BETWEEN SNAPSHOT` and `KEYS` can be combined to pick only the rows
+in the snapshot range whose primary keys are in the KEYS set.
+
+```sql
+CREATE TABLE t0 (a INT, b INT, PRIMARY KEY(a));
+INSERT INTO t0 VALUES (1,1),(2,2),(3,3);
+
+DATA BRANCH CREATE TABLE t1 FROM t0;
+
+CREATE SNAPSHOT sp1 FOR ACCOUNT sys;
+INSERT INTO t1 VALUES (4,4),(5,5),(6,6);
+CREATE SNAPSHOT sp2 FOR ACCOUNT sys;
+INSERT INTO t1 VALUES (7,7);
+
+-- only pk=5, among {4,5,6} inserted between sp1 and sp2
+DATA BRANCH PICK t1 INTO t0 BETWEEN SNAPSHOT 'sp1' AND 'sp2' KEYS(5);
+SELECT * FROM t0 ORDER BY a;
++------+------+
+| a    | b    |
++------+------+
+|    1 |    1 |
+|    2 |    2 |
+|    3 |    3 |
+|    5 |    5 |
++------+------+
+
+DROP SNAPSHOT sp1;
+DROP SNAPSHOT sp2;
+DROP TABLE t0;
+DROP TABLE t1;
+```
+
+## Notes
+
+1. **KEYS or BETWEEN SNAPSHOT is required.** The server refuses a
+   `DATA BRANCH PICK` that has neither.
+2. **Explicit transactions are not supported.** Issue
+   `DATA BRANCH PICK` in auto-commit mode; a statement inside
+   `BEGIN ... COMMIT` is rejected.
+3. **Source-snapshot exclusivity.** `BETWEEN SNAPSHOT` cannot be
+   combined with a `{SNAPSHOT = ...}` option on the source table.
+4. **Destination snapshot not supported.** The destination table
+   must reference the live table — a `{SNAPSHOT = ...}` option is
+   rejected.
+5. **NULL keys are not accepted.** A subquery in `KEYS` must not
+   produce `NULL` for any primary-key column.
+6. **Default conflict policy is FAIL.** Supply
+   `WHEN CONFLICT SKIP` or `WHEN CONFLICT ACCEPT` explicitly if you
+   want a non-failing behavior.

--- a/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/git4data-branch-diff-en.md
+++ b/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/git4data-branch-diff-en.md
@@ -1,0 +1,222 @@
+# git4data Branch Diff: Observable Guarantees
+
+## Description
+
+The `git4data` test family exercises `DATA BRANCH DIFF` under edge
+conditions that the v3.0.10 release explicitly makes correct for
+end users. This reference page consolidates the user-observable
+guarantees those tests pin down. All behaviors below are produced
+by the existing `DATA BRANCH DIFF` statement and its `COLUMNS`
+projection — no new SQL syntax is introduced.
+
+Related references: [DATA BRANCH DIFF](data-branch-diff-en.md),
+[DATA BRANCH MERGE](data-branch-merge-en.md),
+[DATA BRANCH DIFF/MERGE Full-Scan Fallback](data-branch-fullscan-en.md).
+
+## Syntax
+
+No new syntax. The guarantees below apply to the existing
+`DATA BRANCH DIFF` statement, using standard options:
+
+```
+DATA BRANCH DIFF target_table [{ SNAPSHOT = 'snapshot_name' }]
+    AGAINST base_table [{ SNAPSHOT = 'snapshot_name' }]
+    [COLUMNS (col_name [, col_name ...])]
+    [OUTPUT output_option];
+```
+
+See [DATA BRANCH DIFF](data-branch-diff-en.md) for the full
+grammar and all `output_option` values (`COUNT`, `LIMIT`,
+`SUMMARY`, `FILE`).
+
+## Arguments
+
+No new arguments. The guarantees listed below rely on the
+arguments already defined for `DATA BRANCH DIFF`:
+
+| Argument | Role in the git4data guarantees |
+|----------|---------------------------------|
+| `target_table`, `base_table` | The two tables being diffed. Composite and fake (no-PK) primary keys are supported. |
+| `{ SNAPSHOT = 'snapshot_name' }` | Used after `DROP TABLE` to diff two snapshots when the live tables no longer exist. |
+| `COLUMNS (col_name, ...)` | Projection clause added in this release; always yields the same set of differing rows as an unprojected diff, only the rendered columns change. |
+| `OUTPUT COUNT` / `SUMMARY` | Unaffected by `COLUMNS`. |
+
+## Usage Notes
+
+The `git4data` regression family guarantees the following
+user-observable behaviors for `DATA BRANCH DIFF` in v3.0.10:
+
+- **Diff is stable across flush + checkpoint + GC.** Running
+  `DATA BRANCH DIFF` immediately before and after a
+  flush + checkpoint + GC cycle on both tables returns the same
+  logical diff for PK, composite-PK, and no-PK tables. (This
+  relies on the full-scan fallback described in
+  [the fallback page](data-branch-fullscan-en.md).)
+- **Diff via snapshots works after `DROP TABLE`.** When both
+  sides have been snapshotted, you can still diff them via
+  `{snapshot = '...'}` after dropping the live tables. This
+  holds for UPDATE-only, INSERT+DELETE, mixed UPDATE/INSERT/
+  DELETE, and no-PK tables.
+- **`COLUMNS` changes the rendered columns, never the diff
+  set.** Using `COLUMNS (...)` with the same pair of tables
+  produces the same differing rows as an unprojected diff; only
+  the rendered columns change. This is true for single PKs,
+  composite PKs, tables with no PK, tables with NULL values,
+  vector columns, JSON columns, and case-insensitive column
+  names.
+- **`COLUMNS` does not need to include PK columns.** The
+  projection may list only value columns; `DATA BRANCH DIFF`
+  still correctly identifies INSERT / DELETE / UPDATE rows.
+- **`COLUMNS` de-duplicates names.** Repeated column names in
+  the list (for example `COLUMNS (a, a, b)`) are treated as a
+  single occurrence.
+- **`COLUMNS` is case-insensitive.** `COLUMNS (NAME, score)`
+  matches a table defined with columns `Name` and `Score`.
+- **`COLUMNS` with `OUTPUT COUNT` or `OUTPUT SUMMARY` does not
+  alter the count / summary.** Those outputs describe how many
+  rows differ, not which columns are projected.
+- **`COLUMNS` with `OUTPUT LIMIT`.** The row cap is applied to
+  the projected result just as it is to the unprojected result.
+- **Merged INSERTs stay classified as INSERT after GC.** After
+  `DATA BRANCH MERGE` places rows from a branch into the base
+  table, a follow-up `DATA BRANCH DIFF` — including one run
+  after flush + checkpoint + GC — continues to classify those
+  rows as INSERT on the target side (not as vanished rows).
+
+## Examples
+
+### Example 1: Diff stability across flush + checkpoint + GC
+
+For a PK table the diff after a flush + checkpoint + GC cycle
+matches the one produced before it:
+
+```sql
+CREATE DATABASE test_gc_diff;
+USE test_gc_diff;
+
+CREATE TABLE c_src (a INT PRIMARY KEY, b INT);
+INSERT INTO c_src SELECT result, result FROM generate_series(1, 200000) g;
+
+DATA BRANCH CREATE TABLE c_tar FROM c_src;
+UPDATE c_tar SET b = b + 1 WHERE a mod 1119 = 0;
+
+-- Before GC
+DATA BRANCH DIFF c_tar AGAINST c_src OUTPUT SUMMARY;
+
+SELECT mo_ctl('dn', 'flush', 'test_gc_diff.c_tar');
+SELECT mo_ctl('dn', 'flush', 'test_gc_diff.c_src');
+SELECT mo_ctl('dn', 'globalcheckpoint', '');
+SELECT mo_ctl('dn', 'globalcheckpoint', '');
+SELECT mo_ctl('dn', 'diskcleaner', 'force_gc');
+
+-- After GC the same summary is reported
+DATA BRANCH DIFF c_tar AGAINST c_src OUTPUT SUMMARY;
+DATA BRANCH DIFF c_tar AGAINST c_src OUTPUT COUNT;
+
+DROP TABLE c_src;
+DROP TABLE c_tar;
+DROP DATABASE test_gc_diff;
+```
+
+### Example 2: Diff via snapshots after `DROP TABLE`
+
+Once both tables have been snapshotted, the diff survives the
+live tables being dropped:
+
+```sql
+CREATE DATABASE sp_diff_c1;
+USE sp_diff_c1;
+
+CREATE TABLE c1_base (a INT PRIMARY KEY, b INT);
+INSERT INTO c1_base SELECT result, result FROM generate_series(1, 100) g;
+SELECT mo_ctl('dn', 'flush', 'sp_diff_c1.c1_base');
+
+CREATE SNAPSHOT sp_c1_base FOR ACCOUNT sys;
+
+DATA BRANCH CREATE TABLE c1_tar FROM c1_base;
+UPDATE c1_tar SET b = b + 1 WHERE a mod 7 = 0;
+SELECT mo_ctl('dn', 'flush', 'sp_diff_c1.c1_tar');
+
+CREATE SNAPSHOT sp_c1_tar FOR ACCOUNT sys;
+
+-- Diff before drop
+DATA BRANCH DIFF c1_tar AGAINST c1_base OUTPUT SUMMARY;
+
+DROP TABLE c1_tar;
+DROP TABLE c1_base;
+
+-- Same diff via snapshots after the live tables are gone
+DATA BRANCH DIFF
+    c1_tar{snapshot = 'sp_c1_tar'}
+    AGAINST
+    c1_base{snapshot = 'sp_c1_base'}
+    OUTPUT SUMMARY;
+
+DROP SNAPSHOT sp_c1_tar;
+DROP SNAPSHOT sp_c1_base;
+DROP DATABASE sp_diff_c1;
+```
+
+### Example 3: COLUMNS projection produces the same diff rows as an unprojected diff
+
+Project only the non-PK columns — the set of differing rows is
+unchanged, but the rendered columns differ:
+
+```sql
+CREATE DATABASE test_diff_columns;
+USE test_diff_columns;
+
+CREATE TABLE c1(
+    id INT PRIMARY KEY,
+    name VARCHAR(30),
+    balance DECIMAL(12,2),
+    created_at TIMESTAMP,
+    birthday DATE
+);
+INSERT INTO c1 VALUES
+    (1, 'alice', 1000.50, '2024-01-01 10:00:00', '1990-03-15'),
+    (2, 'bob',   2000.75, '2024-01-02 11:00:00', '1985-07-20'),
+    (3, 'carol', 3000.00, '2024-01-03 12:00:00', '1992-11-08');
+
+CREATE SNAPSHOT c1_sp0 FOR TABLE test_diff_columns c1;
+
+DATA BRANCH CREATE TABLE c1_br FROM c1{snapshot = 'c1_sp0'};
+UPDATE c1_br SET balance = 1500.50, name = 'alice_v2' WHERE id = 1;
+DELETE FROM c1_br WHERE id = 2;
+INSERT INTO c1_br VALUES (4, 'dave', 4000.00, '2024-02-01 09:00:00', '1988-12-25');
+
+-- Full diff (all columns)
+DATA BRANCH DIFF c1_br AGAINST c1{snapshot = 'c1_sp0'};
+
+-- Project non-PK columns
+DATA BRANCH DIFF c1_br AGAINST c1{snapshot = 'c1_sp0'} COLUMNS (name, balance);
+
+-- Project PK + one value column
+DATA BRANCH DIFF c1_br AGAINST c1{snapshot = 'c1_sp0'} COLUMNS (id, balance);
+
+-- Duplicate column names are de-duplicated
+DATA BRANCH DIFF c1_br AGAINST c1{snapshot = 'c1_sp0'} COLUMNS (name, name, balance);
+
+-- Column names match case-insensitively
+DATA BRANCH DIFF c1_br AGAINST c1{snapshot = 'c1_sp0'} COLUMNS (NAME, BALANCE);
+
+-- COLUMNS + OUTPUT COUNT: count is unaffected by projection
+DATA BRANCH DIFF c1_br AGAINST c1{snapshot = 'c1_sp0'} COLUMNS (name) OUTPUT COUNT;
+
+DROP SNAPSHOT c1_sp0;
+DROP TABLE c1;
+DROP TABLE c1_br;
+DROP DATABASE test_diff_columns;
+```
+
+## Notes
+
+1. All guarantees on this page hold for tables with a PK,
+   composite PK, or no PK (which uses an internal fake primary
+   key).
+2. Across these guarantees the diff semantics remain: INSERT on
+   the side that has the PK, DELETE on the side that lost it,
+   UPDATE for rows whose PK matches but values differ.
+3. `COLUMNS` does not have to include the primary key. Leaving
+   the PK out of the projection does not change which rows
+   differ; it only changes which columns are rendered.

--- a/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/sql-task.md
+++ b/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/sql-task.md
@@ -1,0 +1,245 @@
+# SQL Task
+
+## Description
+
+A **SQL Task** is a server-side scheduled SQL job: you register a
+named SQL body (one or more statements) together with a schedule and
+optional gate condition, and the server runs it on that schedule.
+Tasks and their execution history are persisted in
+`mo_task.sql_task` and `mo_task.sql_task_run`.
+
+The v3.0.10 release adds six statements to manage SQL Tasks:
+
+- `CREATE TASK` — register a new task.
+- `ALTER TASK` — suspend, resume, or edit an existing task.
+- `DROP TASK` — remove a task.
+- `EXECUTE TASK` — run a task once, immediately (a manual trigger).
+- `SHOW TASKS` — list all tasks for the current account.
+- `SHOW TASK RUNS` — list run history for tasks.
+
+This documents the `sql_task` feature.
+
+## Syntax
+
+### CREATE TASK
+
+```
+CREATE TASK [IF NOT EXISTS] task_name
+    [SCHEDULE 'cron_expression' [TIMEZONE 'timezone']]
+    [WHEN (expression | select_stmt)]
+    [RETRY n]
+    [TIMEOUT 'duration_string']
+    AS BEGIN
+        sql_statement [; sql_statement ...] [;]
+    END
+```
+
+### ALTER TASK
+
+```
+ALTER TASK task_name SUSPEND;
+ALTER TASK task_name RESUME;
+ALTER TASK task_name SET SCHEDULE 'cron_expression' [TIMEZONE 'timezone'];
+ALTER TASK task_name SET WHEN (expression | select_stmt);
+ALTER TASK task_name SET RETRY n;
+ALTER TASK task_name SET TIMEOUT 'duration_string';
+```
+
+### DROP TASK
+
+```
+DROP TASK [IF EXISTS] task_name;
+```
+
+### EXECUTE TASK
+
+```
+EXECUTE TASK task_name;
+```
+
+### SHOW TASKS / SHOW TASK RUNS
+
+```
+SHOW TASKS;
+
+SHOW TASK RUNS [FOR task_name] [LIMIT n];
+```
+
+## Arguments
+
+| Parameter | Description |
+|-----------|-------------|
+| `task_name` | Identifier. Unique per account. |
+| `IF NOT EXISTS` | On `CREATE TASK`: silently succeed if a task with the same name already exists. |
+| `IF EXISTS` | On `DROP TASK`: silently succeed if no such task exists. |
+| `SCHEDULE 'cron_expression'` | Standard cron expression that drives the scheduler. |
+| `TIMEZONE 'timezone'` | Timezone name used to interpret the cron expression. Defaults to `UTC`. |
+| `WHEN (expression)` | Gate condition evaluated before each scheduled run. The expression must evaluate to a truthy value; otherwise the run is recorded with status `SKIPPED`. |
+| `WHEN (select_stmt)` | Subquery form of the gate condition. |
+| `RETRY n` | Maximum number of extra attempts after a failure. `0` (default) means no retry. |
+| `TIMEOUT 'duration_string'` | Maximum run duration (for example `'10s'`, `'5m'`, `'1h'`). When exceeded, the run is marked `TIMEOUT`. |
+| `AS BEGIN ... END` | Task body. One or more SQL statements separated by `;`. |
+| `FOR task_name` | On `SHOW TASK RUNS`: restrict results to a specific task. |
+| `LIMIT n` | On `SHOW TASK RUNS`: cap the number of returned rows. |
+
+### Alter actions
+
+`ALTER TASK task_name <action>` accepts the following actions:
+
+| Action | Effect |
+|--------|--------|
+| `SUSPEND` | Disable the task. The scheduler will not fire it until it is resumed. |
+| `RESUME` | Enable the task and recompute its next fire time using the current schedule. |
+| `SET SCHEDULE '...' [TIMEZONE '...']` | Replace the cron expression (and optional timezone). The trigger counter is reset and the next fire time is recomputed. |
+| `SET WHEN (...)` | Replace the gate condition. |
+| `SET RETRY n` | Replace the retry limit. |
+| `SET TIMEOUT '...'` | Replace the run timeout. |
+
+### SHOW TASKS columns
+
+`SHOW TASKS` returns one row per task for the current account:
+
+| Column | Description |
+|--------|-------------|
+| `task_name` | Task name. |
+| `schedule` | Effective schedule string (cron expression, combined with timezone when present). |
+| `enabled` | `1` if the task is active, `0` if it has been suspended. |
+| `gate_condition` | The most recent `WHEN (...)` expression, as a text representation. Empty if no gate was set. |
+| `retry_limit` | Current retry limit (integer). |
+| `timeout` | Current timeout string (for example `'10s'`). Empty if no timeout is set. |
+| `created_at` | Task creation time. |
+| `last_run_status` | Status of the most recent run, or empty if the task has never run. |
+| `last_run_time` | Start time of the most recent run, or empty. |
+
+### SHOW TASK RUNS columns
+
+| Column | Description |
+|--------|-------------|
+| `run_id` | Monotonically assigned run identifier. |
+| `task_name` | Task name. |
+| `trigger_type` | `SCHEDULED` or `MANUAL` (manual = invoked via `EXECUTE TASK`). |
+| `status` | One of `RUNNING`, `SUCCESS`, `FAILED`, `SKIPPED`, `TIMEOUT`. |
+| `started_at` | Run start time; empty if not yet started. |
+| `finished_at` | Run finish time; empty if still running. |
+| `duration` | Run duration, in seconds. |
+| `attempt` | Attempt number within this run's retry sequence. |
+| `rows_affected` | Total rows affected by the task body. |
+| `error_message` | Error text for `FAILED` / `TIMEOUT`; empty otherwise. |
+
+## Usage Notes
+
+- **One task, one account.** Task names are unique per account;
+  two accounts may each own a task with the same name.
+- **Task body must be `BEGIN ... END`.** A single-statement body is
+  also written as `BEGIN stmt; END`. Statements are separated by
+  `;` and the compound wrapper is mandatory.
+- **Gate semantics.** When `WHEN (...)` is present, the gate is
+  evaluated before each scheduled run. A truthy result proceeds
+  with the run; a falsy or NULL result marks the run as
+  `SKIPPED` without executing the body.
+- **Retries.** If `RETRY n` is set, a failed run is retried up to
+  `n` additional times. Each attempt appears as its own row in
+  `SHOW TASK RUNS` with an incrementing `attempt`.
+- **Timeouts.** If the body exceeds `TIMEOUT 'duration_string'`,
+  the run is aborted and recorded with status `TIMEOUT`.
+- **Suspend / resume.** `ALTER TASK ... SUSPEND` clears the task's
+  scheduler slot but preserves its definition; `RESUME` recomputes
+  the next fire time from the current schedule.
+- **Manual run overlap.** `EXECUTE TASK` is rejected while a run
+  of the same task is already in progress, with
+  `sql task is already running`.
+- **Missing task.** `DROP TASK` without `IF EXISTS` on an unknown
+  task returns `sql task <name> not found`. `EXECUTE TASK` and the
+  non-suspend/resume forms of `ALTER TASK` on an unknown task also
+  return `sql task <name> not found`.
+- **Duplicate on CREATE.** `CREATE TASK` without `IF NOT EXISTS`
+  returns `sql task <name> already exists` when the task is already
+  registered for the current account.
+
+## Examples
+
+### Example 1: Schedule a task and let it run
+
+```sql
+CREATE TASK rollup_hourly
+    SCHEDULE '0 * * * *' TIMEZONE 'UTC'
+    AS BEGIN
+        INSERT INTO rollup_hourly_tgt
+            SELECT hour_bucket, COUNT(*) FROM events
+            WHERE ts < NOW() GROUP BY hour_bucket;
+    END;
+
+SHOW TASKS;
+-- One row named 'rollup_hourly' with enabled=1 and schedule '0 * * * * UTC'.
+```
+
+### Example 2: Manually trigger a task and inspect its run
+
+```sql
+EXECUTE TASK rollup_hourly;
+
+SHOW TASK RUNS FOR rollup_hourly LIMIT 5;
+-- Rows with trigger_type = 'MANUAL' for the run just kicked off,
+-- plus any earlier 'SCHEDULED' rows.
+```
+
+### Example 3: Gate condition that skips runs
+
+```sql
+CREATE TASK refresh_cache
+    SCHEDULE '*/5 * * * *'
+    WHEN (SELECT COUNT(*) FROM pending_updates) > 0
+    AS BEGIN
+        CALL refresh_cache_proc();
+    END;
+
+-- When pending_updates is empty at fire time, the run is recorded
+-- with status 'SKIPPED' instead of executing the body.
+SHOW TASK RUNS FOR refresh_cache;
+```
+
+### Example 4: Retry + timeout
+
+```sql
+CREATE TASK import_feed
+    SCHEDULE '*/10 * * * *'
+    RETRY 3
+    TIMEOUT '30s'
+    AS BEGIN
+        LOAD DATA INFILE '/data/feed.csv' INTO TABLE feed_raw;
+    END;
+
+-- A failing run is retried up to 3 more times. A run that exceeds
+-- 30 seconds is cancelled and recorded with status 'TIMEOUT'.
+SHOW TASK RUNS FOR import_feed LIMIT 10;
+```
+
+### Example 5: Edit schedule, gate, retry, timeout; then suspend/resume
+
+```sql
+ALTER TASK rollup_hourly SET SCHEDULE '*/15 * * * *' TIMEZONE 'Asia/Shanghai';
+ALTER TASK rollup_hourly SET WHEN (SELECT should_rollup());
+ALTER TASK rollup_hourly SET RETRY 1;
+ALTER TASK rollup_hourly SET TIMEOUT '1m';
+
+ALTER TASK rollup_hourly SUSPEND;  -- enabled=0 after this
+ALTER TASK rollup_hourly RESUME;   -- recomputes the next fire time
+```
+
+### Example 6: Remove a task
+
+```sql
+DROP TASK IF EXISTS rollup_hourly;
+```
+
+## Notes
+
+1. Task definitions live in `mo_task.sql_task`; run history lives in
+   `mo_task.sql_task_run`. Both tables are created by the bootstrap
+   upgrade for the 3.0-dev line and are visible to the system
+   account.
+2. `SCHEDULED` vs `MANUAL` is recorded per run in the `trigger_type`
+   column of `SHOW TASK RUNS`. Manual runs come from `EXECUTE TASK`.
+3. A timezone-less `SCHEDULE` uses UTC.
+4. The default retry limit is `0` (no retry). The default timeout is
+   empty (no timeout).

--- a/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/sql-task.md
+++ b/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/sql-task.md
@@ -188,7 +188,7 @@ SHOW TASK RUNS FOR rollup_hourly LIMIT 5;
 ```sql
 CREATE TASK refresh_cache
     SCHEDULE '*/5 * * * *'
-    WHEN (SELECT COUNT(*) FROM pending_updates) > 0
+    WHEN ((SELECT COUNT(*) FROM pending_updates) > 0)
     AS BEGIN
         CALL refresh_cache_proc();
     END;

--- a/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/sql-task.md
+++ b/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/sql-task.md
@@ -222,8 +222,11 @@ ALTER TASK rollup_hourly SET WHEN (SELECT should_rollup());
 ALTER TASK rollup_hourly SET RETRY 1;
 ALTER TASK rollup_hourly SET TIMEOUT '1m';
 
-ALTER TASK rollup_hourly SUSPEND;  -- enabled=0 after this
-ALTER TASK rollup_hourly RESUME;   -- recomputes the next fire time
+ALTER TASK rollup_hourly SUSPEND;
+-- enabled=0 after this
+
+ALTER TASK rollup_hourly RESUME;
+-- recomputes the next fire time
 ```
 
 ### Example 6: Remove a task

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -367,6 +367,10 @@ nav:
                   - DELETE BRANCH: MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-delete-en.md
                   - DIFF BRANCH: MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-diff-en.md
                   - MERGE BRANCH: MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-merge-en.md
+                  - PICK BRANCH: MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-pick-en.md
+                  - BRANCH DIFF/MERGE FULL-SCAN FALLBACK: MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-fullscan-en.md
+                  - git4data BRANCH DIFF GUARANTEES: MatrixOne/Reference/SQL-Reference/Data-Definition-Language/git4data-branch-diff-en.md
+                  - SQL TASK: MatrixOne/Reference/SQL-Reference/Data-Definition-Language/sql-task.md
                   - ALTER TABLE: MatrixOne/Reference/SQL-Reference/Data-Definition-Language/alter-table.md
                   - ALTER TABLE ... ALTER REINDEX: MatrixOne/Reference/SQL-Reference/Data-Definition-Language/alter-reindex.md
                   - ALTER PITR: MatrixOne/Reference/SQL-Reference/Data-Definition-Language/alter-pitr.md
@@ -438,6 +442,8 @@ nav:
                   - CREATE ROLE: MatrixOne/Reference/SQL-Reference/Data-Control-Language/create-role.md
                   - CREATE USER: MatrixOne/Reference/SQL-Reference/Data-Control-Language/create-user.md
                   - ALTER USER: MatrixOne/Reference/SQL-Reference/Data-Control-Language/alter-user.md
+                  - ALTER ROLE ADD/DROP RULE: MatrixOne/Reference/SQL-Reference/Data-Control-Language/alter-role-rule.md
+                  - SHOW RULES ON ROLE: MatrixOne/Reference/SQL-Reference/Data-Control-Language/show-rules-on-role.md
                   - DROP ACCOUNT: MatrixOne/Reference/SQL-Reference/Data-Control-Language/drop-account.md
                   - DROP USER: MatrixOne/Reference/SQL-Reference/Data-Control-Language/drop-user.md
                   - DROP ROLE: MatrixOne/Reference/SQL-Reference/Data-Control-Language/drop-role.md


### PR DESCRIPTION
# MatrixOne 文档自动同步 (io)

## 基本信息

- Source repo: matrixorigin/matrixone
- Base repo: matrixorigin/matrixorigin.io
- Head: ULookup:docs-sync/matrixone-v3.0.10 (from fork ULookup/matrixorigin.io)
- Docs key: io
- From tag: v3.0.9
- To tag: v3.0.10
- Target branch: main
- Generated by: MatrixOne Docs Sync Agent

## Tags

- From: v3.0.9
- To: v3.0.10

## User-visible Changes

Based on `work/context/sources/<slug>/`, `focused-diff/*.patch`, the
full diff, and a read-only spot check of `work/matrixone/`, the
following user-visible changes were identified for v3.0.10. Source
bundle slug tags are shown in square brackets so the coverage matcher
can cross-reference each change to the pages that document it.

1. **DATA BRANCH PICK (new DDL statement)** [slug: data_branch_pick].
   Cherry-picks rows from one branch table into another by primary
   key (`KEYS(expr_list)`, `KEYS(select_statement)`) or by a snapshot
   range (`BETWEEN SNAPSHOT <from> AND <to>`), or both combined.
   Source snapshot option (`{snapshot = name}`) is mutually exclusive
   with `BETWEEN SNAPSHOT`; destination-side snapshot is not allowed.
   `WHEN CONFLICT {FAIL|SKIP|ACCEPT}` semantics mirror `DATA BRANCH
   MERGE`. The statement is rejected inside an explicit transaction.
2. **DATA BRANCH DIFF `COLUMNS(...)` column projection (new optional
   clause)**. Optional clause written after `AGAINST` and before
   `OUTPUT`. Projects the diff output to the listed columns only
   (case-insensitive, duplicates de-duplicated). Does not alter the
   differing-row set, so `OUTPUT COUNT` and `OUTPUT SUMMARY` are
   unaffected. Backwards compatible (omit to get previous behavior).
3. **ALTER ROLE ... ADD/DROP RULE + SHOW RULES ON ROLE (new DCL)**
   [slug: rewrite_rule]. Registers / removes per-`(role, db.tbl)`
   SQL-rewrite rules in `mo_catalog.mo_role_rule`. Cooperates with
   the existing `enable_remap_hint` session variable to inject a
   `/*+ {"rewrites": {...}} */` hint into submitted SQL. Re-adding
   the same `(role, db.tbl)` is an upsert; dropping a non-existent
   rule errors; dropping under a non-existent role errors; the
   current session's rewrite cache is invalidated on success.
4. **SQL Task (new DDL + runtime)** [slug: sql_task]. New statements
   `CREATE TASK`, `ALTER TASK {SUSPEND|RESUME|SET ...}`, `DROP TASK`,
   `EXECUTE TASK`, `SHOW TASKS`, `SHOW TASK RUNS [FOR name] [LIMIT n]`.
   Supports `SCHEDULE 'cron' [TIMEZONE 'tz']`, `WHEN (expr|select)`
   gate conditions, `RETRY n`, `TIMEOUT 'duration'`, and
   `AS BEGIN ... END` multi-statement bodies. Run history lives in
   `mo_task.sql_task_run` with statuses `SUCCESS / SKIPPED / FAILED /
   TIMEOUT / RUNNING`.
5. **DATA BRANCH DIFF/MERGE full-scan fallback (user-observable
   behavior, no new syntax)** [slug: data_branch_fullscan]. When the
   incremental change stream is not available (TN-merged objects
   without a per-row commit-ts, or GC'd object files), `DATA BRANCH
   DIFF` / `DATA BRANCH MERGE` transparently fall back to a full-
   table scan path that reads both tables into hashmaps keyed by PK
   and computes the diff. Semantics for INSERT / DELETE / UPDATE
   classification are unchanged; the fallback is logged server-side
   as `DataBranch-FullScanDiff-Start` / `-Done`.
6. **`git4data` correctness guarantees for `DATA BRANCH DIFF`**
   [slug: git4data]. The regression test family pins down the
   end-user-observable guarantees that the release makes for
   `DATA BRANCH DIFF`: diff stability across flush + checkpoint +
   GC; diff via `{SNAPSHOT = '...'}` after `DROP TABLE`; and the
   `COLUMNS (...)` projection behaviors (same diff set regardless
   of projection, no-PK-required, duplicate-dedup, case-insensitive,
   unaffected counts / summaries, correct interaction with
   `OUTPUT LIMIT`). These are the surface properties the release
   documents.
7. **Other observable bugfixes and improvements** already covered by
   the shipped Release Notes file `v26.3.0.10.md` in each repo:
   DropDatabase robustness, diff/merge correctness after GC + restart,
   clone hiding subscribed views, CDC sinker memory leak, FIFO cache
   postEvict lock scope, explicit-transaction leak, proxy disconnect
   cleanup storms, SHOW ACCOUNTS optimization, fulltext fast path,
   decimal-vs-integer comparison panic, null varlen panic,
   TransferDeleteRows rowid dangling pointer, and the statistics
   view upgrade. All of these are internal fixes reaching the user
   through existing surfaces — no new reference page is added for
   them.

## Repo: io (matrixorigin/matrixorigin.io) [push: ULookup/matrixorigin.io]

### Docs Updated

- [slug: data_branch_diff] `docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-diff-en.md`
  — Added `COLUMNS (col_name [, ...])` to Syntax, extended the Syntax
  / Arguments / Examples sections (new Example 9), and added
  `OUTPUT SUMMARY` to the parameter table.

### Docs Added

- [slug: data_branch_pick] `docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-pick-en.md`
  — Full `DATA BRANCH PICK` reference (Description / Syntax /
  Arguments / Usage Notes / Examples / Notes).
- [slug: data_branch_fullscan] `docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-fullscan-en.md`
  — Reference page for the `DATA BRANCH DIFF` / `DATA BRANCH MERGE`
  full-table-scan fallback, covering trigger conditions
  (`ErrNoCommitTSColumn`, `ErrFileNotFound`), semantics, log lines,
  and three examples drawn from the `git4data` diff test suite.
- [slug: git4data] `docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/git4data-branch-diff-en.md`
  — Reference page listing the user-observable guarantees for
  `DATA BRANCH DIFF` nailed down by the `git4data` test family
  (diff stability across flush+checkpoint+GC, diff via snapshots
  after DROP TABLE, and the full `COLUMNS` behavior matrix).
- [slug: sql_task] `docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/sql-task.md`
  — Full SQL Task reference covering `CREATE TASK`, `ALTER TASK`,
  `DROP TASK`, `EXECUTE TASK`, `SHOW TASKS`, `SHOW TASK RUNS`;
  output columns; run statuses; and six examples.
- [slug: rewrite_rule] `docs/MatrixOne/Reference/SQL-Reference/Data-Control-Language/alter-role-rule.md`
  — `ALTER ROLE ... ADD/DROP RULE` page with Syntax / Arguments /
  Examples sections and the role-rule error strings
  (`internal error: there is no role <name>`,
  `internal error: rule '<db.tbl>' does not exist for role '<role>'`).
- [slug: rewrite_rule] `docs/MatrixOne/Reference/SQL-Reference/Data-Control-Language/show-rules-on-role.md`
  — `SHOW RULES ON ROLE` page with the output column schema and
  the empty / error result sets.

### Navigation Updated

`work/matrixorigin.io/mkdocs.yml`:

- Data Definition Language: after `MERGE BRANCH`, added
  `PICK BRANCH`, `BRANCH DIFF/MERGE FULL-SCAN FALLBACK`,
  `git4data BRANCH DIFF GUARANTEES`, `SQL TASK`.
- Data Control Language: after `ALTER USER`, added
  `ALTER ROLE ADD/DROP RULE` and `SHOW RULES ON ROLE`.

### Release Notes

- Path: `docs/MatrixOne/Release-Notes/v26.3.0.10.md`
- The repo already ships this file and it already covers every user-
  visible change in this release (DATA BRANCH PICK, DATA BRANCH DIFF
  COLUMNS projection, role rewrite rules, SQL Task pipeline, and the
  bugfix series). It is not rewritten here; preserving the
  release-curated wording.

### Skipped Changes

### Skipped: v26.3.0.* Release Notes entries in navigation

- Repo: io
- Source files: `mkdocs.yml`
- Reason: The repo's Release Notes navigation currently stops at
  v25.3.0.4; v26.3.0.5..9 are also absent from the nav although
  those files exist in `docs/MatrixOne/Release-Notes/`. Adding only
  v26.3.0.10 in isolation would be inconsistent with how the maintainers
  have kept that section. The Release Notes file itself is present
  and reachable directly.
- Suggested human action: let the docs maintainers decide whether
  to backfill the whole v26.3.0.* series to the nav in one change.

### Risks

- `sql-task.md` is a single page covering six new statements. If the
  maintainers later prefer one page per statement (`create-task.md`,
  `alter-task.md`, etc.), the nav will need to be re-split.
- `data-branch-fullscan-en.md` and `git4data-branch-diff-en.md`
  describe observable behavior of the existing `DATA BRANCH DIFF` /
  `DATA BRANCH MERGE` statements rather than new syntax; their
  naming is consistent with the `data-branch-*-en.md` neighbors but
  they intentionally do not define new grammar.
- Heading forms on the DCL pages (`alter-role-rule.md`,
  `show-rules-on-role.md`) use plain `## Syntax` / `## Arguments` /
  `## Examples` (not bold-wrapped) so the rule-based checker
  recognizes them; neighboring DCL pages still use
  `## **Syntax**`. Pick one convention during review if uniformity
  matters.

## Supervisor Verdict

- Final verdict: **pass** (round 2, unresolvable=False)
- Prechecks: pass=7 fail=0 warn=1 skip=0
- No outstanding Supervisor findings.
