### PR TITLE
fix(ci): prevent silent pass in SQL execution validation

### DIFF
--- a/.github/workflows/check-sql-syntax.yml
+++ b/.github/workflows/check-sql-syntax.yml
@@ -96,4 +96,4 @@ jobs:
           echo "🔍 Starting SQL Syntax Check"
           echo "============================================================"
           echo "🧾 Diff base branch: ${BASE_BRANCH}"
-          pnpm run check:sql-syntax:changed -- --base-branch "${BASE_BRANCH}"
+          node ./scripts/doc-validator/index.js --changed-only --base-branch "${BASE_BRANCH}"

--- a/.github/workflows/validate-sql-execution.yml
+++ b/.github/workflows/validate-sql-execution.yml
@@ -159,7 +159,7 @@ jobs:
             # Run SQL validation
             echo ""
             echo "🔍 Running SQL Execution Validation..."
-            if pnpm run check:sql-exec:changed -- --base-branch "${BASE_BRANCH}"; then
+            if node ./scripts/doc-validator/index.js --check=execution --changed-only --base-branch "${BASE_BRANCH}"; then
               echo ""
               echo "============================================================"
               echo "✅ SQL Validation PASSED with $SHA ($BRANCH)"

--- a/scripts/doc-validator/index.js
+++ b/scripts/doc-validator/index.js
@@ -56,6 +56,12 @@ async function main() {
   // Determine files to check
   let filesToCheck = []
 
+  if (specifiedFiles.length > 0 && options.changedOnly) {
+    console.error('❌ Error: --changed-only cannot be combined with positional file arguments')
+    console.error(`   Received positional args: ${specifiedFiles.join(' ')}`)
+    process.exit(1)
+  }
+
   if (specifiedFiles.length > 0) {
     // Use files specified from command line
     console.log('📝 Check mode: Specified files')


### PR DESCRIPTION
## What type of PR is this?

- [ ] Enhancement
- [ ] Displaying
- [ ] Typo
- [ ] Doc Request

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:

The workflow invoked the validator via `pnpm run check:sql-exec:changed -- --base-branch main`. pnpm 9 forwards the literal `--` to the script, so commander treated `--base-branch` and `main` as positional file arguments and `--changed-only` lost its base-branch input. Result: 0 files scanned, 0 SQL blocks, exit 0 — CI reported PASS without actually validating any changed docs.

- Call node directly in the workflow so args reach commander verbatim.
- Reject `--changed-only` + positional args in the validator as a defensive guard against future reintroduction.