### PR TITLE
docs: Downgrade validator-ignore to validator-ignore-exec for SQL blocks

### DIFF
--- a/docs/MatrixOne/Develop/Ecological-Tools/BI-Connection/FineBI-connection.md
+++ b/docs/MatrixOne/Develop/Ecological-Tools/BI-Connection/FineBI-connection.md
@@ -101,7 +101,7 @@ MatrixOne supports integration with the data visualization tool FineBI. This art
     !!! note
         Please note that the path `/root/data/table_name.csv` is the path to the data files for each table. You can generate your data following a similar process.
 
-    ```sql <!-- validator-ignore -->
+    ```sql <!-- validator-ignore-exec -->
     use orders;
     load data local infile '/root/data/category.csv' into table category FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '"' LINES TERMINATED BY "\r\n";
     load data local infile '/root/data/review.csv' into table review FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '"' LINES TERMINATED BY "\r\n";

--- a/docs/MatrixOne/Develop/Ecological-Tools/Computing-Engine/Flink/flink-mongo-matrixone.md
+++ b/docs/MatrixOne/Develop/Ecological-Tools/Computing-Engine/Flink/flink-mongo-matrixone.md
@@ -136,7 +136,7 @@ CREATE TABLE cdc_matrixone (
 
 Once the sync task is turned on here, mongodb additions and deletions can be synchronized
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 INSERT INTO cdc_matrixone SELECT `name`,age FROM products;
 ```

--- a/docs/MatrixOne/Develop/Ecological-Tools/Computing-Engine/Flink/flink-postgresql-matrixone.md
+++ b/docs/MatrixOne/Develop/Ecological-Tools/Computing-Engine/Flink/flink-postgresql-matrixone.md
@@ -142,7 +142,7 @@ CREATE TABLE test_pg (
 
 ### Importing PostgreSQL data into MatrixOne
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 insert into test_pg select * from pgsql_bog; 
 ```
@@ -167,7 +167,7 @@ Data can be found to have been imported
 
 ### Adding data to postgrsql
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 insert into public.student values (51, '58', 39, '2020-01-03'); 
 ```
@@ -193,7 +193,7 @@ You can find that the data has been synchronized to the MatrixOne correspondence
 
 To delete data:
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 delete from public.student where stu_id=1; 
 ```

--- a/docs/MatrixOne/Develop/Vector/ivf_rank_options.md
+++ b/docs/MatrixOne/Develop/Vector/ivf_rank_options.md
@@ -6,7 +6,7 @@ When performing vector similarity search using IVF (Inverted File) indexes, Matr
 
 ## Syntax
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 SELECT column_list
 FROM table_name

--- a/docs/MatrixOne/Develop/Vector/vector_search.md
+++ b/docs/MatrixOne/Develop/Vector/vector_search.md
@@ -36,7 +36,7 @@ The Iris dataset is a well-known multi-class taxonomic dataset that can be searc
 
     Prepare a table named `iris_table` and the corresponding Iris dataset data. The dataset has 150 rows of data, each row consisting of a four-dimensional eigenvector and species.
 
-    ```sql <!-- validator-ignore -->
+    ```sql <!-- validator-ignore-exec -->
     CREATE TABLE iris_table(
         species varchar(100), -- category
         attributes vecf64(4) -- feature
@@ -46,7 +46,7 @@ The Iris dataset is a well-known multi-class taxonomic dataset that can be searc
 
 2. Use KNN to predict the category of this input feature
 
-    ```sql <!-- validator-ignore -->
+    ```sql <!-- validator-ignore-exec -->
     mysql>  select * from iris_table order by l2_distance(attributes,"[4,3.3,3,0.9]") asc limit 1;
     +------------------+--------------------+
     | species          | attributes         |

--- a/docs/MatrixOne/Develop/distinct-data/bitmap.md
+++ b/docs/MatrixOne/Develop/distinct-data/bitmap.md
@@ -32,7 +32,7 @@ According to the above scenario one design case,the behavior patterns of differe
 
 Prepare a table named `user_behavior_table` and the corresponding csv data, which has 39270760 rows of data.
 
-```sql <!-- validator-ignore -->
+```sql <!-- validator-ignore-exec -->
 CREATE TABLE user_behavior_table(
 user_id int, -- user id
 behavior varchar(100), -- behavior, including browser,purchase,returns
@@ -46,7 +46,7 @@ LOAD DATA INFILE '/your_path/user_behavior_table.csv' INTO TABLE user_behavior_t
 
 The coarse-grained calculation results are saved in the pre-computed table.Subsequent aggregation of various different dimensions can use the results in the pre-computed table.After simple calculation,the results can be obtained and the query can be accelerated.
 
-```sql <!-- validator-ignore -->
+```sql <!-- validator-ignore-exec -->
 CREATE TABLE precompute AS
 SELECT
   behavior,
@@ -61,7 +61,7 @@ GROUP BY  behavior,occur_year,bucket;
 
 Calculates the number of deduplications for user\_id in case of user behavior and year aggregation, reflecting the number of users who browsed, purchased, and returned items in different years.
 
-```sql <!-- validator-ignore -->
+```sql <!-- validator-ignore-exec -->
 mysql> SELECT
     ->     behavior,
     ->     occur_year,
@@ -96,7 +96,7 @@ mysql> select behavior,occur_year,count(distinct user_id) from user_behavior_tab
 
 Calculate the number of users viewing, purchasing, and returning items from 2022-2023.
 
-```sql <!-- validator-ignore -->
+```sql <!-- validator-ignore-exec -->
 mysql> SELECT behavior, SUM(cnt) FROM (
     -> SELECT
     -> behavior,

--- a/docs/MatrixOne/Develop/export-data/select-into-outfile.md
+++ b/docs/MatrixOne/Develop/export-data/select-into-outfile.md
@@ -94,7 +94,7 @@ sudo docker run --name <name> --privileged -d -p 6001:6001 -v ${local_data_path}
 
     - Export to file system stage
 
-    <!-- validator-ignore -->
+    <!-- validator-ignore-exec -->
     ```sql
     create stage stage_fs url = 'file:///Users/admin/test';
     select * from user into outfile 'stage://stage_fs/user.csv';

--- a/docs/MatrixOne/Develop/import-data/bulk-load/load-jsonline.md
+++ b/docs/MatrixOne/Develop/import-data/bulk-load/load-jsonline.md
@@ -175,7 +175,7 @@ In this tutorial, we will guide you through loading two jsonline files with obje
 
 5. Execute `LOAD DATA` with the corresponding file path in MySQL client, import the *jsonline_object.jl*  and the file *jsonline_array.jl* into MatrixOne:
 
-    ```sql <!-- validator-ignore -->
+    ```sql <!-- validator-ignore-exec -->
     load data infile {'filepath'='$filepath/jsonline_object.jl','format'='jsonline','jsondata'='object'} into table t1;
     load data infile {'filepath'='$filepath/jsonline_array.jl','format'='jsonline','jsondata'='array'} into table t2;
     ```

--- a/docs/MatrixOne/Develop/import-data/bulk-load/load-s3.md
+++ b/docs/MatrixOne/Develop/import-data/bulk-load/load-s3.md
@@ -100,7 +100,7 @@ In this tutorial, we will walk you through the process of loading a **.csv** fil
 
 5. After the import is successful, you can run SQL statements to check the result of imported data:
 
-    ```sql <!-- validator-ignore -->
+    ```sql <!-- validator-ignore-exec -->
     mysql> select * from t1;
     +-----------+-----------+-----------+-----------+
     | col1      | col2      | col3      | col4      |

--- a/docs/MatrixOne/Develop/import-data/bulk-load/load-s3.md
+++ b/docs/MatrixOne/Develop/import-data/bulk-load/load-s3.md
@@ -45,7 +45,7 @@ The other paramaters are identical to a ordinary LOAD DATA, see [LOAD DATA](../.
 
 **Statement Examples**:
 
-```sql <!-- validator-ignore -->
+```sql <!-- validator-ignore-exec -->
 # LOAD a csv file from AWS S3 us-east-1 region, test-load-mo bucket, without compression
 LOAD DATA URL s3option{"endpoint"='s3.us-east-1.amazonaws.com', "access_key_id"='XXXXXX', "secret_access_key"='XXXXXX', "bucket"='test-load-mo', "filepath"='test.csv', "region"='us-east-1', "compression"='none'} INTO TABLE t1 FIELDS TERMINATED BY ',' ENCLOSED BY '\"' LINES TERMINATED BY '\n';
 

--- a/docs/MatrixOne/Develop/read-data/multitable-join-query.md
+++ b/docs/MatrixOne/Develop/read-data/multitable-join-query.md
@@ -131,7 +131,7 @@ The join result of an inner join returns only rows that match the join condition
 
 There are two ways of writing an `inner join` that are completely equivalent in results:
 
-```sql <!-- validator-ignore -->
+```sql <!-- validator-ignore-exec -->
 mysql> SELECT   
     l_orderkey,
     SUM(l_extendedprice * (1 - l_discount)) AS revenue,
@@ -169,7 +169,7 @@ LIMIT 10;
 
 Write as `Join`, the syntax is as follows:
 
-```sql <!-- validator-ignore -->
+```sql <!-- validator-ignore-exec -->
 mysql> SELECT   
     l_orderkey,
     SUM(l_extendedprice * (1 - l_discount)) AS revenue,

--- a/docs/MatrixOne/Develop/read-data/multitable-join-query.md
+++ b/docs/MatrixOne/Develop/read-data/multitable-join-query.md
@@ -99,7 +99,7 @@ Make sure you have already [Deployed standalone MatrixOne](../../Get-Started/ins
 
 3. Load data into the created tables:
 
-    ```sql <!-- validator-ignore -->
+    ```sql <!-- validator-ignore-exec -->
     load data infile '/YOUR_TPCH_DATA_PATH/nation.tbl' into table NATION FIELDS TERMINATED BY '|' OPTIONALLY ENCLOSED BY '"' LINES TERMINATED BY '\n';
 
     load data infile '/YOUR_TPCH_DATA_PATH/region.tbl' into table REGION FIELDS TERMINATED BY '|' OPTIONALLY ENCLOSED BY '"' LINES TERMINATED BY '\n';

--- a/docs/MatrixOne/Develop/read-data/subquery.md
+++ b/docs/MatrixOne/Develop/read-data/subquery.md
@@ -141,7 +141,7 @@ Make sure you have already [Deployed standalone MatrixOne](../../Get-Started/ins
 
 3. Load data into the created tables:
 
-    ```sql <!-- validator-ignore -->
+    ```sql <!-- validator-ignore-exec -->
     load data infile '/YOUR_TPCH_DATA_PATH/nation.tbl' into table NATION FIELDS TERMINATED BY '|' OPTIONALLY ENCLOSED BY '"' LINES TERMINATED BY '\n';
 
     load data infile '/YOUR_TPCH_DATA_PATH/region.tbl' into table REGION FIELDS TERMINATED BY '|' OPTIONALLY ENCLOSED BY '"' LINES TERMINATED BY '\n';

--- a/docs/MatrixOne/Develop/udf/udf-python-advanced.md
+++ b/docs/MatrixOne/Develop/udf/udf-python-advanced.md
@@ -334,7 +334,7 @@ source /your_download_path/ddl.sql
 
 1. To create a udf function:
 
-    ```sql <!-- validator-ignore -->
+    ```sql <!-- validator-ignore-exec -->
     create or replace function py_detect(features json, amount decimal) 
     returns bool 
     language python 

--- a/docs/MatrixOne/Maintain/backup-restore/mobr-backup-restore/mobr-pitr-backup-restore.md
+++ b/docs/MatrixOne/Maintain/backup-restore/mobr-backup-restore/mobr-pitr-backup-restore.md
@@ -43,7 +43,7 @@ A large SaaS provider manages a multi-tenant environment that provides various s
 
 There are two tenants acc1 and acc2 under this system, which represent different customers. Each tenant has product information and order information.
   
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 create account acc1 admin_name 'root' identified by '111';
 create account acc2 admin_name 'root' identified by '111';
@@ -154,7 +154,7 @@ pitr3 2024-10-28 17:25:32 2024-10-28 17:25:32 account acc2 **10 h
 
 Due to an upgrade script error, both db1 and db2 under acc1 were deleted, db1 under acc2 was deleted, and the orders table data under db2 was cleared.
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 --Execute under acc1
 drop database db1;

--- a/docs/MatrixOne/Maintain/backup-restore/mobr-backup-restore/mobr-snapshot-backup-restore.md
+++ b/docs/MatrixOne/Maintain/backup-restore/mobr-backup-restore/mobr-snapshot-backup-restore.md
@@ -41,7 +41,7 @@ This document mainly introduces how to use `mo_br` to perform cluster/tenant lev
 
 - Connect to the Matrixone system tenant to execute table creation statements
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 create database if not exists snapshot_read;
 use snapshot_read;
@@ -67,7 +67,7 @@ sp_01 2024-05-10 02:06:08.01635 account sys
 
 - Connect to the Matrixone system tenant and delete some data in the table.
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 delete from snapshot_read.test_snapshot_read where a <= 50;
 
@@ -87,7 +87,7 @@ mysql> select count(*) from snapshot_read.test_snapshot_read;
 
 - Connect to the Matrixone system tenant to query the recovery status
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 mysql> select count(*) from snapshot_read.test_snapshot_read;
 +----------+
@@ -101,7 +101,7 @@ mysql> select count(*) from snapshot_read.test_snapshot_read;
 
 - Connect to the Matrixone system tenant to execute sql statements
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 create database if not exists snapshot_read;
 use snapshot_read;
@@ -138,7 +138,7 @@ sp_02 2024-05-10 02:47:15.638519 account sys
 
 - Connect to Matrixone system tenant to delete some data
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 delete from snapshot_read.test_snapshot_read where a <= 50;
 delete from snapshot_read.test_snapshot_read_1 where a >= 50;
@@ -167,7 +167,7 @@ mysql> select count(*) from snapshot_read.test_snapshot_read_1;
 
 - Connect to the Matrixone system tenant to query the recovery status
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 mysql> select count(*) from snapshot_read.test_snapshot_read;
 +----------+

--- a/docs/MatrixOne/Maintain/cdc/mo-mo.md
+++ b/docs/MatrixOne/Maintain/cdc/mo-mo.md
@@ -75,7 +75,7 @@ CREATE DATABASE analytics_db;
 
 Connect to the downstream MatrixOne to check full data synchronization.
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 mysql> SELECT * FROM analytics_db.analytics_activities;
 +-------------+---------+---------------+---------------------+---------+
@@ -100,7 +100,7 @@ UPDATE production_db.user_activities SET activity_type = 'logout' WHERE activity
 
 Connect to the downstream MatrixOne to check incremental data synchronization.
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 mysql> SELECT * FROM analytics_db.analytics_activities;
 +-------------+---------+---------------+---------------------+---------+

--- a/docs/MatrixOne/Maintain/cdc/mo-mysql.md
+++ b/docs/MatrixOne/Maintain/cdc/mo-mysql.md
@@ -37,7 +37,7 @@ INSERT INTO source_db.orders (order_id, customer_id, order_date, amount, status)
 
 ### Create Downstream Database
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 create database analytics_db;
 ```
@@ -78,7 +78,7 @@ Check task status.
 
 Connect to the downstream MySQL to verify full data synchronization.
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 mysql> select * from analytics_db.orders_backup;
 +----------+-------------+---------------------+--------+------------+
@@ -118,7 +118,7 @@ mysql> select * from source_db.orders;
 
 Connect to the downstream MySQL to verify incremental data synchronization.
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 mysql> select * from analytics_db.orders_backup;
 +----------+-------------+---------------------+--------+------------+
@@ -179,7 +179,7 @@ Manually resume the task.
 
 Connect to the downstream MySQL to verify checkpoint recovery.
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 mysql> select * from analytics_db.orders_backup;
 +----------+-------------+---------------------+--------+------------+

--- a/docs/MatrixOne/Overview/architecture/architecture-cold-hot-data-separation.md
+++ b/docs/MatrixOne/Overview/architecture/architecture-cold-hot-data-separation.md
@@ -24,7 +24,7 @@ The environment introduced in this chapter will be based on the environment of [
 
 1. Prepare a table named `pe` and the corresponding CSV data. This CSV data table is 35.8MB, with 1,048,575 rows of data. We will use the following SQL statement to create two databases and load the same data table into the `pe` table in both databases.
 
-    ```sql <!-- validator-ignore -->
+    ```sql <!-- validator-ignore-exec -->
     create database stock;
     drop table if exists stock.pe;
     create table stock.pe (
@@ -82,7 +82,7 @@ spec:
 
 After completing the above settings and starting the MatrixOne cluster, you can experience the effect of cache acceleration through the results of multiple queries. Here, you can run a full table scan of `stock.pe` multiple times in a row.
 
-```sql <!-- validator-ignore -->
+```sql <!-- validator-ignore-exec -->
 mysql> select * from stock.pe into outfile "test01.txt";
 Empty set (6.53 sec)
 
@@ -102,7 +102,7 @@ The above results show that the first query is noticeably slower because it need
 
 Next, you can alternate and run a full table scan of `stock.pe` and `stock2.pe` multiple times.
 
-```sql <!-- validator-ignore -->
+```sql <!-- validator-ignore-exec -->
 mysql> select * from stock2.pe into outfile "test05.txt";
 Empty set (5.84 sec)
 
@@ -130,7 +130,7 @@ In many business scenarios, we often need to accelerate the queries due to a lar
 
 For example, the following SQL query:
 
-```sql <!-- validator-ignore -->
+```sql <!-- validator-ignore-exec -->
 SELECT pe1.ts_code, pe1.pe, pe1.pb
 FROM stock2.pe as pe1
 WHERE pe1.pe = (SELECT min(pe2.pe)
@@ -142,7 +142,7 @@ DESC LIMIT 1;
 
 If not optimized, the execution speed is as follows:
 
-```sql <!-- validator-ignore -->
+```sql <!-- validator-ignore-exec -->
 SELECT pe1.ts_code, pe1.pe, pe1.pb
 FROM stock2.pe as pe1
 WHERE pe1.pe = (SELECT min(pe2.pe)
@@ -162,7 +162,7 @@ DESC LIMIT
 
 This SQL query only involves the query of the `stock2.pe` table. We can preheat the table data to the cache by pre-scanning the complete table data, so the query can significantly improve the speed of this SQL query.
 
-```sql <!-- validator-ignore -->
+```sql <!-- validator-ignore-exec -->
 mysql> select * from stock2.pe into outfile "test11.txt";
 Empty set (6.48 sec)
 

--- a/docs/MatrixOne/Overview/architecture/streaming.md
+++ b/docs/MatrixOne/Overview/architecture/streaming.md
@@ -54,7 +54,7 @@ CREATE STREAM STUDENTS (ID STRING KEY, SCORE INT)
 
 You can also query streams and connect them with other tables and materialized views, as shown below:
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 SELECT * FROM STUDENTS WHERE `rank` > 5;
 ```

--- a/docs/MatrixOne/Reference/Data-Types/data-types.md
+++ b/docs/MatrixOne/Reference/Data-Types/data-types.md
@@ -599,7 +599,7 @@ mysql> select * from t1;
 
 ### Example
 
-```sql <!-- validator-ignore -->
+```sql <!-- validator-ignore-exec -->
 drop table test01;
 create table test01 (col1 int, col2 datalink);
 create stage stage01 url='file:///Users/admin/case/';

--- a/docs/MatrixOne/Reference/Data-Types/datalink-type.md
+++ b/docs/MatrixOne/Reference/Data-Types/datalink-type.md
@@ -41,7 +41,7 @@ There is a file `t1.csv` under `/Users/admin/case`
 this is a test message
 ```
 
-```sql <!-- validator-ignore -->
+```sql <!-- validator-ignore-exec -->
 drop table test01;
 create table test01 (col1 int, col2 datalink);
 create stage stage01 url='file:///Users/admin/case/';

--- a/docs/MatrixOne/Reference/Functions-and-Operators/Other/load_file.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/Other/load_file.md
@@ -28,7 +28,7 @@ There is a file `t1.csv` under `/Users/admin/case`
 this is a test message
 ```
 
-```sql <!-- validator-ignore -->
+```sql <!-- validator-ignore-exec -->
 create table t1 (col1 int, col2 datalink);
 create stage stage1 url='file:///Users/admin/case/';
 insert into t1 values (1, 'file:///Users/admin/case/t1.csv');

--- a/docs/MatrixOne/Reference/Functions-and-Operators/Other/sleep.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/Other/sleep.md
@@ -27,7 +27,7 @@ SLEEP(duration)
 
     1. In session 1, execute the following command to query the current connection_id and execute the `SLEEP()` function:
 
-        ```sql <!-- validator-ignore -->
+        ```sql <!-- validator-ignore-exec -->
         mysql> select connection_id();
         +-----------------+
         | connection_id() |
@@ -40,7 +40,7 @@ SLEEP(duration)
 
     2. At this point, open a new session, interrupt session 1, and run the following command.
 
-        ```sql <!-- validator-ignore -->
+        ```sql <!-- validator-ignore-exec -->
         mysql> kill 1463;
         Query OK, 0 rows affected (0.00 sec)
         ```
@@ -66,7 +66,7 @@ SLEEP(duration)
 
 ## **Examples**
 
-```sql <!-- validator-ignore -->
+```sql <!-- validator-ignore-exec -->
 -- without interruption
 mysql> SELECT SLEEP(1);
 +----------+

--- a/docs/MatrixOne/Reference/Functions-and-Operators/Other/stage_list.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/Other/stage_list.md
@@ -27,7 +27,7 @@ There are the following files and directories under the directory `/Users/admin/
 customer	student.csv	t1.csv		t2.txt		t3		user.txt
 ```
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 create stage stage_test url = 'file:///Users/admin/case';
 

--- a/docs/MatrixOne/Reference/Functions-and-Operators/Vector/cluster_centers.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/Vector/cluster_centers.md
@@ -22,7 +22,7 @@ SELECT cluster_centers(col kmeans 'k, op_type, init_type, normalize')  FROM tbl;
 
 ## Examples
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 drop table if exists points;
 CREATE TABLE points (id int auto_increment PRIMARY KEY,coordinate vecf32(2));

--- a/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/alter-sequence.md
+++ b/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/alter-sequence.md
@@ -40,7 +40,7 @@ mo_only:
 
 ## **Examples**
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 -- Create a sequence called alter_seq_01, set the increment of the sequence to 2, set the minimum value of the sequence to 30 and the maximum value to 100, and enable the loop
 create sequence alter_seq_01 as smallint increment by 2 minvalue 30 maxvalue 100 cycle;

--- a/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/alter-stage.md
+++ b/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/alter-stage.md
@@ -63,7 +63,7 @@ URL= "stage://<stagename>[/path/]"
 
 ## **Example**
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 create stage stage_fs url = 'file:///Users/admin/test' comment='this is a stage';
 

--- a/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/create-clone.md
+++ b/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/create-clone.md
@@ -111,7 +111,7 @@ INSERT INTO acc2_tbl (id, email) VALUES (1, 'alice@example.com'), (2, 'bob@examp
 
 **Clone Table:**
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 -- Clone a table within the same tenant
 CREATE TABLE acc1_db.t2 CLONE acc1_db.acc1_tbl;
@@ -142,7 +142,7 @@ mysql>  SELECT * FROM acc1_db.t3;
 
 **Clone Database:**
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 -- Clone a database within the same tenant
 CREATE DATABASE acc1_db_clone CLONE acc1_db;
@@ -185,7 +185,7 @@ mysql> SHOW TABLES;
 
 ### Case 2: Clone Data from Another Ordinary Tenant to Sys
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 -- Switch to sys tenant
 -- mysql -h 127.0.0.1 -P 6001 -u sys:root -p111
@@ -225,7 +225,7 @@ mysql> select * from sys_db_from_acc1.acc1_tbl_clone;
 
 ### Case 3: Clone Sys Tenant Data to Another Ordinary Tenant
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 -- Create test data under the sys tenant
 CREATE DATABASE sys_db;
@@ -271,7 +271,7 @@ mysql> select * from acc1_db.sys_tbl_clone;
 
 ### Case 4: Clone Data from One Ordinary Tenant to Another
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 -- Sys creates a snapshot for the source tenant acc1
 CREATE SNAPSHOT sp_acc1_for_clone FOR ACCOUNT acc1;

--- a/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/create-function-python.md
+++ b/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/create-function-python.md
@@ -63,7 +63,7 @@ To ensure that the data types used in writing Python UDF are consistent with tho
 
 **Example 1**
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 --Sum of Two Numbers with python UDF
 create or replace function py_add(a int, b int) returns int language python as 
@@ -85,7 +85,7 @@ mysql> select py_add(1,2);
 
 **Example 2**
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 create or replace function py_helloworld() returns varchar(255) language python as 
 $$

--- a/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/create-snapshot.md
+++ b/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/create-snapshot.md
@@ -48,7 +48,7 @@ mysql> SHOW SNAPSHOTS;
 
 **Example 3: Tenant admin creates tenant-level snapshots**
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 CREATE SNAPSHOT account_sp2 FOR ACCOUNT acc1;
 CREATE SNAPSHOT account_sp3 FOR ACCOUNT;
@@ -70,7 +70,7 @@ mysql> SHOW SNAPSHOTS;
 
 **Example 4: Tenant admin creates database-level snapshot**
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 mysql> CREATE SNAPSHOT db_sp1 FOR DATABASE db1;
 Query OK, 0 rows affected (0.01 sec)
@@ -86,7 +86,7 @@ mysql> SHOW SNAPSHOTS;
 
 **Example 5: Tenant admin creates table-level snapshot**
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 mysql> CREATE SNAPSHOT tab_sp1 FOR TABLE db1 t1;
 Query OK, 0 rows affected (0.01 sec)

--- a/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/create-stage.md
+++ b/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/create-stage.md
@@ -66,7 +66,7 @@ URL= "stage://<stagename>[/path/]"
   
 ## **Example**
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 -- file system
 create stage stage_fs url = 'file:///Users/admin/test';

--- a/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-create-en.md
+++ b/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-create-en.md
@@ -89,7 +89,7 @@ You can specify the data point in time using the following methods:
 
 Create a data branch from an existing table:
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 -- Expected-Rows: 0
 CREATE DATABASE test;
@@ -188,7 +188,7 @@ DROP SNAPSHOT sp_products;
 
 Create a branch of an entire database:
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 -- Expected-Rows: 0
 CREATE DATABASE source_db;
@@ -229,7 +229,7 @@ SELECT * FROM dev_db.users;
 
 ### Example 4: Create Database Branch from Snapshot
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 -- Expected-Rows: 0
 CREATE SNAPSHOT sp_source FOR DATABASE source_db;

--- a/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-delete-en.md
+++ b/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-delete-en.md
@@ -117,7 +117,7 @@ DROP DATABASE test_db;
 
 ### Example 2: Delete Database Branch
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 -- Expected-Rows: 0
 CREATE DATABASE source_db;

--- a/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-diff-en.md
+++ b/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-diff-en.md
@@ -79,7 +79,7 @@ The system automatically detects the branch relationship between two tables:
 
 Compare two tables without a common ancestor:
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 -- Expected-Rows: 0
 CREATE DATABASE test;
@@ -258,7 +258,7 @@ DROP TABLE test.t2;
 
 ### Example 6: Export Differences as SQL File
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 -- Expected-Rows: 0
 CREATE TABLE test.t1 (a INT PRIMARY KEY, b INT);
@@ -307,7 +307,7 @@ mysql -h <mo_host> -P <mo_port> -u <user> -p <db_name> < diff_t2_t1_20241225.sql
 
 **Import CSV file (full sync)**:
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 -- Expected-Success: false
 LOAD DATA LOCAL INFILE '/tmp/diff_output/diff_xxx.csv'
@@ -320,7 +320,7 @@ LINES TERMINATED BY '\n';
 
 Stage is a logical object in MatrixOne for connecting to external storage (such as S3, HDFS). You can output difference files directly to object storage for cross-cluster/cross-environment data synchronization.
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 -- Expected-Rows: 0
 CREATE STAGE my_stage URL = 's3://my-bucket/diff-output/?region=us-east-1&access_key_id=xxx&secret_access_key=yyy';
@@ -348,7 +348,7 @@ Advantages of using Stage:
 
 ### Example 7: Detect Update Operations
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 -- Expected-Rows: 0
 CREATE TABLE test.t0 (a INT PRIMARY KEY, b INT, c INT);
@@ -389,7 +389,7 @@ DROP TABLE test.t2;
 
 ### Example 8: Difference Comparison for Composite Primary Key Tables
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 -- Expected-Rows: 0
 CREATE TABLE test.orders (

--- a/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-merge-en.md
+++ b/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-merge-en.md
@@ -68,7 +68,7 @@ Conflicts occur when:
 
 ### Example 1: Simple Merge (No Conflicts)
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 -- Expected-Rows: 0
 CREATE DATABASE test;
@@ -129,7 +129,7 @@ DROP TABLE test.t2;
 
 ### Example 2: Handling INSERT Conflicts
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 -- Create base table
 -- Expected-Rows: 0
@@ -199,7 +199,7 @@ DROP TABLE test.t2;
 
 ### Example 3: Handling UPDATE Conflicts
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 -- Create base table
 -- Expected-Rows: 0
@@ -257,7 +257,7 @@ DROP TABLE test.t2;
 
 ### Example 4: Merge Without Common Ancestor
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 -- Create two independent tables
 -- Expected-Rows: 0
@@ -316,7 +316,7 @@ DROP TABLE test.t2;
 
 ### Example 5: Complex Merge Scenario
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 -- Create base table
 -- Expected-Rows: 0
@@ -389,7 +389,7 @@ DROP TABLE test.t3;
 
 ### Example 6: Merge with NULL Values
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 -- Create table with NULL values
 -- Expected-Rows: 0

--- a/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/drop-function.md
+++ b/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/drop-function.md
@@ -20,7 +20,7 @@ The `DROP FUNCTION` statement represents the deletion of a user-defined function
 
 **Example 1**
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 --Removing Parametric Functions
 

--- a/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/drop-stage.md
+++ b/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/drop-stage.md
@@ -18,7 +18,7 @@ mo_only:
 
 ## **Example**
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 create stage stage_fs url = 'file:///Users/admin/test';
 

--- a/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/restore-pitr.md
+++ b/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/restore-pitr.md
@@ -20,7 +20,7 @@ mo_only:
 
 ### Example 1: Restoring the cluster
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 
 -- Execute under sys tenant
@@ -92,7 +92,7 @@ mysql> show databases;
 
 ### Example 2: Restoring a tenant
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 CREATE database db1;
 CREATE database db2;
@@ -160,7 +160,7 @@ mysql> show databases;
 
 ### Example 3: Restoring the database
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 CREATE database db1;
 
@@ -225,7 +225,7 @@ mysql> show databases;
 
 ### Example 4: Restore table
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 -- Executed under tenant acc1
 CREATE TABLE t1(n1 int);

--- a/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/restore-snapshot.md
+++ b/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/restore-snapshot.md
@@ -204,7 +204,7 @@ mysql> SHOW DATABASES;
 
 ### Example 4: Restore Table
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 -- Execute in tenant acc1
 CREATE TABLE t1(n1 INT);

--- a/docs/MatrixOne/Reference/SQL-Reference/Data-Manipulation-Language/load-data-infile.md
+++ b/docs/MatrixOne/Reference/SQL-Reference/Data-Manipulation-Language/load-data-infile.md
@@ -45,7 +45,7 @@ The LOAD DATA statement reads rows from a text file into a table at a very high 
 
 If the file content uses a different character set than the default, you can use `CHARACTER SET` to specify the character set. For example, you can use `CHARACTER SET utf8` to specify the character set of the imported content as utf8:
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 LOAD DATA INFILE '/tmp/test.txt' INTO TABLE table1 IGNORE 1 LINES;
 ```
@@ -133,7 +133,7 @@ The contents of data.txt are as follows:
 
 Connect mo than execute the following statement to import the data.txt contents to t1:
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 create table t1(n1 int,n2 varchar(255));
 load data infile 'Users/admin/test/case/data.txt' into table t1;
@@ -160,7 +160,7 @@ The contents of data.txt are as follows:
 
 Connect mo than execute the following statement to import the data.txt contents to t2:
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 create table t2(n1 int,n2 varchar(255));
 load data infile 'Users/admin/test/case/data.txt' into table t2 fields escaped by 'a';
@@ -187,7 +187,7 @@ The contents of data.txt are as follows:
 
 Connect mo than execute the following statement to import the data.txt contents to t3:
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 create table t3(n1 int,n2 varchar(255));
 load data infile 'Users/admin/test/case/data.txt' into table t3 fields escaped by '';
@@ -219,7 +219,7 @@ The contents of data.txt are as follows:
 
 Connect mo than execute the following statement to import the data.txt contents to t4:
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 create table t4(n1 int,n2 varchar(255));
 load data infile 'Users/admin/test/case/data.txt' into table t4;
@@ -337,7 +337,7 @@ For example, for a large file of 2 G, use two threads to load; the second thread
 
 **Enable/Disable Parallel Loading Command Line Example**:
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 --  Enable Parallel Loading
 load data infile 'file_name' into table tbl_name FIELDS TERMINATED BY '|' ENCLOSED BY '\"' LINES TERMINATED BY '\n' IGNORE 1 LINES PARALLEL 'TRUE';
@@ -360,7 +360,7 @@ MatrixOne supports the use of the STRICT parameter to specify the way to cut the
 
 **Example**:
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 -- Enable pre-reading mode
 load data infile 'file_name' into table tbl_name PARALLEL 'TRUE' STRICT 'TRUE';
@@ -586,7 +586,7 @@ Query OK, 0 rows affected (0.02 sec)
 
 Load the data file into table t1:
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 load data infile '<your-local-file-path>/char_varchar.csv' into table t1 fields terminated by'|';
 ```
@@ -626,7 +626,7 @@ mysql> select * from t1;
 
 Following the example above, you can modify the `LOAD DATA` statement and add `LINES STARTING BY 'aa' ignore 10 lines;` at the end of the statement to experience the difference:
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 delete from t1;
 load data infile '<your-local-file-path>/char_varchar.csv' into table t1 fields terminated by'|' LINES STARTING BY 'aa' ignore 10 lines;
@@ -634,7 +634,7 @@ load data infile '<your-local-file-path>/char_varchar.csv' into table t1 fields 
 
 The query result is as follows:
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 mysql> select * from t1;
 +---------+---------+---------+---------+
@@ -688,7 +688,7 @@ load data infile {'filepath'='<your-local-file-path>/jsonline_array.jl','format'
 
 The query result is as follows:
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 mysql> select * from t1;
 +------+------+------+------------+---------------------+---------------------+------+--------+---------------------------------------+-------+-------+-------+
@@ -711,7 +711,7 @@ load data infile {'filepath'='<your-local-file-path>/jsonline_array.jl','format'
 
 The query result is as follows:
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 mysql> select * from t1;
 +------+------+------+------------+---------------------+---------------------+------+--------+-------------------------------------+-------+-------+-------+
@@ -739,7 +739,7 @@ There is a file `t1.csv` in the `/Users/admin/test` directory:
 3	c
 ```
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 create table t1(n1 int,n2 varchar(10));
 create stage stage_fs url = 'file:///Users/admin/test';
@@ -769,7 +769,7 @@ There is a file `t1.csv` in the `/Users/admin/test` directory:
 3	c
 ```
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 create table t2(n1 int,n2 varchar(10));
 create stage stage_fs1 url = 'file:///Users/admin/test';
@@ -798,7 +798,7 @@ There is a file `t1.csv` under `/User/` in HDFS:
 3	c
 ```
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 mysql> create table t1(n1 int,n2 text);
 Query OK, 0 rows affected (0.03 sec)
@@ -830,7 +830,7 @@ There is a file `t1.csv` under `/User/` in HDFS:
 3	c
 ```
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 mysql> create table t2(n1 int,n2 varchar(10));
 Query OK, 0 rows affected (0.02 sec)

--- a/docs/MatrixOne/Reference/SQL-Reference/Data-Query-Language/by-rank-with-option.md
+++ b/docs/MatrixOne/Reference/SQL-Reference/Data-Query-Language/by-rank-with-option.md
@@ -12,7 +12,7 @@ The `BY RANK WITH OPTION` clause is used in vector similarity search queries to 
 
 ## Syntax Structure
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 SELECT column_list
 FROM table_name

--- a/docs/MatrixOne/Reference/SQL-Reference/Other/SHOW-Statements/show-stage.md
+++ b/docs/MatrixOne/Reference/SQL-Reference/Other/SHOW-Statements/show-stage.md
@@ -18,7 +18,7 @@ mo_only:
 
 ## **Example**
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 mysql> create stage stage_fs url = 'file:///Users/admin/test';
 Query OK, 0 rows affected (0.03 sec)

--- a/docs/MatrixOne/Reference/SQL-Reference/Other/kill.md
+++ b/docs/MatrixOne/Reference/SQL-Reference/Other/kill.md
@@ -23,7 +23,7 @@ The `KILL` statement terminates a running query or process.
 
 ## **Examples**
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 select connection_id();
 +-----------------+

--- a/docs/MatrixOne/Tutorial/git4data-demo.md
+++ b/docs/MatrixOne/Tutorial/git4data-demo.md
@@ -107,7 +107,7 @@ CREATE SNAPSHOT sp_orders_v1 FOR TABLE demo_branch orders;
 
 Create two independent branch tables from the main table, one for each team:
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 -- Risk control branch: for flagging high-risk orders
 DATA BRANCH CREATE TABLE orders_risk FROM orders;
@@ -118,7 +118,7 @@ DATA BRANCH CREATE TABLE orders_promo FROM orders;
 
 At this point, all three tables have identical data. Let's verify:
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 SELECT * FROM orders_risk ORDER BY order_id;
 SELECT * FROM orders_promo ORDER BY order_id;
@@ -135,7 +135,7 @@ Now both teams work on their own branches independently, without interfering wit
 
 **Risk control team** operates on `orders_risk`:
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 -- Flag Bob's order as high risk
 UPDATE orders_risk SET risk_flag = 1 WHERE order_id = 1002;
@@ -149,7 +149,7 @@ INSERT INTO orders_risk VALUES (1006, 'Frank', 500.00, 1, NULL);
 
 **Operations team** operates on `orders_promo`:
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 -- Add campaign tags to Alice's and Bob's orders, and apply a 10% discount
 UPDATE orders_promo SET promo_tag = 'summer_sale', amount = amount * 0.9
@@ -161,7 +161,7 @@ INSERT INTO orders_promo VALUES (1007, 'Grace', 39.90, 0, 'summer_sale');
 
 At this point, the main table is completely unaffected:
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 SELECT * FROM orders ORDER BY order_id;
 -- Still the original 5 rows, with no changes whatsoever
@@ -173,7 +173,7 @@ Before merging, let's see what each branch has changed relative to the main tabl
 
 **View differences between the risk control branch and the main table:**
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 DATA BRANCH DIFF orders_risk AGAINST orders;
 ```
@@ -194,7 +194,7 @@ You can clearly see: 1 row updated, 1 row deleted, 1 row inserted.
 
 **View differences between the operations branch and the main table:**
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 DATA BRANCH DIFF orders_promo AGAINST orders;
 ```
@@ -264,14 +264,14 @@ You can also export to object storage (via Stage):
 
 First, merge the risk control branch (no conflict scenario):
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 DATA BRANCH MERGE orders_risk INTO orders;
 ```
 
 Verify the main table:
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 SELECT * FROM orders ORDER BY order_id;
 ```
@@ -315,14 +315,14 @@ The system tells you which rows have conflicts and will not silently overwrite d
 
 In this scenario, the risk control flag is more important than the operations discount, so we choose SKIP (keep the risk control modifications in the main table):
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 DATA BRANCH MERGE orders_promo INTO orders WHEN CONFLICT SKIP;
 ```
 
 Verify the final result:
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 SELECT * FROM orders ORDER BY order_id;
 ```
@@ -361,7 +361,7 @@ Unlike a regular `DROP TABLE`, `DATA BRANCH DELETE` retains metadata records in 
 
 If issues are discovered after merging, you can use the snapshot to return to the initial state:
 
-<!-- validator-ignore -->
+<!-- validator-ignore-exec -->
 ```sql
 RESTORE ACCOUNT sys DATABASE demo_branch TABLE orders FROM SNAPSHOT sp_orders_v1;
 ```

--- a/scripts/downgrade-ignore-to-exec.js
+++ b/scripts/downgrade-ignore-to-exec.js
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+/**
+ * Downgrade `<!-- validator-ignore -->` to `<!-- validator-ignore-exec -->`
+ * for every block that the triage report (tmp/ignore-all-triage.json)
+ * classified as safe-to-parse (verdicts: `parsed-only` or `external-needed`).
+ *
+ * Blocks in those buckets parse cleanly against the MatrixOne native parser
+ * but can't run in the generic execution sandbox (missing state, external
+ * files, etc.). Keeping them under `validator-ignore` silently skips the
+ * syntax checker too; downgrading to `validator-ignore-exec` keeps syntax
+ * coverage while still skipping execution.
+ *
+ * Untouched:
+ *   syntax-error / syntax-template / non-sql-shell  — still require ignore-all
+ *
+ * Two forms handled, mirroring unmark-safe-ignore.js:
+ *   Form A (inline on fence):  ```sql <!-- validator-ignore -->
+ *   Form B (bare preceding):   <!-- validator-ignore -->
+ *                              ```sql
+ *
+ * Usage:
+ *   node scripts/downgrade-ignore-to-exec.js [--dry-run] [--file <path>]
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs'
+
+const TRIAGE = 'tmp/ignore-all-triage.json'
+const DOWNGRADE_VERDICTS = new Set(['parsed-only', 'external-needed'])
+
+function isBarePrecedingIgnore(line) {
+  return /^\s*<!--\s*validator-ignore\s*-->\s*$/.test(line)
+}
+
+function rewriteInlineIgnore(line) {
+  return line.replace(/<!--\s*validator-ignore\s*-->/, '<!-- validator-ignore-exec -->')
+}
+
+async function main() {
+  const dryRun = process.argv.includes('--dry-run')
+  const onlyFile = process.argv.includes('--file')
+    ? process.argv[process.argv.indexOf('--file') + 1]
+    : null
+
+  const triage = JSON.parse(readFileSync(TRIAGE, 'utf-8'))
+  const blocks = triage.results.filter(r =>
+    DOWNGRADE_VERDICTS.has(r.verdict) && (!onlyFile || r.file === onlyFile)
+  )
+  console.log(`Targeting ${blocks.length} blocks (dryRun=${dryRun}, onlyFile=${onlyFile || 'all'})`)
+
+  const byFile = new Map()
+  for (const b of blocks) {
+    if (!byFile.has(b.file)) byFile.set(b.file, [])
+    byFile.get(b.file).push(b)
+  }
+
+  let touched = 0, skipped = 0, warned = 0
+  for (const [file, list] of byFile) {
+    const raw = readFileSync(file, 'utf-8')
+    const lines = raw.split('\n')
+    const rewrite = new Map()
+    const replaceBare = new Map()  // idx -> new text
+
+    list.sort((a, b) => b.startLine - a.startLine)
+
+    for (const b of list) {
+      // fence line = startLine - 1 (1-indexed) -> array idx startLine - 2
+      const fenceIdx = b.startLine - 2
+      if (fenceIdx < 0 || fenceIdx >= lines.length) {
+        console.warn(`  ! ${file}:${b.startLine} fence out of range`)
+        warned++; continue
+      }
+      const fenceLine = lines[fenceIdx]
+      if (!/^\s*```/.test(fenceLine)) {
+        console.warn(`  ! ${file}:${b.startLine} expected fence, got: ${fenceLine.slice(0, 80)}`)
+        warned++; continue
+      }
+      const hasInline = /<!--\s*validator-ignore(?:-exec)?\s*-->/.test(fenceLine)
+      const prevIdx = fenceIdx - 1
+      const prevIsBare = prevIdx >= 0 && isBarePrecedingIgnore(lines[prevIdx])
+
+      // If already downgraded, skip.
+      const hasInlineExec = /<!--\s*validator-ignore-exec\s*-->/.test(fenceLine)
+      const prevIsBareExec = prevIdx >= 0 && /^\s*<!--\s*validator-ignore-exec\s*-->\s*$/.test(lines[prevIdx])
+      if (!hasInline && !prevIsBare) {
+        if (hasInlineExec || prevIsBareExec) { skipped++; continue }
+        console.warn(`  ! ${file}:${b.startLine} no validator-ignore marker found`)
+        warned++; continue
+      }
+
+      if (hasInline && /<!--\s*validator-ignore\s*-->/.test(fenceLine)) {
+        rewrite.set(fenceIdx, rewriteInlineIgnore(fenceLine))
+      }
+      if (prevIsBare) {
+        // Preserve indentation, swap marker text.
+        const indentMatch = lines[prevIdx].match(/^(\s*)/)
+        replaceBare.set(prevIdx, `${indentMatch ? indentMatch[1] : ''}<!-- validator-ignore-exec -->`)
+      }
+      touched++
+    }
+
+    if (!rewrite.size && !replaceBare.size) continue
+
+    const next = lines.slice()
+    for (const [i, v] of rewrite) next[i] = v
+    for (const [i, v] of replaceBare) next[i] = v
+    const out = next.join('\n')
+    if (!dryRun && out !== raw) writeFileSync(file, out, 'utf-8')
+    console.log(`  ${dryRun ? '[dry]' : '✓'} ${file} — inline:${rewrite.size} bare:${replaceBare.size}`)
+  }
+
+  console.log('')
+  console.log(`Touched blocks: ${touched}`)
+  console.log(`Already downgraded: ${skipped}`)
+  console.log(`Warnings: ${warned}`)
+  if (dryRun) console.log('(--dry-run: no files written)')
+}
+
+main().catch(err => { console.error(err); process.exit(1) })


### PR DESCRIPTION
## What type of PR is this?                                                                              
                                                                                                           
  - [x] Enhancement                                                                                        
  - [ ] Displaying                                                                                         
  - [ ] Typo                                                                                               
  - [ ] Doc Request                                         
                                                                                                           
  ## Which issue(s) this PR fixes:                                                                         
                                                                                                           
  issue #                                                   

  ## What this PR does / why we need it:                                                                   
   
  **Why.** `validator-ignore` skips both syntax and execution checks. Many SQL blocks got this marker only 
  because they can't run in the sandbox (missing fixtures, S3/STAGE, privileged ops) even though their SQL
  is syntactically valid — silently dropping syntax coverage.                                              
                                                            
  **How.** Re-triaged all 126 remaining `<!-- validator-ignore -->` blocks with                            
  `scripts/triage-ignore-all.js`, then downgraded every parseable one to `<!-- validator-ignore-exec -->`
  (keeps syntax check, skips execution only). Kept `validator-ignore` for the 11 blocks that are truly     
  unparseable: syntax templates with placeholders, real parser gaps (`CREATE STREAM`, `FORMAT 'parquet'`),
  and the `//` comment-syntax demo.

  **Result.** 118 blocks downgraded across 44 files. Full `pnpm run check:sql-syntax:all` green: **450/450 
  files, 4205/4205 statements** (up from 3690 — **+515 statements** now syntax-checked). Coverage buckets:
  `ignore-all` 126 → **11**, `ignore-exec` 407 → **524**, `executed` unchanged.  