### PR TITLE
Feat/llms sql index

### DIFF
--- a/docs/hooks/agent_delivery.py
+++ b/docs/hooks/agent_delivery.py
@@ -1,6 +1,6 @@
 """MkDocs hook: emit agent-friendly artifacts alongside the HTML build.
 
-Produces three things so LLM-driven clients (Cursor, Claude Code, ChatGPT,
+Produces four things so LLM-driven clients (Cursor, Claude Code, ChatGPT,
 MCP servers, etc.) can consume the MatrixOne docs without parsing HTML:
 
 1. **Per-page markdown mirror.** Every source `docs/MatrixOne/**/*.md` file
@@ -13,7 +13,10 @@ MCP servers, etc.) can consume the MatrixOne docs without parsing HTML:
    doc keeps llms.txt fresh without touching this file. The header carries
    a blockquote of behavioural directives for SQL-writing agents and a
    direct pointer to the MySQL Compatibility Matrix.
-3. **`site/llms-full.txt`**. The whole corpus concatenated into one file so
+3. **`site/llms-sql.txt`**. A flat per-statement index of every SQL-Reference
+   page with its MySQL compatibility tag, so agents can scan the full SQL
+   surface area in one fetch without parsing the matrix table.
+4. **`site/llms-full.txt`**. The whole corpus concatenated into one file so
    agents can stuff the full docs into a single context window when needed.
 
 Override the base URL via `MATRIXONE_DOCS_BASE_URL` env var. Defaults to
@@ -32,7 +35,23 @@ from typing import Iterable
 BASE_URL_DEFAULT = "https://docs.matrixorigin.io"
 DOC_ROOT_REL = Path("MatrixOne")
 COMPAT_MATRIX_REL = "MatrixOne/Reference/mysql-compatibility-matrix.md"
+SQL_REF_ROOT_REL = Path("MatrixOne/Reference/SQL-Reference")
 MAX_AUTO_DESC_CHARS = 160
+
+SQL_CATEGORY_ORDER = [
+    ("Data-Definition-Language", "DDL — Data Definition Language"),
+    ("Data-Manipulation-Language", "DML — Data Manipulation Language"),
+    ("Data-Query-Language", "DQL — Data Query Language"),
+    ("Data-Control-Language", "DCL — Data Control Language"),
+    ("Other", "Other"),
+]
+COMPAT_TAG = {
+    "full": "full",
+    "partial": "partial",
+    "none": "none",
+    "mo_only": "mo-only",
+    "unknown": "unknown",
+}
 
 # Curated list of top-tier pages to highlight in llms.txt. Paths are relative
 # to `docs/`. Second tuple element is an optional description override; leave
@@ -128,6 +147,7 @@ def on_post_build(config, **_kwargs):
     llms.append("")
     llms.append(f"- **MySQL Compatibility Matrix**: {compat_url}")
     llms.append(f"- **Per-page markdown mirror**: append `.md` to any doc URL under {base}/")
+    llms.append(f"- **Full SQL reference (flat index, all statements)**: {base}/llms-sql.txt")
     llms.append(f"- **Full corpus**: {base}/llms-full.txt")
     llms.append(f"- **Generated**: {built_at} (UTC)")
     llms.append("")
@@ -150,7 +170,11 @@ def on_post_build(config, **_kwargs):
         llms.append("")
     (site_dir / "llms.txt").write_text("\n".join(llms), encoding="utf-8")
 
-    # 3. llms-full.txt
+    # 3. llms-sql.txt — flat index of every SQL-Reference page with compat tag.
+    sql_lines = _build_sql_index(docs_dir, base, built_at)
+    (site_dir / "llms-sql.txt").write_text("\n".join(sql_lines), encoding="utf-8")
+
+    # 4. llms-full.txt
     sections_order = [
         "MatrixOne/Overview",
         "MatrixOne/Get-Started",
@@ -202,7 +226,73 @@ def on_post_build(config, **_kwargs):
         full_parts.append("")
         full_parts.append(src.read_text(encoding="utf-8"))
     (site_dir / "llms-full.txt").write_text("\n".join(full_parts), encoding="utf-8")
-    print(f"[agent-delivery] emitted llms.txt and llms-full.txt ({len(seen)} pages)")
+    print(f"[agent-delivery] emitted llms.txt, llms-sql.txt and llms-full.txt ({len(seen)} pages)")
+
+
+def _build_sql_index(docs_dir: Path, base: str, built_at: str) -> list[str]:
+    """Emit a flat one-line-per-statement catalogue of every SQL-Reference
+    page. Each line is `- [TITLE](URL) [compat-tag]: one-line description.`
+    so agents can scan the whole SQL surface area in a single fetch.
+    """
+    root = docs_dir / SQL_REF_ROOT_REL
+    lines: list[str] = [
+        "# MatrixOne SQL Reference — Flat Index",
+        "",
+        f"> Every SQL statement supported by MatrixOne, grouped by category, "
+        f"each tagged with its MySQL 8.0 compatibility status. Generated from "
+        f"`mysql_compat` frontmatter on {built_at} (UTC).",
+        "",
+        "Legend: `[full]` MySQL-compatible · `[partial]` compatible with "
+        "caveats (see linked page for `differs_from_mysql:`) · "
+        "`[mo-only]` MatrixOne-only, no MySQL counterpart · "
+        "`[none]` not supported · `[unknown]` frontmatter missing.",
+        "",
+        f"Compatibility matrix (grouped table view): {base}/{COMPAT_MATRIX_REL}",
+        "",
+    ]
+    if not root.exists():
+        lines.append("_No SQL-Reference pages found._")
+        return lines
+
+    buckets: dict[str, list[tuple[str, str, str, str]]] = {k: [] for k, _ in SQL_CATEGORY_ORDER}
+    uncategorised: list[tuple[str, str, str, str]] = []
+    for src in sorted(root.rglob("*.md")):
+        rel_to_ref = src.relative_to(root)
+        parts = rel_to_ref.parts
+        category = parts[0] if len(parts) > 1 else "__root__"
+        text = _read(src) or ""
+        fm, _ = _split_frontmatter(text)
+        compat = COMPAT_TAG.get(fm.get("mysql_compat", "unknown"), "unknown")
+        title = fm.get("title") or _page_title(src) or rel_to_ref.as_posix()
+        desc = _page_description(src) or ""
+        rel_from_docs = src.relative_to(docs_dir).as_posix()
+        url = f"{base}/{rel_from_docs}"
+        row = (title, url, compat, desc)
+        if category in buckets:
+            buckets[category].append(row)
+        else:
+            uncategorised.append(row)
+
+    for key, label in SQL_CATEGORY_ORDER:
+        rows = buckets.get(key) or []
+        if not rows:
+            continue
+        lines.append(f"## {label}")
+        lines.append("")
+        for title, url, compat, desc in sorted(rows, key=lambda r: r[0].lower()):
+            suffix = f": {desc}" if desc else ""
+            lines.append(f"- [{title}]({url}) [{compat}]{suffix}")
+        lines.append("")
+
+    if uncategorised:
+        lines.append("## Uncategorised")
+        lines.append("")
+        for title, url, compat, desc in sorted(uncategorised, key=lambda r: r[0].lower()):
+            suffix = f": {desc}" if desc else ""
+            lines.append(f"- [{title}]({url}) [{compat}]{suffix}")
+        lines.append("")
+
+    return lines
 
 
 _FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---\s*\n", re.DOTALL)

--- a/docs/hooks/agent_delivery.py
+++ b/docs/hooks/agent_delivery.py
@@ -58,50 +58,104 @@ COMPAT_TAG = {
 # it as None to auto-derive from the page's frontmatter/first paragraph.
 FEATURED_PAGES = [
     ("Docs", [
-        ("MatrixOne/Overview/matrixone-introduction.md", None),
-        ("MatrixOne/Overview/matrixone-feature-list.md", None),
-        ("MatrixOne/Get-Started/install-standalone-matrixone.md", None),
+        ("MatrixOne/Overview/matrixone-introduction.md",
+         "What MatrixOne is: a hyper-converged cloud-native HSTAP database that unifies OLTP, OLAP, streaming, and vector/full-text workloads in one engine."),
+        ("MatrixOne/Overview/matrixone-feature-list.md",
+         "Feature list at a glance — what's supported today vs on the roadmap."),
+        ("MatrixOne/Get-Started/install-standalone-matrixone.md",
+         "Single-node install walkthrough — fastest path to a running instance for trying things out."),
         ("MatrixOne/Reference/SQL-Reference/SQL-Type.md",
-         "SQL statement taxonomy — entry point for every supported statement"),
+         "SQL statement taxonomy — entry point for every supported statement."),
         (COMPAT_MATRIX_REL,
-         "MySQL 8.0 compatibility status per SQL statement — consult first"),
+         "MySQL 8.0 compatibility status per SQL statement — consult first before assuming syntax works."),
+        ("MatrixOne/Reference/Data-Types/data-types.md",
+         "All supported data types, including MatrixOne-specific `VECF32` / `VECF64` vectors and `DATALINK`."),
+        ("MatrixOne/Reference/Variable/system-variables/system-variables-overview.md",
+         "System variables reference — session/global toggles that change SQL behaviour."),
+        ("MatrixOne/Reference/System-Parameters/system-parameter.md",
+         "Server configuration parameters (static startup-time + dynamic) for tuning the engine."),
+    ]),
+    ("Core Capabilities", [
+        ("MatrixOne/Overview/feature/key-feature-htap.md",
+         "HTAP: run transactional and analytical workloads against the same data without ETL."),
+        ("MatrixOne/Tutorial/git4data-demo.md",
+         "Git-for-Data branching workflow: create/diff/merge data branches just like code branches — the MatrixOne differentiator for agent-safe experiments."),
+        ("MatrixOne/Maintain/backup-restore/mobr-backup-restore/mobr-snapshot-backup-restore.md",
+         "Snapshot-based backup & restore — cluster/tenant/database/table scope, copy-on-write semantics."),
+        ("MatrixOne/Maintain/backup-restore/mobr-backup-restore/mobr-pitr-backup-restore.md",
+         "Point-in-time recovery (PITR) — restore to an arbitrary timestamp within the configured retention window."),
+        ("MatrixOne/Tutorial/efficient-clone-demo.md",
+         "CREATE CLONE: instant copy-on-write table/database clones, including across tenants."),
+        ("MatrixOne/Develop/Vector/vector_search.md",
+         "Vector search with `VECF32` / `VECF64`, L2/cosine/IP distance, IVFFLAT and HNSW indexes."),
+        ("MatrixOne/Reference/SQL-Reference/Data-Definition-Language/create-fulltext-index.md",
+         "Full-text indexing — natural-language, boolean, and JSON search modes."),
+        ("MatrixOne/Tutorial/hybrid-search-demo.md",
+         "Hybrid retrieval: combine vector search with full-text and scalar filters in a single query — the RAG-friendly pattern."),
     ]),
     ("SDK & Drivers", [
         ("MatrixOne/Develop/connect-mo/python-connect-to-matrixone.md",
-         "Python client setup (PyMySQL / SQLAlchemy)"),
+         "Python client setup (PyMySQL / SQLAlchemy)."),
         ("MatrixOne/Develop/connect-mo/java-connect-to-matrixone/connect-mo-with-jdbc.md",
-         "Java/JDBC client setup"),
+         "Java/JDBC client setup."),
         ("MatrixOne/Develop/connect-mo/connect-to-matrixone-with-go.md",
-         "Go client setup"),
+         "Go client setup (`database/sql` + driver)."),
+    ]),
+    ("Data In / Out", [
+        ("MatrixOne/Develop/import-data/bulk-load/bulk-load-overview.md",
+         "Bulk load overview: `LOAD DATA` for CSV/JSONL, `SOURCE` for SQL dumps, S3-backed external ingestion."),
+        ("MatrixOne/Develop/import-data/bulk-load/load-s3.md",
+         "Load directly from S3-compatible object storage via stages."),
+        ("MatrixOne/Reference/SQL-Reference/Data-Definition-Language/create-external-table.md",
+         "External tables: query CSV/Parquet/S3 data in place without ingestion."),
+        ("MatrixOne/Develop/export-data/select-into-outfile.md",
+         "Export query results via `SELECT ... INTO OUTFILE` to local files or S3 stages."),
+    ]),
+    ("Migrate", [
+        ("MatrixOne/Migrate/migrate-overview.md",
+         "Migration overview: tools and workflows for moving from MySQL / PostgreSQL / Oracle / SQL Server to MatrixOne."),
+        ("MatrixOne/Migrate/migrate-from-mysql-to-matrixone.md",
+         "MySQL → MatrixOne migration — the most common path, leverages MySQL wire-protocol compatibility."),
     ]),
     ("Operate", [
-        ("MatrixOne/Deploy/deploy-MatrixOne-cluster.md", None),
-        ("MatrixOne/Maintain/backup-restore/backup-restore-overview.md", None),
+        ("MatrixOne/Deploy/deploy-MatrixOne-cluster.md",
+         "Distributed cluster deployment on Kubernetes — separates storage, compute, and transaction."),
+        ("MatrixOne/Maintain/backup-restore/backup-restore-overview.md",
+         "Backup & restore strategy overview — snapshot, PITR, and `mo_br` tool."),
     ]),
     ("Optional", [
         ("MatrixOne/Overview/architecture/matrixone-architecture-design.md",
-         "HSTAP architecture deep dive — storage/compute/transaction split"),
-        ("MatrixOne/Performance-Tuning/performance-tuning-overview.md", None),
+         "HSTAP architecture deep dive — storage/compute/transaction split, TAE engine, log service, proxy."),
+        ("MatrixOne/Performance-Tuning/performance-tuning-overview.md",
+         "Performance tuning methods — query plan reading, indexing, statistics, resource controls."),
         ("MatrixOne/Troubleshooting/error-code.md",
-         "Error code taxonomy — look up any 5-character error code"),
+         "Error code taxonomy — look up any 5-character error code."),
     ]),
 ]
 
 SYSTEM_PROMPT_BLOCK = (
-    "MatrixOne is a cloud-native HTAP database broadly MySQL 8.0 compatible, "
-    "but not every MySQL 8.0 feature is supported. Before assuming syntax "
-    "works, consult the MySQL Compatibility Matrix at "
-    "/MatrixOne/Reference/mysql-compatibility-matrix.md. Use `SHOW CREATE "
-    "TABLE` to confirm schema shape; system tables differ from MySQL. SQL "
-    "examples on these pages are validated against the latest 3.0-dev image "
-    "via `scripts/doc-validator`."
+    "MatrixOne is a cloud-native HSTAP database unifying OLTP, OLAP, streaming, "
+    "vector, and full-text workloads in one engine. It is broadly MySQL 8.0 "
+    "wire-protocol compatible, but not all MySQL features are supported — "
+    "always verify against the MySQL Compatibility Matrix. SQL examples on "
+    "these pages are executed against the latest 3.0-dev image by "
+    "`scripts/doc-validator` on every pull request."
+)
+
+# Short routing hint shown after the header bullets so agents know which
+# artifact to pull for which kind of question.
+AGENT_ROUTING = (
+    "Agent routing: writing or debugging SQL → pull `llms-sql.txt` for the "
+    "flat per-statement catalogue; broad conceptual questions → this file; "
+    "long-context offline reading → `llms-full.txt`; authoritative diffs "
+    "from MySQL → the MySQL Compatibility Matrix linked above."
 )
 
 # Behavioural directives kept here so they survive prompt-review sweeps.
 # Each entry should be one actionable line.
 AGENT_HINTS = [
     "Not all MySQL 8.0 features are supported — consult the compatibility matrix before assuming syntax works.",
-    "Prefer MatrixOne-native clauses when documented: `CLUSTER BY`, `AS OF TIMESTAMP`, `USING IVFFLAT`/`USING HNSW`, `CLONE`, `PITR`.",
+    "Prefer MatrixOne-native clauses when documented: `CLUSTER BY`, `AS OF TIMESTAMP`, `USING IVFFLAT`/`USING HNSW`, `CLONE`, `PITR`, `SNAPSHOT`.",
     "Use `SHOW CREATE TABLE <name>` to inspect a table before mutating it; system tables differ from MySQL.",
     "Vector indexes (`USING IVFFLAT`, `USING HNSW`) must be declared via `CREATE INDEX`, not `ALTER TABLE ADD INDEX`.",
     "Secondary indexes are syntactically accepted but do not yet accelerate queries — do not rely on them for performance.",
@@ -109,7 +163,9 @@ AGENT_HINTS = [
     "Tables created with `CLUSTER BY` and temporary tables cannot be altered — plan schema shape up front.",
     "`CREATE DATABASE` supports only `utf8mb4` / `utf8mb4_bin`; the `ENCRYPTION` clause is accepted but inert.",
     "Foreign keys do not support `ON CASCADE DELETE`.",
+    "`LOAD DATA INFILE` expects a local absolute path or a stage URL (e.g. `stage://my_stage/file.csv`) — relative paths and MySQL-style secure-file-priv do not apply.",
     "Use `CREATE SNAPSHOT` / `PITR` / `CREATE CLONE` for point-in-time and copy-on-write workflows rather than MySQL's binlog tooling.",
+    "For agent-safe experiments, prefer a data branch (`DATA BRANCH CREATE` → test → `DATA BRANCH DIFF` → `DATA BRANCH MERGE` / delete) over mutating shared tables in place.",
 ]
 
 
@@ -150,6 +206,8 @@ def on_post_build(config, **_kwargs):
     llms.append(f"- **Full SQL reference (flat index, all statements)**: {base}/llms-sql.txt")
     llms.append(f"- **Full corpus**: {base}/llms-full.txt")
     llms.append(f"- **Generated**: {built_at} (UTC)")
+    llms.append("")
+    llms.append(AGENT_ROUTING)
     llms.append("")
     llms.append("Hints for AI agents writing MatrixOne SQL:")
     llms.append("")

--- a/docs/hooks/agent_delivery.py
+++ b/docs/hooks/agent_delivery.py
@@ -4,12 +4,15 @@ Produces three things so LLM-driven clients (Cursor, Claude Code, ChatGPT,
 MCP servers, etc.) can consume the MatrixOne docs without parsing HTML:
 
 1. **Per-page markdown mirror.** Every source `docs/MatrixOne/**/*.md` file
-   is copied into `site/` at the same relative location (minus the
-   `MatrixOne/` prefix that the mkdocs nav already strips). Frontmatter is
+   is copied into `site/` at the same relative location. Frontmatter is
    preserved as-is — it's cheap metadata for downstream tools.
 2. **`site/llms.txt`**. A concise llmstxt.org-format index pointing at the
-   most load-bearing pages (Overview → Get Started → Reference) plus a
-   blockquote of behavioural directives for SQL-writing agents.
+   most load-bearing pages. Section titles come from the page's `title:`
+   frontmatter (or first H1); one-line descriptions come from the page's
+   `description:` frontmatter with a first-paragraph fallback, so editing a
+   doc keeps llms.txt fresh without touching this file. The header carries
+   a blockquote of behavioural directives for SQL-writing agents and a
+   direct pointer to the MySQL Compatibility Matrix.
 3. **`site/llms-full.txt`**. The whole corpus concatenated into one file so
    agents can stuff the full docs into a single context window when needed.
 
@@ -20,42 +23,48 @@ Override the base URL via `MATRIXONE_DOCS_BASE_URL` env var. Defaults to
 from __future__ import annotations
 
 import os
+import re
 import shutil
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Iterable
 
 BASE_URL_DEFAULT = "https://docs.matrixorigin.io"
 DOC_ROOT_REL = Path("MatrixOne")
+COMPAT_MATRIX_REL = "MatrixOne/Reference/mysql-compatibility-matrix.md"
+MAX_AUTO_DESC_CHARS = 160
 
 # Curated list of top-tier pages to highlight in llms.txt. Paths are relative
-# to `docs/` (same as the rest of the mkdocs config). Order matters: items
-# appear in the listed sequence in the output.
+# to `docs/`. Second tuple element is an optional description override; leave
+# it as None to auto-derive from the page's frontmatter/first paragraph.
 FEATURED_PAGES = [
     ("Docs", [
-        ("MatrixOne/Overview/matrixone-introduction.md",
-         "What MatrixOne is and when to pick it"),
-        ("MatrixOne/Overview/matrixone-feature-list.md",
-         "Feature list at a glance"),
-        ("MatrixOne/Get-Started/install-standalone-matrixone.md",
-         "Single-node install walkthrough"),
+        ("MatrixOne/Overview/matrixone-introduction.md", None),
+        ("MatrixOne/Overview/matrixone-feature-list.md", None),
+        ("MatrixOne/Get-Started/install-standalone-matrixone.md", None),
         ("MatrixOne/Reference/SQL-Reference/SQL-Type.md",
-         "SQL statement taxonomy"),
-        ("MatrixOne/Reference/mysql-compatibility-matrix.md",
-         "MySQL 8.0 compatibility status per SQL statement"),
+         "SQL statement taxonomy — entry point for every supported statement"),
+        (COMPAT_MATRIX_REL,
+         "MySQL 8.0 compatibility status per SQL statement — consult first"),
     ]),
     ("SDK & Drivers", [
         ("MatrixOne/Develop/connect-mo/python-connect-to-matrixone.md",
-         "Python client setup"),
+         "Python client setup (PyMySQL / SQLAlchemy)"),
         ("MatrixOne/Develop/connect-mo/java-connect-to-matrixone/connect-mo-with-jdbc.md",
          "Java/JDBC client setup"),
         ("MatrixOne/Develop/connect-mo/connect-to-matrixone-with-go.md",
          "Go client setup"),
     ]),
     ("Operate", [
-        ("MatrixOne/Deploy/deploy-MatrixOne-cluster.md",
-         "Cluster deployment overview"),
-        ("MatrixOne/Maintain/backup-restore/backup-restore-overview.md",
-         "Backup & restore strategy"),
+        ("MatrixOne/Deploy/deploy-MatrixOne-cluster.md", None),
+        ("MatrixOne/Maintain/backup-restore/backup-restore-overview.md", None),
+    ]),
+    ("Optional", [
+        ("MatrixOne/Overview/architecture/matrixone-architecture-design.md",
+         "HSTAP architecture deep dive — storage/compute/transaction split"),
+        ("MatrixOne/Performance-Tuning/performance-tuning-overview.md", None),
+        ("MatrixOne/Troubleshooting/error-code.md",
+         "Error code taxonomy — look up any 5-character error code"),
     ]),
 ]
 
@@ -68,6 +77,21 @@ SYSTEM_PROMPT_BLOCK = (
     "examples on these pages are validated against the latest 3.0-dev image "
     "via `scripts/doc-validator`."
 )
+
+# Behavioural directives kept here so they survive prompt-review sweeps.
+# Each entry should be one actionable line.
+AGENT_HINTS = [
+    "Not all MySQL 8.0 features are supported — consult the compatibility matrix before assuming syntax works.",
+    "Prefer MatrixOne-native clauses when documented: `CLUSTER BY`, `AS OF TIMESTAMP`, `USING IVFFLAT`/`USING HNSW`, `CLONE`, `PITR`.",
+    "Use `SHOW CREATE TABLE <name>` to inspect a table before mutating it; system tables differ from MySQL.",
+    "Vector indexes (`USING IVFFLAT`, `USING HNSW`) must be declared via `CREATE INDEX`, not `ALTER TABLE ADD INDEX`.",
+    "Secondary indexes are syntactically accepted but do not yet accelerate queries — do not rely on them for performance.",
+    "`ALTER TABLE` cannot combine column-level clauses (CHANGE/MODIFY/RENAME COLUMN, ADD/DROP PK) with other clauses; split into separate statements.",
+    "Tables created with `CLUSTER BY` and temporary tables cannot be altered — plan schema shape up front.",
+    "`CREATE DATABASE` supports only `utf8mb4` / `utf8mb4_bin`; the `ENCRYPTION` clause is accepted but inert.",
+    "Foreign keys do not support `ON CASCADE DELETE`.",
+    "Use `CREATE SNAPSHOT` / `PITR` / `CREATE CLONE` for point-in-time and copy-on-write workflows rather than MySQL's binlog tooling.",
+]
 
 
 def _base_url() -> str:
@@ -97,21 +121,32 @@ def on_post_build(config, **_kwargs):
 
     # 2. llms.txt
     base = _base_url()
-    llms = ["# MatrixOne", ""]
+    compat_url = f"{base}/{COMPAT_MATRIX_REL}"
+    built_at = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    llms: list[str] = ["# MatrixOne", ""]
     llms.append(f"> {SYSTEM_PROMPT_BLOCK}")
+    llms.append("")
+    llms.append(f"- **MySQL Compatibility Matrix**: {compat_url}")
+    llms.append(f"- **Per-page markdown mirror**: append `.md` to any doc URL under {base}/")
+    llms.append(f"- **Full corpus**: {base}/llms-full.txt")
+    llms.append(f"- **Generated**: {built_at} (UTC)")
     llms.append("")
     llms.append("Hints for AI agents writing MatrixOne SQL:")
     llms.append("")
-    llms.append("- Not all MySQL 8.0 features are supported — consult the compatibility matrix.")
-    llms.append("- Prefer MatrixOne-native clauses when documented (`CLUSTER BY`, `AS OF TIMESTAMP`, `USING IVFFLAT`, `CLONE`).")
-    llms.append("- Use `SHOW CREATE TABLE <name>` to inspect a table before mutating it.")
+    for hint in AGENT_HINTS:
+        llms.append(f"- {hint}")
     llms.append("")
     for section_title, entries in FEATURED_PAGES:
         llms.append(f"## {section_title}")
-        for rel_path, desc in entries:
+        for rel_path, override in entries:
             url = f"{base}/{rel_path}"
-            title = _page_title(docs_dir / rel_path) or rel_path
-            llms.append(f"- [{title}]({url}): {desc}")
+            src_path = docs_dir / rel_path
+            title = _page_title(src_path) or rel_path
+            desc = override or _page_description(src_path) or ""
+            if desc:
+                llms.append(f"- [{title}]({url}): {desc}")
+            else:
+                llms.append(f"- [{title}]({url})")
         llms.append("")
     (site_dir / "llms.txt").write_text("\n".join(llms), encoding="utf-8")
 
@@ -137,6 +172,7 @@ def on_post_build(config, **_kwargs):
         "# MatrixOne — Full Documentation",
         "",
         "Source: " + base,
+        f"Generated: {built_at} (UTC)",
         "",
         SYSTEM_PROMPT_BLOCK,
         "",
@@ -169,21 +205,97 @@ def on_post_build(config, **_kwargs):
     print(f"[agent-delivery] emitted llms.txt and llms-full.txt ({len(seen)} pages)")
 
 
-def _page_title(md_path: Path) -> str | None:
+_FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---\s*\n", re.DOTALL)
+_MD_LINK_RE = re.compile(r"\[([^\]]+)\]\([^)]+\)")
+_MD_EMPHASIS_RE = re.compile(r"\*\*([^*]+)\*\*|\*([^*]+)\*|`([^`]+)`")
+
+
+def _read(md_path: Path) -> str | None:
     if not md_path.exists():
         return None
-    text = md_path.read_text(encoding="utf-8", errors="replace")
-    # Prefer explicit `title:` frontmatter; fall back to first H1.
-    if text.startswith("---"):
-        end = text.find("\n---", 3)
-        if end != -1:
-            frontmatter = text[3:end]
-            for line in frontmatter.splitlines():
-                if line.startswith("title:"):
-                    raw = line.split(":", 1)[1].strip()
-                    return raw.strip('"\'')
-    for line in text.splitlines():
+    return md_path.read_text(encoding="utf-8", errors="replace")
+
+
+def _split_frontmatter(text: str) -> tuple[dict[str, str], str]:
+    """Return (frontmatter_dict, body). Accepts only flat scalar frontmatter —
+    nested lists/dicts (e.g. `differs_from_mysql:`) are ignored.
+    """
+    m = _FRONTMATTER_RE.match(text)
+    if not m:
+        return {}, text
+    fm: dict[str, str] = {}
+    for line in m.group(1).splitlines():
+        if not line or line.startswith((" ", "\t", "-", "#")):
+            continue
+        if ":" not in line:
+            continue
+        key, _, raw = line.partition(":")
+        fm[key.strip()] = raw.strip().strip('"\'')
+    return fm, text[m.end():]
+
+
+def _page_title(md_path: Path) -> str | None:
+    text = _read(md_path)
+    if text is None:
+        return None
+    fm, body = _split_frontmatter(text)
+    if fm.get("title"):
+        return fm["title"]
+    for line in body.splitlines():
         line = line.strip()
         if line.startswith("# "):
             return line[2:].strip().replace("**", "")
     return None
+
+
+def _page_description(md_path: Path) -> str | None:
+    """Derive a one-line description: prefer `description:` or `summary:`
+    frontmatter; fall back to the first non-heading, non-code paragraph, with
+    markdown emphasis/link markup flattened and truncated to MAX_AUTO_DESC_CHARS.
+    """
+    text = _read(md_path)
+    if text is None:
+        return None
+    fm, body = _split_frontmatter(text)
+    for key in ("description", "summary"):
+        if fm.get(key):
+            return _clip(fm[key])
+
+    in_code = False
+    paragraph: list[str] = []
+    for raw in body.splitlines():
+        line = raw.strip()
+        if line.startswith("```"):
+            in_code = not in_code
+            continue
+        if in_code:
+            continue
+        if not line:
+            if paragraph:
+                break
+            continue
+        if line.startswith(("#", ">", "|", "-", "*", "!", "<")):
+            # Skip headings, blockquotes, tables, lists, images, HTML.
+            continue
+        paragraph.append(line)
+
+    if not paragraph:
+        return None
+    return _clip(" ".join(paragraph))
+
+
+def _clip(text: str) -> str:
+    cleaned = _MD_LINK_RE.sub(r"\1", text)
+    cleaned = _MD_EMPHASIS_RE.sub(lambda m: next(g for g in m.groups() if g), cleaned)
+    cleaned = " ".join(cleaned.split())
+    # Strip a trailing colon that usually introduces a now-dropped list.
+    cleaned = cleaned.rstrip(":").rstrip()
+    if len(cleaned) <= MAX_AUTO_DESC_CHARS:
+        return cleaned
+    clipped = cleaned[:MAX_AUTO_DESC_CHARS]
+    # Back up to the last sentence boundary or space to avoid mid-word cuts.
+    for boundary in (". ", "; ", ", ", " "):
+        idx = clipped.rfind(boundary)
+        if idx > MAX_AUTO_DESC_CHARS * 0.6:
+            return clipped[:idx].rstrip(",;. ") + "…"
+    return clipped.rstrip() + "…"


### PR DESCRIPTION
## What type of PR is this?
                                                                                                                                  
  - [x] Enhancement                                                                                                                                    
  - [ ] Displaying                                                                                                                                     
  - [ ] Typo                                                                                                                                           
  - [ ] Doc Request                                                                                                                                    
                                                                                                                                                       
  ## Which issue(s) this PR fixes:                                                                                                                     
                                                                                                                                                       
  issue #                                                   

  ## What this PR does / why we need it:

  Enriches the agent-facing artifacts emitted by `docs/hooks/agent_delivery.py` so that LLM-driven clients (Cursor, Claude Code, ChatGPT, MCP servers) 
  can consume MatrixOne docs with higher signal density and zero per-edit code changes.
                                                                                                                                                       
  ### Changes                                                                                                                                          
   
  **1. `llms.txt` header & routing (commit `0b1f7d9a`)**                                                                                               
                                                            
  - One-line descriptions in `FEATURED_PAGES` become optional overrides; when omitted, the hook auto-derives from each page's `description:` /         
  `summary:` frontmatter, falling back to the first non-heading paragraph (clipped at 160 chars, trailing colon stripped). Editing a doc keeps
  `llms.txt` fresh without touching the hook.                                                                                                          
  - Header bullets now expose: direct link to the MySQL Compatibility Matrix, per-page `.md` mirror convention, link to `llms-full.txt`, UTC build
  date.                                                                                                                                                
  - Agent-hint list grows from 3 to 10 lines covering vector index declaration, `ALTER TABLE` clause restrictions, `CLUSTER BY` / temp-table
  immutability, charset/collation limits, inert `ENCRYPTION`, FK `ON CASCADE DELETE`, and `SNAPSHOT` / `PITR` / `CLONE` as the MySQL-binlog            
  replacement.                                              
  - New "Optional" section surfaces architecture deep-dive, performance tuning overview, and the error-code taxonomy.                                  
                                                                                                                                                       
  **2. New `llms-sql.txt` flat index (commit `8a215312`)**                                                                                             
                                                                                                                                                       
  - Flattens every `docs/MatrixOne/Reference/SQL-Reference/**/*.md` page into one bullet per statement, grouped by DDL / DML / DQL / DCL / Other, each 
  tagged `[full]` / `[partial]` / `[mo-only]` / `[none]` / `[unknown]` from existing `mysql_compat` frontmatter — no new metadata to maintain.
  - Linked from `llms.txt` as the canonical SQL discovery route, complementing the grouped-table compatibility matrix.                                 
  - Current build: 126 statements — distribution (38 full / 35 partial / 53 mo-only) matches the compatibility matrix exactly.                         
                                                                                                                                                       
  **3. Curated entries expansion (commit `7c2fe7c9`)**                                                                                                 
                                                                                                                                                       
  - `Docs`: add Data Types overview, System Variables overview, System Parameters overview so agents can pick types and tune the engine without        
  crawling `Reference/`.                                    
  - **New `Core Capabilities` section** highlighting MatrixOne differentiators: HTAP, Git-for-Data branches, Snapshot, PITR, CLONE, vector search,     
  full-text search, hybrid search.                                                                                                                     
  - **New `Data In / Out` section**: bulk load overview, S3 ingestion, external tables, `SELECT INTO OUTFILE`.
  - **New `Migrate` section**: migration overview + MySQL path.                                                                                        
  - `SYSTEM_PROMPT_BLOCK` rewritten as a compact positioning blurb (the repeated compat-matrix pointer moved to the header bullets).                   
  - `AGENT_ROUTING` line tells agents which artifact to pull per task (SQL → `llms-sql.txt`; concepts → `llms.txt`; long-context → `llms-full.txt`;    
  MySQL diffs → compat matrix).                                                                                                                        
  - `AGENT_HINTS` extended with `LOAD DATA INFILE` path semantics (stage URLs vs absolute paths) and the `DATA BRANCH CREATE` → `DIFF` → `MERGE`       
  safe-experiment workflow.                                                                                                                            
                                                            
  ### Why                                                                                                                                              
                                                            
  The existing `llms.txt` was 43 lines / 13 entries with hard-coded one-line descriptions, required code edits whenever a new high-value page shipped, 
  and did not surface MatrixOne's differentiators (Git-for-Data, vector, PITR, CLONE). Agents consuming it had no flat catalogue of SQL statements
  either — they had to parse the compatibility-matrix markdown table or crawl `SQL-Type.md`. These changes route agents to the right artifact for the  
  task, surface the core capabilities narrative up front, and cut future per-edit maintenance.

  ### Resulting artifacts

  | File | Before | After |
  |---|---|---|
  | `site/llms.txt` | 43 lines, 13 entries, 4 sections | 70 lines, 27 entries, 7 sections |
  | `site/llms-sql.txt` | — | 151 lines, 126 statements, 5 categories |                                                                                
  | `site/llms-full.txt` | 88k lines (unchanged generation logic) | 88k lines |                                                                        
  | `site/**/*.md` mirror | 652 pages (unchanged) | 652 pages |