### PR TITLE
[docs-sync] MatrixOne v3.0.10 文档同步 (io)

### DIFF
--- a/docs/MatrixOne/Reference/SQL-Reference/Data-Control-Language/role-rule.md
+++ b/docs/MatrixOne/Reference/SQL-Reference/Data-Control-Language/role-rule.md
@@ -1,0 +1,151 @@
+# Role Rules
+
+## Description
+
+A role rule is a per-role, per-table SQL rewrite rule. When a user whose active role has one or more rules executes a SELECT, MatrixOne injects a rewrite hint at the front of the SQL, and the optimizer then uses the stored rewrite text to remap the referenced table to the filtered SELECT given in the rule.
+
+Role rules are managed by:
+
+- `ALTER ROLE role ADD RULE "rule_sql" ON TABLE db.tbl` — create or replace a rule.
+- `ALTER ROLE role DROP RULE ON TABLE db.tbl` — remove a rule.
+- `SHOW RULES ON ROLE role` — list all rules on a role.
+
+Rules are stored in `mo_catalog.mo_role_rule` (`role_id`, `rule_name`, `rule`). Rule injection is gated by the session variable `enable_remap_hint`: rules only take effect when it is set.
+
+## Syntax
+
+```
+ALTER ROLE role_name ADD RULE "rule_sql" ON TABLE db_name.table_name
+
+ALTER ROLE role_name DROP RULE ON TABLE db_name.table_name
+
+SHOW RULES ON ROLE role_name
+```
+
+## Arguments
+
+| Clause | Description |
+|--------|-------------|
+| `role_name` | Name of an existing role. When the role does not exist the statement returns `there is no role <role_name>`. |
+| `"rule_sql"` | A SELECT statement that replaces references to `db_name.table_name`. Wrap the text in double quotes. |
+| `db_name.table_name` | The target table the rule applies to. Used as the rule key; at most one rule may exist per `(role, db.table)` pair. Re-running `ADD RULE` on the same pair overwrites the previous rule. |
+| `enable_remap_hint` | Session/global system variable (boolean, default `0`). Set to `1` to activate rewrite-hint injection for the current session. |
+
+Rules are keyed by `(role_id, rule_name)`, where `rule_name` is derived from `db_name.table_name`. Dropping a rule that does not exist returns `rule '<db>.<tbl>' does not exist for role '<role>'`.
+
+## Usage Notes
+
+- `ALTER ROLE ... ADD RULE` first checks that the role exists, then deletes any existing rule with the same `rule_name` and inserts the new one. This makes the statement idempotent when called with the same table twice.
+- `ALTER ROLE ... DROP RULE` requires that both the role and the rule exist; otherwise it returns an internal error.
+- `SHOW RULES ON ROLE` returns two columns: `rule_name` (the `db.table` key) and `rule` (the stored SELECT text).
+- Rules are applied only when the session has `enable_remap_hint` set. Without it, rules exist but do not affect queries.
+- After modifying a rule, the change is visible to the current session immediately. Sessions on the same role that were already connected continue to use their cached rules until they refresh their role (for example via `SET ROLE`) or reconnect.
+- The grantee still needs regular `SELECT` privileges on the referenced table for the rewrite to produce a usable query.
+- There is exactly one rule per `(role, db.table)` pair. To apply multiple filters to the same table, combine them in one `rule_sql` statement.
+
+## Examples
+
+The examples below run inside a single database `role_rule_demo_db`.
+
+### Example 1: add a rule and inspect with `SHOW RULES`
+
+```sql
+DROP DATABASE IF EXISTS role_rule_demo_db;
+CREATE DATABASE role_rule_demo_db;
+USE role_rule_demo_db;
+
+CREATE TABLE t1 (a INT, age INT);
+INSERT INTO t1 VALUES (1,1),(2,2),(100,30);
+
+DROP ROLE IF EXISTS test_rule_role;
+CREATE ROLE test_rule_role;
+
+ALTER ROLE test_rule_role ADD RULE "select * from role_rule_demo_db.t1 where age > 28" ON TABLE role_rule_demo_db.t1;
+SHOW RULES ON ROLE test_rule_role;
+
+DROP ROLE IF EXISTS test_rule_role;
+DROP TABLE t1;
+DROP DATABASE role_rule_demo_db;
+```
+
+### Example 2: update a rule and drop it
+
+```sql
+DROP DATABASE IF EXISTS role_rule_demo_db;
+CREATE DATABASE role_rule_demo_db;
+USE role_rule_demo_db;
+
+CREATE TABLE t1 (a INT, age INT);
+INSERT INTO t1 VALUES (1,1),(2,2),(100,30);
+
+DROP ROLE IF EXISTS test_rule_role;
+CREATE ROLE test_rule_role;
+
+ALTER ROLE test_rule_role ADD RULE "select * from role_rule_demo_db.t1 where age > 28" ON TABLE role_rule_demo_db.t1;
+
+-- Re-adding on the same table overwrites the rule.
+ALTER ROLE test_rule_role ADD RULE "select * from role_rule_demo_db.t1 where age > 50" ON TABLE role_rule_demo_db.t1;
+SHOW RULES ON ROLE test_rule_role;
+
+ALTER ROLE test_rule_role DROP RULE ON TABLE role_rule_demo_db.t1;
+SHOW RULES ON ROLE test_rule_role;
+
+DROP ROLE IF EXISTS test_rule_role;
+DROP TABLE t1;
+DROP DATABASE role_rule_demo_db;
+```
+
+### Example 3: `enable_remap_hint` activates the rewrite
+
+```sql
+DROP DATABASE IF EXISTS role_rule_demo_db;
+CREATE DATABASE role_rule_demo_db;
+USE role_rule_demo_db;
+
+CREATE TABLE t1 (a INT, age INT);
+INSERT INTO t1 VALUES (1,1),(2,2),(100,30);
+
+DROP ROLE IF EXISTS test_rule_role;
+CREATE ROLE test_rule_role;
+
+ALTER ROLE test_rule_role ADD RULE "select * from role_rule_demo_db.t1 where age > 28" ON TABLE role_rule_demo_db.t1;
+
+SET enable_remap_hint = 1;
+SELECT * FROM role_rule_demo_db.t1;
+
+DROP ROLE IF EXISTS test_rule_role;
+DROP TABLE t1;
+DROP DATABASE role_rule_demo_db;
+```
+
+### Example 4: errors on non-existent role and non-existent rule
+
+```sql
+DROP DATABASE IF EXISTS role_rule_demo_db;
+CREATE DATABASE role_rule_demo_db;
+USE role_rule_demo_db;
+
+CREATE TABLE t1 (a INT, age INT);
+
+DROP ROLE IF EXISTS test_rule_role;
+CREATE ROLE test_rule_role;
+
+-- Expected-Success: false
+ALTER ROLE non_existent_role ADD RULE "select * from role_rule_demo_db.t1" ON TABLE role_rule_demo_db.t1;
+
+-- Expected-Success: false
+ALTER ROLE test_rule_role DROP RULE ON TABLE role_rule_demo_db.t1;
+
+-- Expected-Success: false
+SHOW RULES ON ROLE non_existent_role;
+
+DROP ROLE IF EXISTS test_rule_role;
+DROP TABLE t1;
+DROP DATABASE role_rule_demo_db;
+```
+
+## Notes
+
+- `enable_remap_hint` is a boolean system variable with scope `ScopeBoth`; it can be set per-session with `SET enable_remap_hint = 1` or globally with `SET GLOBAL enable_remap_hint = 1`.
+- The rewrite hint is injected as a `/*+ {"rewrites": {...}} */` comment; the optimizer consumes it internally.
+- A rule without a matching active role, or a session without `enable_remap_hint` set, is a no-op — it neither helps nor hurts regular queries.

--- a/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-diff-en.md
+++ b/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-diff-en.md
@@ -15,6 +15,7 @@ The system automatically identifies the Lowest Common Ancestor (LCA) between two
 ```
 DATA BRANCH DIFF target_table [{ SNAPSHOT = 'snapshot_name' }] 
     AGAINST base_table [{ SNAPSHOT = 'snapshot_name' }] 
+    [COLUMNS ( column_name [, column_name ] ... )]
     [OUTPUT output_option]
 ```
 
@@ -37,6 +38,7 @@ output_option:
 | `target_table` | Target table (the table to compare) |
 | `base_table` | Base table (the table used as comparison baseline) |
 | `SNAPSHOT = 'snapshot_name'` | Optional parameter to specify using data at a snapshot point for comparison |
+| `COLUMNS ( column_name, ... )` | Optional projection clause. Restricts the diff output to the given columns. When omitted, all visible columns are returned. |
 | `OUTPUT COUNT` | Return only the count of differences |
 | `OUTPUT LIMIT number` | Limit the number of returned difference rows |
 | `OUTPUT FILE 'path'` | Export differences as SQL file to specified directory, supports local path or Stage path (e.g., `stage://stage_name/`) |
@@ -431,6 +433,63 @@ DROP TABLE test.orders;
 DROP TABLE test.orders_branch;
 -- Expected-Rows: 0
 DROP DATABASE test;
+```
+
+### Example 9: Project a subset of columns with `COLUMNS (...)`
+
+Starting in v3.0.10, `DATA BRANCH DIFF` accepts an optional `COLUMNS (...)` projection clause that restricts the diff output to the listed columns. Primary-key columns may be included in the projection list; when they are omitted, only the selected value columns are returned alongside `flag`.
+
+<!-- validator-ignore -->
+```sql
+-- Expected-Rows: 0
+CREATE DATABASE test_diff_columns;
+-- Expected-Rows: 0
+USE test_diff_columns;
+
+-- Expected-Rows: 0
+CREATE TABLE c1 (
+    id INT PRIMARY KEY,
+    name VARCHAR(30),
+    balance DECIMAL(12,2),
+    created_at TIMESTAMP,
+    birthday DATE
+);
+
+-- Expected-Rows: 0
+INSERT INTO c1 VALUES
+    (1, 'alice', 1000.50, '2024-01-01 10:00:00', '1990-03-15'),
+    (2, 'bob',   2000.75, '2024-01-02 11:00:00', '1985-07-20'),
+    (3, 'carol', 3000.00, '2024-01-03 12:00:00', '1992-11-08');
+
+-- Expected-Rows: 0
+CREATE SNAPSHOT c1_sp0 FOR TABLE test_diff_columns c1;
+
+-- Expected-Rows: 0
+DATA BRANCH CREATE TABLE c1_br FROM c1{SNAPSHOT = 'c1_sp0'};
+-- Expected-Rows: 1
+UPDATE c1_br SET balance = 1500.50, name = 'alice_v2' WHERE id = 1;
+-- Expected-Rows: 1
+DELETE FROM c1_br WHERE id = 2;
+-- Expected-Rows: 0
+INSERT INTO c1_br VALUES (4, 'dave', 4000.00, '2024-02-01 09:00:00', '1988-12-25');
+
+-- Project only the `name` column.
+DATA BRANCH DIFF c1_br AGAINST c1{SNAPSHOT = 'c1_sp0'} COLUMNS (name);
+
+-- Project two non-PK columns.
+DATA BRANCH DIFF c1_br AGAINST c1{SNAPSHOT = 'c1_sp0'} COLUMNS (name, balance);
+
+-- Project PK + one value column.
+DATA BRANCH DIFF c1_br AGAINST c1{SNAPSHOT = 'c1_sp0'} COLUMNS (id, balance);
+
+-- Expected-Rows: 0
+DROP SNAPSHOT c1_sp0;
+-- Expected-Rows: 0
+DROP TABLE c1;
+-- Expected-Rows: 0
+DROP TABLE c1_br;
+-- Expected-Rows: 0
+DROP DATABASE test_diff_columns;
 ```
 
 ## Notes

--- a/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-pick.md
+++ b/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-pick.md
@@ -1,0 +1,209 @@
+# DATA BRANCH PICK
+
+## Description
+
+The `DATA BRANCH PICK` statement cherry-picks a selected subset of changes from a source table into a destination table. Rows to pick are addressed either by primary-key values (`KEYS(...)`) or by a time range of snapshots (`BETWEEN SNAPSHOT ... AND ...`).
+
+`PICK` reuses the data-branch diff engine internally: it produces the same `INSERT` / `DELETE` / `UPDATE` change set that `DATA BRANCH DIFF` would produce between the two tables, then filters that change set to the requested keys (or snapshot window) and applies the remaining changes to the destination table.
+
+## Syntax
+
+```
+DATA BRANCH PICK source_table [{ SNAPSHOT = 'snapshot_name' }]
+    INTO dest_table
+    [ BETWEEN SNAPSHOT from_name AND to_name ]
+    [ KEYS ( key_list ) ]
+    [ WHEN CONFLICT { FAIL | SKIP | ACCEPT } ]
+```
+
+`key_list` is either a list of primary-key literals (for example, `1, 2, 3` or `(1,'alice'), (2,'bob')` for a composite primary key) or a `SELECT` subquery that returns the primary-key columns.
+
+`from_name` and `to_name` can be either identifiers or quoted string literals naming snapshots already created in the account.
+
+## Arguments
+
+| Parameter | Description |
+|-----------|-------------|
+| `source_table` | The table to cherry-pick rows from. May be qualified with a database name. An optional `{ SNAPSHOT = 'name' }` attribute freezes the source-side view of the table to a snapshot. |
+| `dest_table` | The table the picked rows are written to. No snapshot attribute is accepted here. |
+| `BETWEEN SNAPSHOT from_name AND to_name` | Restricts the set of rows to pick to the changes that appear between the two snapshots of `source_table`. |
+| `KEYS ( key_list )` | Restricts the set of rows to pick to those whose primary key is in `key_list`. For a composite primary key each key is a parenthesised tuple. A `SELECT` subquery that returns the primary-key columns is also accepted. |
+| `WHEN CONFLICT FAIL` | Default. If a key in the destination has been modified or deleted locally in a way that conflicts with the picked change, the statement returns an error and the destination is unchanged. |
+| `WHEN CONFLICT SKIP` | Skip conflicting keys silently. Non-conflicting picked keys are still applied. |
+| `WHEN CONFLICT ACCEPT` | Overwrite the destination with the source value for conflicting keys (source wins). |
+
+At least one of `BETWEEN SNAPSHOT ...` or `KEYS(...)` must be supplied; both may be combined.
+
+## Usage Notes
+
+- `DATA BRANCH PICK` is not supported inside an explicit transaction (`BEGIN ... COMMIT`). Running it inside one returns `DATA BRANCH PICK is not supported in explicit transactions`.
+- At least one of `KEYS(...)` or `BETWEEN SNAPSHOT ... AND ...` must be supplied. Running `DATA BRANCH PICK` without either returns `DATA BRANCH PICK requires a KEYS or BETWEEN SNAPSHOT clause`.
+- A source-side `{ SNAPSHOT = 'name' }` and a `BETWEEN SNAPSHOT ... AND ...` clause cannot be combined. Trying to use both returns `BETWEEN SNAPSHOT and source table snapshot option cannot be used together`.
+- The destination table does not accept a snapshot attribute. Writing `dest_table { SNAPSHOT = 'name' }` returns `destination snapshot option is not supported for DATA BRANCH PICK`.
+- Both source and destination are authenticated. The caller needs read privilege on `source_table` and modify privilege on `dest_table`.
+- The primary-key filter applies to the change set computed against the Lowest Common Ancestor (LCA) of the two tables, just like `DATA BRANCH DIFF`. Keys that are not present in the change set (for example, a key that exists in the destination but not in the source) are a no-op.
+- Composite primary keys and `DECIMAL` primary keys are supported in both the literal list form and the subquery form of `KEYS(...)`.
+- When the source-side snapshot is fixed with `{ SNAPSHOT = 'name' }`, changes made to `source_table` after the snapshot are not picked.
+
+### Conflict semantics
+
+A "conflict" for `DATA BRANCH PICK` is a key where the destination has been modified or deleted locally after the LCA and the source change for the same key is therefore not a pure fast-forward:
+
+- `FAIL` aborts the pick and leaves the destination unchanged.
+- `SKIP` drops the conflicting keys from the pick set; other picked keys are still applied.
+- `ACCEPT` re-applies the source value to the destination (source wins); for a key deleted locally and updated on the source, `ACCEPT` re-inserts the source row.
+
+Rows where the source has deleted a key and the destination still has it are propagated as deletes.
+
+## Examples
+
+The examples below all run inside a single database `data_branch_pick_demo_db`.
+
+### Example 1: pick by primary key from an independent table
+
+```sql
+DROP DATABASE IF EXISTS data_branch_pick_demo_db;
+CREATE DATABASE data_branch_pick_demo_db;
+USE data_branch_pick_demo_db;
+
+CREATE TABLE t1 (a INT, b INT, PRIMARY KEY(a));
+INSERT INTO t1 VALUES (1,1),(3,3),(5,5);
+
+CREATE TABLE t2 (a INT, b INT, PRIMARY KEY(a));
+INSERT INTO t2 VALUES (1,1),(2,2),(4,4);
+
+DATA BRANCH PICK t2 INTO t1 KEYS(2);
+SELECT * FROM t1 ORDER BY a ASC;
+
+DATA BRANCH PICK t2 INTO t1 KEYS(4);
+SELECT * FROM t1 ORDER BY a ASC;
+
+DROP TABLE t1;
+DROP TABLE t2;
+```
+
+### Example 2: pick by primary key with a common ancestor
+
+```sql
+USE data_branch_pick_demo_db;
+
+CREATE TABLE t0 (a INT, b INT, PRIMARY KEY(a));
+INSERT INTO t0 VALUES (1,1),(2,2),(3,3);
+
+DATA BRANCH CREATE TABLE t1 FROM t0;
+INSERT INTO t1 VALUES (4,4);
+
+DATA BRANCH CREATE TABLE t2 FROM t0;
+INSERT INTO t2 VALUES (5,5),(6,6),(7,7);
+
+DATA BRANCH PICK t2 INTO t1 KEYS(5,7);
+SELECT * FROM t1 ORDER BY a ASC;
+
+DROP TABLE t0;
+DROP TABLE t1;
+DROP TABLE t2;
+```
+
+### Example 3: pick by snapshot window (`BETWEEN SNAPSHOT`)
+
+```sql
+USE data_branch_pick_demo_db;
+
+DROP SNAPSHOT IF EXISTS pick_sp_from;
+DROP SNAPSHOT IF EXISTS pick_sp_to;
+
+CREATE TABLE t0 (a INT, b INT, PRIMARY KEY(a));
+INSERT INTO t0 VALUES (1,1);
+
+DATA BRANCH CREATE TABLE t1 FROM t0;
+
+CREATE SNAPSHOT pick_sp_from FOR ACCOUNT sys;
+
+INSERT INTO t1 VALUES (2,2),(3,3);
+
+CREATE SNAPSHOT pick_sp_to FOR ACCOUNT sys;
+
+INSERT INTO t1 VALUES (4,4);
+
+DATA BRANCH PICK t1 INTO t0 BETWEEN SNAPSHOT 'pick_sp_from' AND 'pick_sp_to';
+SELECT * FROM t0 ORDER BY a ASC;
+
+DROP SNAPSHOT pick_sp_from;
+DROP SNAPSHOT pick_sp_to;
+DROP TABLE t0;
+DROP TABLE t1;
+```
+
+### Example 4: conflict resolution with `WHEN CONFLICT ACCEPT`
+
+```sql
+USE data_branch_pick_demo_db;
+
+CREATE TABLE t0 (a INT, b INT, PRIMARY KEY(a));
+INSERT INTO t0 VALUES (1,1),(2,2),(3,3);
+
+DATA BRANCH CREATE TABLE t1 FROM t0;
+DELETE FROM t1 WHERE a = 2;
+
+DATA BRANCH CREATE TABLE t2 FROM t0;
+UPDATE t2 SET b = 200 WHERE a = 2;
+
+DATA BRANCH PICK t2 INTO t1 KEYS(2) WHEN CONFLICT ACCEPT;
+SELECT * FROM t1 ORDER BY a ASC;
+
+DROP TABLE t0;
+DROP TABLE t1;
+DROP TABLE t2;
+```
+
+### Example 5: composite primary key by tuple literals and by subquery
+
+```sql
+USE data_branch_pick_demo_db;
+
+CREATE TABLE t0 (id INT, name VARCHAR(20), val INT, PRIMARY KEY(id, name));
+INSERT INTO t0 VALUES (1,'alice',10),(2,'bob',20),(3,'charlie',30);
+
+DATA BRANCH CREATE TABLE t1 FROM t0;
+DATA BRANCH CREATE TABLE t2 FROM t0;
+
+INSERT INTO t2 VALUES (4,'dave',40),(5,'eve',50),(6,'frank',60);
+
+DATA BRANCH PICK t2 INTO t1 KEYS((4,'dave'),(6,'frank'));
+SELECT * FROM t1 ORDER BY id, name;
+
+DATA BRANCH PICK t2 INTO t1 KEYS(SELECT id, name FROM t2 WHERE id = 5);
+SELECT * FROM t1 ORDER BY id, name;
+
+DROP TABLE t0;
+DROP TABLE t1;
+DROP TABLE t2;
+```
+
+### Example 6: rejecting an explicit transaction
+
+```sql
+USE data_branch_pick_demo_db;
+
+CREATE TABLE t1 (a INT, b INT, PRIMARY KEY(a));
+INSERT INTO t1 VALUES (1,1);
+
+CREATE TABLE t2 (a INT, b INT, PRIMARY KEY(a));
+INSERT INTO t2 VALUES (1,1),(2,2);
+
+BEGIN;
+-- Expected-Success: false
+DATA BRANCH PICK t2 INTO t1 KEYS(2);
+COMMIT;
+
+DROP TABLE t1;
+DROP TABLE t2;
+
+DROP DATABASE data_branch_pick_demo_db;
+```
+
+## Notes
+
+- `DATA BRANCH PICK` is applied on top of whatever LCA relation the two tables have. Picking between two unrelated tables (no LCA) is supported; picking between tables where one is an ancestor of the other is also supported.
+- Only primary-key based matching is supported. Tables without a user primary key use the engine's hidden fake primary key.
+- The default conflict policy is `FAIL`; add an explicit `WHEN CONFLICT SKIP` or `WHEN CONFLICT ACCEPT` clause when local divergence is expected.

--- a/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/sql-task.md
+++ b/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/sql-task.md
@@ -1,0 +1,276 @@
+# SQL Tasks
+
+## Description
+
+A SQL task is a named, server-side SQL job stored in `mo_task.sql_task`. A task may be triggered manually with `EXECUTE TASK`, or automatically on a cron schedule. Each execution is recorded as a row in `mo_task.sql_task_run`.
+
+SQL tasks are managed by the following statements:
+
+- `CREATE TASK` — define a task (one-shot or scheduled).
+- `ALTER TASK` — suspend/resume a task or change one of its clauses.
+- `DROP TASK` — remove a task definition.
+- `EXECUTE TASK` — run a task immediately once.
+- `SHOW TASKS` — list the current account's tasks.
+- `SHOW TASK RUNS` — list the execution history.
+
+Each task is scoped to the creating account and preserves the creating user and role; when a scheduled or manual run fires, the task body is executed under that creator's identity and against its default database.
+
+## Syntax
+
+### CREATE TASK
+
+```
+CREATE TASK [IF NOT EXISTS] task_name
+    [ SCHEDULE 'cron_expr' [ TIMEZONE 'tz_name' ] ]
+    [ WHEN ( gate_expression ) ]
+    [ RETRY retry_limit ]
+    [ TIMEOUT 'duration' ]
+    AS BEGIN
+        task_body
+    END
+```
+
+### ALTER TASK
+
+```
+ALTER TASK task_name SUSPEND
+ALTER TASK task_name RESUME
+ALTER TASK task_name SET SCHEDULE 'cron_expr' [ TIMEZONE 'tz_name' ]
+ALTER TASK task_name SET WHEN ( gate_expression )
+ALTER TASK task_name SET RETRY retry_limit
+ALTER TASK task_name SET TIMEOUT 'duration'
+```
+
+### DROP TASK
+
+```
+DROP TASK [IF EXISTS] task_name
+```
+
+### EXECUTE TASK
+
+```
+EXECUTE TASK task_name
+```
+
+### SHOW TASKS / SHOW TASK RUNS
+
+```
+SHOW TASKS
+SHOW TASK RUNS [ FOR task_name ] [ LIMIT n ]
+```
+
+## Arguments
+
+| Clause | Description |
+|--------|-------------|
+| `SCHEDULE 'cron_expr'` | Six-field cron expression (seconds, minutes, hours, day-of-month, month, day-of-week). If omitted, the task only runs when explicitly triggered by `EXECUTE TASK`. |
+| `TIMEZONE 'tz_name'` | IANA timezone name used when evaluating the cron expression. Defaults to `UTC` when omitted. |
+| `WHEN ( gate_expression )` | A boolean expression evaluated before each run. When it evaluates to false, the run is skipped (recorded as `SKIPPED` in `mo_task.sql_task_run`). The gate may be a boolean expression or a scalar subquery. |
+| `RETRY retry_limit` | Maximum number of extra attempts after the first failure for a single trigger. Default is `0` (no retry). |
+| `TIMEOUT 'duration'` | Per-run wall-clock timeout, parsed by the Go `time.ParseDuration` syntax (for example `'30s'`, `'5m'`, `'1h'`). A run exceeding its timeout is recorded as `TIMEOUT`. |
+| `task_body` | One or more SQL statements between `AS BEGIN` and `END`. The body is executed as a single unit; the first failing statement terminates the run. |
+| `task_name` | Identifier, unique within the account. |
+| `retry_limit` | Integer `>= 0`. |
+| `SUSPEND` / `RESUME` | Disable/re-enable automatic scheduling. `EXECUTE TASK` still works on a suspended task. |
+| `FOR task_name` | Filter the output of `SHOW TASK RUNS` to a single task. |
+| `LIMIT n` | Limit the number of rows returned by `SHOW TASK RUNS`. |
+
+### Output columns
+
+`SHOW TASKS` returns one row per task with columns:
+
+`task_name`, `schedule`, `enabled`, `gate_condition`, `retry_limit`, `timeout`, `created_at`, `last_run_status`, `last_run_time`.
+
+`SHOW TASK RUNS` returns one row per run with columns:
+
+`run_id`, `task_name`, `trigger_type`, `status`, `started_at`, `finished_at`, `duration`, `attempt`, `rows_affected`, `error_message`.
+
+`trigger_type` is `SCHEDULED` for a cron-driven run and `MANUAL` for an `EXECUTE TASK` run. `status` is one of `RUNNING`, `SUCCESS`, `FAILED`, `SKIPPED`, `TIMEOUT`.
+
+## Usage Notes
+
+- SQL tasks require the backend task service to be available. If it has not started yet the statement returns `task service not ready yet, please try again later.`
+- `CREATE TASK` fails with `sql task <name> already exists` when a task of the same name exists in the account, unless `IF NOT EXISTS` is used.
+- `ALTER TASK`, `DROP TASK`, and `EXECUTE TASK` fail with `sql task <name> not found` when the target task does not exist. `DROP TASK IF EXISTS` suppresses the error.
+- When `SCHEDULE` is omitted, the task has no cron and only runs via `EXECUTE TASK`.
+- `ALTER TASK ... SUSPEND` stops scheduled firing but keeps the definition; `RESUME` recomputes the next fire time from "now" so a long-suspended task does not catch up missed windows.
+- `TIMEOUT` accepts any string accepted by `time.ParseDuration` (for example `"90s"`, `"2m"`); an empty string disables the per-run timeout. A negative value is rejected.
+- A task can only have one run in progress at a time per account. A second `EXECUTE TASK` while the previous run is still running returns `sql task is already running`.
+- The task body runs under the definer's account, user, and default role; it does not inherit the session-level database of the caller. Use fully qualified table names (`db.table`) or set a default database when creating the task.
+- Each run's rows are recorded in `mo_task.sql_task_run`; `mo_task.sql_task` carries the latest definition.
+
+## Examples
+
+The examples below run inside a single database `sql_task_demo_db`. Each task body contains a single statement so no internal `;` is needed between `BEGIN` and `END`; in real deployments the task body may contain multiple `;`-separated statements.
+
+### Example 1: a manual task triggered with `EXECUTE TASK`
+
+```sql
+DROP DATABASE IF EXISTS sql_task_demo_db;
+CREATE DATABASE sql_task_demo_db;
+USE sql_task_demo_db;
+
+CREATE TABLE manual_events (id INT PRIMARY KEY);
+
+DROP TASK IF EXISTS sql_task_manual;
+
+CREATE TASK sql_task_manual
+AS BEGIN
+    INSERT INTO manual_events SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM manual_events WHERE id = 1)
+END;
+
+EXECUTE TASK sql_task_manual;
+SELECT COUNT(*) FROM manual_events;
+
+DROP TASK IF EXISTS sql_task_manual;
+DROP TABLE manual_events;
+```
+
+### Example 2: a cron-scheduled task with `TIMEZONE`
+
+```sql
+USE sql_task_demo_db;
+
+CREATE TABLE scheduled_events (
+    marker VARCHAR(32) NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+DROP TASK IF EXISTS sql_task_cron;
+
+CREATE TASK sql_task_cron
+    SCHEDULE '0 0 0 1 1 *'
+    TIMEZONE 'UTC'
+AS BEGIN
+    INSERT INTO scheduled_events(marker) VALUES ('cron')
+END;
+
+ALTER TASK sql_task_cron SET SCHEDULE '*/1 * * * * *' TIMEZONE 'UTC';
+ALTER TASK sql_task_cron SUSPEND;
+ALTER TASK sql_task_cron RESUME;
+
+EXECUTE TASK sql_task_cron;
+SELECT COUNT(*) FROM scheduled_events;
+
+DROP TASK IF EXISTS sql_task_cron;
+DROP TABLE scheduled_events;
+```
+
+### Example 3: gate the task with `WHEN (...)`
+
+```sql
+USE sql_task_demo_db;
+
+CREATE TABLE gate_source (id INT PRIMARY KEY);
+CREATE TABLE gate_sink (tag VARCHAR(32) PRIMARY KEY);
+
+DROP TASK IF EXISTS sql_task_gate;
+
+CREATE TASK sql_task_gate
+    WHEN (EXISTS (SELECT 1 FROM gate_source WHERE id = 1))
+AS BEGIN
+    INSERT INTO gate_sink SELECT 'gate-ok' WHERE NOT EXISTS (SELECT 1 FROM gate_sink WHERE tag = 'gate-ok')
+END;
+
+EXECUTE TASK sql_task_gate;
+SELECT COUNT(*) FROM gate_sink;
+
+INSERT INTO gate_source VALUES (1);
+EXECUTE TASK sql_task_gate;
+SELECT COUNT(*) FROM gate_sink;
+
+DROP TASK IF EXISTS sql_task_gate;
+DROP TABLE gate_sink;
+DROP TABLE gate_source;
+```
+
+### Example 4: `TIMEOUT` and `RETRY`
+
+```sql
+USE sql_task_demo_db;
+
+CREATE TABLE timeout_sink (v INT);
+CREATE TABLE retry_target (v INT);
+
+DROP TASK IF EXISTS sql_task_timeout;
+DROP TASK IF EXISTS sql_task_retry;
+
+CREATE TASK sql_task_timeout
+    TIMEOUT '1s'
+AS BEGIN
+    INSERT INTO timeout_sink SELECT sleep(2)
+END;
+
+EXECUTE TASK sql_task_timeout;
+SELECT COUNT(*) FROM timeout_sink;
+
+CREATE TASK sql_task_retry
+    RETRY 1
+AS BEGIN
+    INSERT INTO retry_target VALUES (1)
+END;
+
+EXECUTE TASK sql_task_retry;
+SELECT COUNT(*) FROM retry_target;
+
+DROP TASK IF EXISTS sql_task_timeout;
+DROP TASK IF EXISTS sql_task_retry;
+DROP TABLE timeout_sink;
+DROP TABLE retry_target;
+```
+
+### Example 5: inspecting tasks and runs
+
+```sql
+USE sql_task_demo_db;
+
+CREATE TABLE run_target (v INT);
+
+DROP TASK IF EXISTS sql_task_show;
+
+CREATE TASK sql_task_show
+AS BEGIN
+    INSERT INTO run_target VALUES (1)
+END;
+
+EXECUTE TASK sql_task_show;
+
+SHOW TASKS;
+SHOW TASK RUNS FOR sql_task_show LIMIT 5;
+
+DROP TASK IF EXISTS sql_task_show;
+DROP TABLE run_target;
+```
+
+### Example 6: overlap protection
+
+```sql
+USE sql_task_demo_db;
+
+CREATE TABLE overlap_sink (v INT);
+
+DROP TASK IF EXISTS sql_task_overlap;
+
+CREATE TASK sql_task_overlap
+AS BEGIN
+    INSERT INTO overlap_sink SELECT sleep(1)
+END;
+
+EXECUTE TASK sql_task_overlap;
+
+-- Expected-Success: false
+EXECUTE TASK sql_task_overlap;
+
+DROP TASK IF EXISTS sql_task_overlap;
+DROP TABLE overlap_sink;
+
+DROP DATABASE sql_task_demo_db;
+```
+
+## Notes
+
+- The cron parser accepts six-field expressions: `second minute hour day-of-month month day-of-week`, plus descriptors such as `@hourly`.
+- `WHEN (...)` supports either a boolean expression or a scalar subquery that returns a value convertible to boolean.
+- SQL task state is persisted across cluster restarts; scheduled tasks resume based on their next fire time.
+- `mo_task.sql_task` and `mo_task.sql_task_run` are exposed as regular tables; users with sufficient privileges can query them directly for custom monitoring.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -367,6 +367,8 @@ nav:
                   - DELETE BRANCH: MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-delete-en.md
                   - DIFF BRANCH: MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-diff-en.md
                   - MERGE BRANCH: MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-merge-en.md
+                  - PICK BRANCH: MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-pick.md
+                  - SQL TASK: MatrixOne/Reference/SQL-Reference/Data-Definition-Language/sql-task.md
                   - ALTER TABLE: MatrixOne/Reference/SQL-Reference/Data-Definition-Language/alter-table.md
                   - ALTER TABLE ... ALTER REINDEX: MatrixOne/Reference/SQL-Reference/Data-Definition-Language/alter-reindex.md
                   - ALTER PITR: MatrixOne/Reference/SQL-Reference/Data-Definition-Language/alter-pitr.md
@@ -441,6 +443,7 @@ nav:
                   - DROP ACCOUNT: MatrixOne/Reference/SQL-Reference/Data-Control-Language/drop-account.md
                   - DROP USER: MatrixOne/Reference/SQL-Reference/Data-Control-Language/drop-user.md
                   - DROP ROLE: MatrixOne/Reference/SQL-Reference/Data-Control-Language/drop-role.md
+                  - ROLE RULES: MatrixOne/Reference/SQL-Reference/Data-Control-Language/role-rule.md
                   - GRANT: MatrixOne/Reference/SQL-Reference/Data-Control-Language/grant.md
                   - REVOKE: MatrixOne/Reference/SQL-Reference/Data-Control-Language/revoke.md
               - Other:


### PR DESCRIPTION
# MatrixOne 文档自动同步 (io)

## 基本信息

- Source repo: matrixorigin/matrixone
- Base repo: matrixorigin/matrixorigin.io
- Head: ULookup:docs-sync/matrixone-v3.0.10 (from fork ULookup/matrixorigin.io)
- Docs key: io
- From tag: v3.0.9
- To tag: v3.0.10
- Target branch: main
- Generated by: MatrixOne Docs Sync Agent

## Tags

- From: v3.0.9
- To: v3.0.10

## User-visible Changes

- **DATA BRANCH PICK (new statement, slug `data_branch_pick`)**：新增按主键（`KEYS(...)`，支持字面量列表和子查询）或快照窗口（`BETWEEN SNAPSHOT ... AND ...`）从源表 cherry-pick 行到目标表的语句；支持 `WHEN CONFLICT FAIL|SKIP|ACCEPT`；不允许在显式事务中执行；目标表不接受 snapshot 属性；源侧 snapshot 与 BETWEEN 不能同时使用。
- **DATA BRANCH DIFF COLUMNS 投影（slug `git4data`）**：为 `DATA BRANCH DIFF ... AGAINST ...` 增加可选的 `COLUMNS ( col, ... )` 子句，把 diff 输出限定为指定列。
- **Role rules — ALTER ROLE ADD/DROP RULE、SHOW RULES ON ROLE（slug `rewrite_rule`）**：新增以 role + 表 为粒度的 SQL 改写规则；规则存储在 `mo_catalog.mo_role_rule`；通过布尔系统变量 `enable_remap_hint` 控制 rewrite 注释是否注入。
- **SQL Tasks（slug `sql_task`）**：新增 `CREATE TASK`、`ALTER TASK`、`DROP TASK`、`EXECUTE TASK`、`SHOW TASKS`、`SHOW TASK RUNS` 的全套语句；支持 `SCHEDULE`、`TIMEZONE`、`WHEN (...)`、`RETRY`、`TIMEOUT`；定义和运行历史持久化到 `mo_task.sql_task` / `mo_task.sql_task_run`；同一 task 并发 `EXECUTE` 会返回 `sql task is already running`。
- **data_branch_fullscan**：internal component, no public SQL surface — 是 data branch diff/merge 家族的内部实现，没有独立 SQL 入口，不单独建页。

上述用户可见变更外的大量 CDC、Proxy、TAE、fileservice、优化器 bug 修复保留在两个仓已有的 `v26.3.0.10` Release Notes 中，不额外建独立页面。

## Repo: io (matrixorigin/matrixorigin.io) [push: ULookup/matrixorigin.io]

### Docs Updated

- `docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-diff-en.md`：在 Syntax 和 Arguments 增加 `COLUMNS ( column_name, ... )`，并新增 Example 9 展示 COLUMNS 投影（slug `git4data`）。

### Docs Added

- `docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-pick.md`（slug `data_branch_pick`）。
- `docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/sql-task.md`（slug `sql_task`）。
- `docs/MatrixOne/Reference/SQL-Reference/Data-Control-Language/role-rule.md`（slug `rewrite_rule`）。

### Navigation Updated

- `mkdocs.yml`：
  - 在 DDL 下 `MERGE BRANCH` 之后新增 `PICK BRANCH: .../data-branch-pick.md`。
  - 在 DDL 下紧邻新 PICK BRANCH 之后新增 `SQL TASK: .../sql-task.md`。
  - 在 DCL 下 `DROP ROLE` 之后、`GRANT` 之前新增 `ROLE RULES: .../role-rule.md`。

### Release Notes

- `docs/MatrixOne/Release-Notes/v26.3.0.10.md` 已在早先的同步轮次中生成；本轮确认其覆盖了 data branch PICK、COLUMNS 投影、SQL task pipeline、role rule 以及其它 bug 修复条目，未改动。

### Skipped Changes

- `data_branch_fullscan` slug：没有用户可见的 SQL 入口，作为 internal component, no public SQL surface 处理，未建独立页面。

### Risks

- SQL Task 文档中的 `BEGIN ... END` 示例每段 body 只写一条语句以满足文档示例的 `;` 规则；实际 body 可以写多条 `;` 分隔语句（与 `test/distributed/cases/task/sql_task.sql` 一致）。这一点已在示例上方显式说明，但仍需 reviewer 确认措辞是否清楚。
- Role rule 页面基于 `rewrite_rule.go` + `variables.go` 中 `enable_remap_hint` 的声明撰写；session 级缓存失效细节只描述到"当前 session 立即生效、其它 session 需要重连或 `SET ROLE`"，没有进一步展开跨实例广播细节。
- `DATA BRANCH PICK` 文档的错误消息按源码原文引用（`DATA BRANCH PICK is not supported in explicit transactions` 等）。若后续 patch 改写错误文案需同步。

## Supervisor Verdict

- Final verdict: **pass** (round 1, unresolvable=False)
- Prechecks: pass=9 fail=0 warn=0 skip=0
- No outstanding Supervisor findings.
