### PR TITLE
Chore/doc validator triage passes

### DIFF
--- a/docs/MatrixOne/Develop/Ecological-Tools/Computing-Engine/Flink/flink-postgresql-matrixone.md
+++ b/docs/MatrixOne/Develop/Ecological-Tools/Computing-Engine/Flink/flink-postgresql-matrixone.md
@@ -149,7 +149,6 @@ insert into test_pg select * from pgsql_bog;
 
 Query the corresponding table data in MatrixOne;
 
-<!-- validator-ignore-exec -->
 ```sql
 mysql> select * from student;
 +--------+----------+---------+------------+

--- a/docs/MatrixOne/Develop/Ecological-Tools/Etl/DataX/datax-mysql-matrixone.md
+++ b/docs/MatrixOne/Develop/Ecological-Tools/Etl/DataX/datax-mysql-matrixone.md
@@ -118,7 +118,6 @@ python /opt/module/datax/bin/datax.py /opt/module/datax/job/mysql2mo.json
 
 ### View data in a MatrixOne table
 
-<!-- validator-ignore-exec -->
 ```sql
 mysql> select * from mysql_datax;
 +------+-------+--------+------+------------+--------+

--- a/docs/MatrixOne/Develop/Publish-Subscribe/pub-sub-overview.md
+++ b/docs/MatrixOne/Develop/Publish-Subscribe/pub-sub-overview.md
@@ -222,7 +222,7 @@ create account acc2 admin_name = 'test_account' identified by '111';
 
 5. View changes on the subscription side
 
-<!-- validator-ignore-exec -->
+    <!-- validator-ignore-exec -->
     ```sql
     -- Check stock availability in acc1
     mysql> select * from inventory ;

--- a/docs/MatrixOne/Develop/Transactions/matrixone-transaction-overview/implicit-transaction.md
+++ b/docs/MatrixOne/Develop/Transactions/matrixone-transaction-overview/implicit-transaction.md
@@ -31,7 +31,6 @@ In MatrixOne, if the implicit transaction is enabled (`SET AUTOCOMMIT=0`), all o
 
 **MySQL Implicit Transaction Behavior Example**
 
-<!-- validator-ignore-exec -->
 ```sql
 mysql> select @@SQL_SELECT_LIMIT;
 +----------------------+
@@ -94,7 +93,6 @@ mysql> select @@SQL_SELECT_LIMIT;
 
 **MatrixOne Implicit Transaction Behavior Example**
 
-<!-- validator-ignore-exec -->
 ```sql
 mysql> select @@SQL_SELECT_LIMIT;
 +----------------------+

--- a/docs/MatrixOne/Develop/Vector/cluster_centers.md
+++ b/docs/MatrixOne/Develop/Vector/cluster_centers.md
@@ -73,7 +73,7 @@ Suppose we have annual shopping data for a set of customers, including their ann
 
 2. Determining the Cluster Center
 
-<!-- validator-ignore-exec -->
+    <!-- validator-ignore-exec -->
     ```sql
     mysql> SELECT cluster_centers(in_ex kmeans '2,vector_l2_ops,random,false') AS centers FROM customer_table;
     +------------------------------------------------------------------------+
@@ -123,7 +123,7 @@ A music streaming service wants to divide users into groups based on their prefe
 
 2. View vector normalization results
 
-<!-- validator-ignore-exec -->
+    <!-- validator-ignore-exec -->
     ```sql
     mysql> select normalize_l2(grade) from music_table;
     +---------------------------------------------------------------------------------------------------------+
@@ -140,7 +140,7 @@ A music streaming service wants to divide users into groups based on their prefe
 
 3. Determining the Cluster Center
 
-<!-- validator-ignore-exec -->
+    <!-- validator-ignore-exec -->
     ```sql
     mysql> SELECT cluster_centers(grade kmeans '2,vector_l2_ops,kmeansplusplus,true') AS centers FROM music_table;
     +------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+

--- a/docs/MatrixOne/Develop/distinct-data/bitmap.md
+++ b/docs/MatrixOne/Develop/distinct-data/bitmap.md
@@ -46,7 +46,8 @@ LOAD DATA INFILE '/your_path/user_behavior_table.csv' INTO TABLE user_behavior_t
 
 The coarse-grained calculation results are saved in the pre-computed table.Subsequent aggregation of various different dimensions can use the results in the pre-computed table.After simple calculation,the results can be obtained and the query can be accelerated.
 
-```sql <!-- validator-ignore-exec -->
+<!-- validator-ignore-exec -->
+```sql
 CREATE TABLE precompute AS
 SELECT
   behavior,

--- a/docs/MatrixOne/Develop/export-data/select-into-outfile.md
+++ b/docs/MatrixOne/Develop/export-data/select-into-outfile.md
@@ -94,7 +94,6 @@ sudo docker run --name <name> --privileged -d -p 6001:6001 -v ${local_data_path}
 
     - Export to file system stage
 
-    <!-- validator-ignore-exec -->
     ```sql
     create stage stage_fs url = 'file:///Users/admin/test';
     select * from user into outfile 'stage://stage_fs/user.csv';

--- a/docs/MatrixOne/Develop/export-data/select-into-outfile.md
+++ b/docs/MatrixOne/Develop/export-data/select-into-outfile.md
@@ -94,6 +94,7 @@ sudo docker run --name <name> --privileged -d -p 6001:6001 -v ${local_data_path}
 
     - Export to file system stage
 
+    <!-- validator-ignore-exec -->
     ```sql
     create stage stage_fs url = 'file:///Users/admin/test';
     select * from user into outfile 'stage://stage_fs/user.csv';

--- a/docs/MatrixOne/Develop/import-data/bulk-load/load-s3.md
+++ b/docs/MatrixOne/Develop/import-data/bulk-load/load-s3.md
@@ -100,7 +100,8 @@ In this tutorial, we will walk you through the process of loading a **.csv** fil
 
 5. After the import is successful, you can run SQL statements to check the result of imported data:
 
-    ```sql <!-- validator-ignore-exec -->
+    <!-- validator-ignore-exec -->
+    ```sql
     mysql> select * from t1;
     +-----------+-----------+-----------+-----------+
     | col1      | col2      | col3      | col4      |

--- a/docs/MatrixOne/Develop/import-data/delete-data.md
+++ b/docs/MatrixOne/Develop/import-data/delete-data.md
@@ -113,7 +113,6 @@ mysql> SELECT * FROM employees;
 
 - Example 2
 
-<!-- validator-ignore-exec -->
 ```sql
 -- Create table
 CREATE TABLE orders (

--- a/docs/MatrixOne/Develop/read-data/multitable-join-query.md
+++ b/docs/MatrixOne/Develop/read-data/multitable-join-query.md
@@ -131,7 +131,8 @@ The join result of an inner join returns only rows that match the join condition
 
 There are two ways of writing an `inner join` that are completely equivalent in results:
 
-```sql <!-- validator-ignore-exec -->
+<!-- validator-ignore-exec -->
+```sql
 mysql> SELECT   
     l_orderkey,
     SUM(l_extendedprice * (1 - l_discount)) AS revenue,
@@ -169,7 +170,8 @@ LIMIT 10;
 
 Write as `Join`, the syntax is as follows:
 
-```sql <!-- validator-ignore-exec -->
+<!-- validator-ignore-exec -->
+```sql
 mysql> SELECT   
     l_orderkey,
     SUM(l_extendedprice * (1 - l_discount)) AS revenue,

--- a/docs/MatrixOne/Develop/read-data/query-data-single-table.md
+++ b/docs/MatrixOne/Develop/read-data/query-data-single-table.md
@@ -71,7 +71,6 @@ Result is as below:
 
 To filter query results, you can use the `WHERE` statement.
 
-<!-- validator-ignore-exec -->
 ```sql
 mysql> SELECT * FROM token_count WHERE id = 25;
 ```
@@ -92,7 +91,6 @@ To sort query results, you can use the `ORDER BY` statement.
 
 For example, the following SQL statement can be used to sort the data in the *token_count* table in descending order (DESC) by *times* column.
 
-<!-- validator-ignore-exec -->
 ```sql
 mysql> SELECT id, token, times FROM token_count ORDER BY times DESC;
 ```
@@ -121,7 +119,6 @@ Result is as below:
 
 To limit the number of query results, you can use the `LIMIT` statement.
 
-<!-- validator-ignore-exec -->
 ```sql
 mysql> SELECT id, token, times FROM token_count ORDER BY times DESC LIMIT 5;
 ```
@@ -146,7 +143,6 @@ To have a better understanding of the overall data situation, you can use the `G
 
 For example, you can group basic information by `id`, `count`, and `times` columns and count them separately:
 
-<!-- validator-ignore-exec -->
 ```sql
 mysql> SELECT id, count, times FROM token_count GROUP BY id, count, times ORDER BY times DESC LIMIT 5;
 ```

--- a/docs/MatrixOne/Develop/read-data/window-function/time-window.md
+++ b/docs/MatrixOne/Develop/read-data/window-function/time-window.md
@@ -56,7 +56,6 @@ Example of use:
 
 This example demonstrates how to slide every 5 minutes over a 10-minute time window, giving a maximum and minimum temperature every 5 minutes.
 
-<!-- validator-ignore-exec -->
 ```sql
 mysql> drop table if exists sensor_data;
 CREATE TABLE sensor_data (ts timestamp(3) primary key, temperature FLOAT);

--- a/docs/MatrixOne/Develop/schema-design/create-table-as-select.md
+++ b/docs/MatrixOne/Develop/schema-design/create-table-as-select.md
@@ -38,6 +38,7 @@ See chapter [Create Table As Select](../../Reference/SQL-Reference/Data-Definiti
 
 Suppose we have an e-commerce platform and we want to create a data table to analyze the details of each order including order number, customer ID, order date, product ID, product quantity and product price.
 
+<!-- validator-ignore-exec -->
 ```sql
 CREATE TABLE orders(
 order_id int auto_increment PRIMARY KEY,

--- a/docs/MatrixOne/Develop/schema-design/create-table-as-select.md
+++ b/docs/MatrixOne/Develop/schema-design/create-table-as-select.md
@@ -38,7 +38,6 @@ See chapter [Create Table As Select](../../Reference/SQL-Reference/Data-Definiti
 
 Suppose we have an e-commerce platform and we want to create a data table to analyze the details of each order including order number, customer ID, order date, product ID, product quantity and product price.
 
-<!-- validator-ignore-exec -->
 ```sql
 CREATE TABLE orders(
 order_id int auto_increment PRIMARY KEY,

--- a/docs/MatrixOne/Maintain/backup-restore/mobr-backup-restore/mobr-pitr-backup-restore.md
+++ b/docs/MatrixOne/Maintain/backup-restore/mobr-backup-restore/mobr-pitr-backup-restore.md
@@ -43,7 +43,6 @@ A large SaaS provider manages a multi-tenant environment that provides various s
 
 There are two tenants acc1 and acc2 under this system, which represent different customers. Each tenant has product information and order information.
   
-<!-- validator-ignore-exec -->
 ```sql
 create account acc1 admin_name 'root' identified by '111';
 create account acc2 admin_name 'root' identified by '111';

--- a/docs/MatrixOne/Maintain/backup-restore/mobr-backup-restore/mobr-snapshot-backup-restore.md
+++ b/docs/MatrixOne/Maintain/backup-restore/mobr-backup-restore/mobr-snapshot-backup-restore.md
@@ -41,7 +41,6 @@ This document mainly introduces how to use `mo_br` to perform cluster/tenant lev
 
 - Connect to the Matrixone system tenant to execute table creation statements
 
-<!-- validator-ignore-exec -->
 ```sql
 create database if not exists snapshot_read;
 use snapshot_read;
@@ -67,7 +66,6 @@ sp_01 2024-05-10 02:06:08.01635 account sys
 
 - Connect to the Matrixone system tenant and delete some data in the table.
 
-<!-- validator-ignore-exec -->
 ```sql
 delete from snapshot_read.test_snapshot_read where a <= 50;
 

--- a/docs/MatrixOne/Maintain/cdc/mo-mysql.md
+++ b/docs/MatrixOne/Maintain/cdc/mo-mysql.md
@@ -37,7 +37,6 @@ INSERT INTO source_db.orders (order_id, customer_id, order_date, amount, status)
 
 ### Create Downstream Database
 
-<!-- validator-ignore-exec -->
 ```sql
 create database analytics_db;
 ```
@@ -78,7 +77,6 @@ Check task status.
 
 Connect to the downstream MySQL to verify full data synchronization.
 
-<!-- validator-ignore-exec -->
 ```sql
 mysql> select * from analytics_db.orders_backup;
 +----------+-------------+---------------------+--------+------------+
@@ -118,7 +116,6 @@ mysql> select * from source_db.orders;
 
 Connect to the downstream MySQL to verify incremental data synchronization.
 
-<!-- validator-ignore-exec -->
 ```sql
 mysql> select * from analytics_db.orders_backup;
 +----------+-------------+---------------------+--------+------------+
@@ -179,7 +176,6 @@ Manually resume the task.
 
 Connect to the downstream MySQL to verify checkpoint recovery.
 
-<!-- validator-ignore-exec -->
 ```sql
 mysql> select * from analytics_db.orders_backup;
 +----------+-------------+---------------------+--------+------------+

--- a/docs/MatrixOne/Overview/architecture/architecture-cold-hot-data-separation.md
+++ b/docs/MatrixOne/Overview/architecture/architecture-cold-hot-data-separation.md
@@ -130,7 +130,8 @@ In many business scenarios, we often need to accelerate the queries due to a lar
 
 For example, the following SQL query:
 
-```sql <!-- validator-ignore-exec -->
+<!-- validator-ignore-exec -->
+```sql
 SELECT pe1.ts_code, pe1.pe, pe1.pb
 FROM stock2.pe as pe1
 WHERE pe1.pe = (SELECT min(pe2.pe)
@@ -142,7 +143,8 @@ DESC LIMIT 1;
 
 If not optimized, the execution speed is as follows:
 
-```sql <!-- validator-ignore-exec -->
+<!-- validator-ignore-exec -->
+```sql
 SELECT pe1.ts_code, pe1.pe, pe1.pb
 FROM stock2.pe as pe1
 WHERE pe1.pe = (SELECT min(pe2.pe)

--- a/docs/MatrixOne/Overview/architecture/streaming.md
+++ b/docs/MatrixOne/Overview/architecture/streaming.md
@@ -54,7 +54,6 @@ CREATE STREAM STUDENTS (ID STRING KEY, SCORE INT)
 
 You can also query streams and connect them with other tables and materialized views, as shown below:
 
-<!-- validator-ignore-exec -->
 ```sql
 SELECT * FROM STUDENTS WHERE `rank` > 5;
 ```

--- a/docs/MatrixOne/Performance-Tuning/explain/explain-views.md
+++ b/docs/MatrixOne/Performance-Tuning/explain/explain-views.md
@@ -6,7 +6,6 @@
 
 We have prepared a simple example to help you understand the execution plan for interpreting the `VIEW` using `EXPLAIN`.
 
-<!-- validator-ignore-exec -->
 ```sql
 > drop table if exists t1;
 > create table t1 (id int,ti tinyint unsigned,si smallint,bi bigint unsigned,fl float,dl double,de decimal,ch char(20),vch varchar(20),dd date,dt datetime);

--- a/docs/MatrixOne/Reference/Data-Types/data-types.md
+++ b/docs/MatrixOne/Reference/Data-Types/data-types.md
@@ -445,7 +445,6 @@ mysql> select * from datetest;
 
 - DATETIME
 
-<!-- validator-ignore-exec -->
 ```sql
 -- Create a table named "datetimetest" with 1 attributes of a "datetime"
 create table datetimetest (a datetime(0) not null, primary key(a));

--- a/docs/MatrixOne/Reference/Functions-and-Operators/Aggregate-Functions/any-value.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/Aggregate-Functions/any-value.md
@@ -25,7 +25,6 @@ The function return value and type are the same as the return value and type of 
 
 ## **Examples**
 
-<!-- validator-ignore-exec -->
 ```sql
 > create table t1(
     -> a int,

--- a/docs/MatrixOne/Reference/Functions-and-Operators/Aggregate-Functions/bit_and.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/Aggregate-Functions/bit_and.md
@@ -20,7 +20,6 @@ The BIT_AND(expr) function returns the bitwise AND of all bits in expr.
 
 ## **Examples**
 
-<!-- validator-ignore-exec -->
 ```sql
 > drop table if exists t1;
 > CREATE TABLE t1 (id CHAR(1), number INT);

--- a/docs/MatrixOne/Reference/Functions-and-Operators/Aggregate-Functions/bit_or.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/Aggregate-Functions/bit_or.md
@@ -20,7 +20,6 @@ The BIT_OR(expr) function returns the bitwise OR of all bits in expr.
 
 ## **Examples**
 
-<!-- validator-ignore-exec -->
 ```sql
 > drop table if exists t1;
 > CREATE TABLE t1 (id CHAR(1), number INT);

--- a/docs/MatrixOne/Reference/Functions-and-Operators/Aggregate-Functions/bit_xor.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/Aggregate-Functions/bit_xor.md
@@ -20,7 +20,6 @@ The BIT_XOR(expr) function returns the bitwise XOR of all bits in expr.
 
 ## **Examples**
 
-<!-- validator-ignore-exec -->
 ```sql
 > drop table if exists t1;
 > CREATE TABLE t1 (id CHAR(1), number INT);

--- a/docs/MatrixOne/Reference/Functions-and-Operators/Aggregate-Functions/bitmap.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/Aggregate-Functions/bitmap.md
@@ -223,7 +223,6 @@ mysql> SELECT bitmap_bit_position(0),bitmap_bit_position(1),bitmap_bit_position(
 
 So you need to combine the `BITMAP_BUCKET_NUMBER()` function if you want to dedupe data larger than 32767.
 
-<!-- validator-ignore-exec -->
 ```sql
 -- Grouped in buckets, the first bucket contains three non-repeating numbers (0,1,32767) and the second bucket contains three non-repeating numbers (32768,32769,65535).
 mysql> SELECT bitmap_count(BITMAP_CONSTRUCT_AGG(BITMAP_BIT_POSITION(n1))) AS t1_bitmap FROM t1 GROUP BY BITMAP_BUCKET_NUMBER(n1);

--- a/docs/MatrixOne/Reference/Functions-and-Operators/Aggregate-Functions/sum.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/Aggregate-Functions/sum.md
@@ -63,7 +63,6 @@ drop table if exists tbl2;
 
 - Example 2:
 
-<!-- validator-ignore-exec -->
 ```sql
 > CREATE TABLE t1(a varchar(255), b INT, c INT UNSIGNED, d DECIMAL(12,2), e REAL);
 > INSERT INTO t1 VALUES('iynfj', 1, 1, 1, 1);

--- a/docs/MatrixOne/Reference/Functions-and-Operators/Datetime/convert-tz.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/Datetime/convert-tz.md
@@ -20,7 +20,6 @@ The `CONVERT_TZ()` function is used to convert a given datetime from one time zo
 
 ## **Examples**
 
-<!-- validator-ignore-exec -->
 ```sql
 mysql> SELECT CONVERT_TZ('2004-01-01 12:00:00','GMT','MET');
 +-------------------------------------------+

--- a/docs/MatrixOne/Reference/Functions-and-Operators/Datetime/date-add.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/Datetime/date-add.md
@@ -20,7 +20,6 @@ The ``DATE_ADD()`` function adds a time/date interval to a date and then returns
 
 ## **Examples**
 
-<!-- validator-ignore-exec -->
 ```sql
 create table t2(orderid int, productname varchar(20), orderdate datetime);
 insert into t2 values ('1','Jarl','2008-11-11 13:23:44.657');

--- a/docs/MatrixOne/Reference/Functions-and-Operators/Datetime/date-format.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/Datetime/date-format.md
@@ -125,7 +125,6 @@ mysql> SELECT Date_format(f1, "%m") AS d1,
   2 rows in set (0.00 sec)
 ```
 
-<!-- validator-ignore-exec -->
 ```sql
 CREATE TABLE t5 (a int, b date);
 INSERT INTO t5

--- a/docs/MatrixOne/Reference/Functions-and-Operators/Datetime/date-format.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/Datetime/date-format.md
@@ -62,7 +62,6 @@ Formats the date value according to the format string. If either argument is NUL
 
 ## **Examples**
 
-<!-- validator-ignore-exec -->
 ```sql
 mysql> SELECT DATE_FORMAT('2009-10-04 22:23:00', '%W %M %Y');
 +--------------------------------------------+

--- a/docs/MatrixOne/Reference/Functions-and-Operators/Datetime/date-sub.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/Datetime/date-sub.md
@@ -20,7 +20,6 @@ DATE_SUB(date,INTERVAL expr unit)
 
 ## **Examples**
 
-<!-- validator-ignore-exec -->
 ```sql
 create table t2(orderid int, productname varchar(20), orderdate datetime);
 insert into t2 values ('1','Jarl','2008-11-11 13:23:44.657');

--- a/docs/MatrixOne/Reference/Functions-and-Operators/Datetime/datediff.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/Datetime/datediff.md
@@ -18,7 +18,6 @@
 
 ## **Examples**
 
-<!-- validator-ignore-exec -->
 ```sql
 mysql> SELECT DATEDIFF('2007-12-31 23:59:59','2007-12-30');
 +-------------------------------------------+
@@ -37,7 +36,6 @@ mysql> SELECT DATEDIFF('2010-11-30 23:59:59','2010-12-31');
 1 row in set (0.00 sec)
 ```
 
-<!-- validator-ignore-exec -->
 ```sql
 create table t1(a INT,  b date);
 insert into t1 values(1, "2012-10-11");

--- a/docs/MatrixOne/Reference/Functions-and-Operators/Datetime/extract.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/Datetime/extract.md
@@ -19,7 +19,6 @@ The ``EXTRACT()`` function uses the same kinds of unit specifiers as ``DATE_ADD(
 
 ## **Examples**
 
-<!-- validator-ignore-exec -->
 ```sql
 create table t2(orderid int, productname varchar(20), orderdate datetime);
 insert into t2 values ('1','Jarl','2008-11-11 13:23:44.657');

--- a/docs/MatrixOne/Reference/Functions-and-Operators/Datetime/from-unixtime.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/Datetime/from-unixtime.md
@@ -19,7 +19,6 @@ The ``FROM_UNIXTIME()`` function returns a representation of ``unix_timestamp`` 
 
 ## **Examples**
 
-<!-- validator-ignore-exec -->
 ```sql
 mysql> SELECT FROM_UNIXTIME(1447430881);
 +---------------------------+

--- a/docs/MatrixOne/Reference/Functions-and-Operators/Datetime/hour.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/Datetime/hour.md
@@ -18,7 +18,6 @@ Returns the hour for time. The range of the return value is 0 to 23 for time-of-
 
 ## **Examples**
 
-<!-- validator-ignore-exec -->
 ```sql
 drop table if exists t1;
 create table t1(a datetime, b timestamp);

--- a/docs/MatrixOne/Reference/Functions-and-Operators/Datetime/minute.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/Datetime/minute.md
@@ -32,7 +32,6 @@ mysql> SELECT MINUTE('2008-02-03 10:05:03');
 
 - Example 2:
 
-<!-- validator-ignore-exec -->
 ```sql
 drop table if exists t1;
 create table t1(a datetime, b timestamp);

--- a/docs/MatrixOne/Reference/Functions-and-Operators/Datetime/minute.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/Datetime/minute.md
@@ -20,7 +20,6 @@ Returns the minute for time, in the range 0 to 59, or NULL if time is NULL.
 
 - Example 1:
 
-<!-- validator-ignore-exec -->
 ```sql
 mysql> SELECT MINUTE('2008-02-03 10:05:03');
 +-----------------------------+

--- a/docs/MatrixOne/Reference/Functions-and-Operators/Datetime/month.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/Datetime/month.md
@@ -20,7 +20,6 @@ Returns the month for date, in the range 1 to 12 for January to December, or 0 f
 
 - Example 1:
 
-<!-- validator-ignore-exec -->
 ```sql
 mysql> SELECT MONTH('2008-02-03');
 +-------------------+

--- a/docs/MatrixOne/Reference/Functions-and-Operators/Datetime/second.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/Datetime/second.md
@@ -18,7 +18,6 @@ Returns the second for time, in the range 0 to 59, or NULL if time is NULL.
 
 ## **Examples**
 
-<!-- validator-ignore-exec -->
 ```sql
 drop table if exists t1;
 create table t1(a datetime, b timestamp);

--- a/docs/MatrixOne/Reference/Functions-and-Operators/Datetime/str-to-date.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/Datetime/str-to-date.md
@@ -23,7 +23,6 @@ See the [`DATE_FORMAT()`](date-format.md) function description for format specif
 
 ## **Examples**
 
-<!-- validator-ignore-exec -->
 ```sql
 mysql> SELECT STR_TO_DATE('2022-01-06 10:20:30','%Y-%m-%d %H:%i:%s') as result;
 +---------------------+

--- a/docs/MatrixOne/Reference/Functions-and-Operators/Datetime/time.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/Datetime/time.md
@@ -18,7 +18,6 @@ Extracts the time part of the time or datetime expression expr and returns it as
 
 ## **Examples**
 
-<!-- validator-ignore-exec -->
 ```sql
 mysql> SELECT TIME('2003-12-31 01:02:03');
 +---------------------------+

--- a/docs/MatrixOne/Reference/Functions-and-Operators/Datetime/timestamp.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/Datetime/timestamp.md
@@ -18,7 +18,6 @@ With a single argument, this function returns the date or datetime expression ex
 
 ## **Examples**
 
-<!-- validator-ignore-exec -->
 ```sql
 mysql> SELECT TIMESTAMP('2003-12-31');
 +----------------------------+
@@ -29,7 +28,6 @@ mysql> SELECT TIMESTAMP('2003-12-31');
 1 row in set (0.00 sec)
 ```
 
-<!-- validator-ignore-exec -->
 ```sql
 CREATE TABLE t1(c1 DATE NOT NULL);
 INSERT INTO t1 VALUES('2000-01-01');

--- a/docs/MatrixOne/Reference/Functions-and-Operators/Datetime/timestampdiff.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/Datetime/timestampdiff.md
@@ -23,7 +23,6 @@ This function returns `NULL` if datetime_expr1 or datetime_expr2 is `NULL`.
 
 - Example 1:
 
-<!-- validator-ignore-exec -->
 ```sql
 mysql> SELECT TIMESTAMPDIFF( MICROSECOND, '2017-12-01 12:15:12','2018-01-01 7:18:20');
 +---------------------------------------------------------------------+

--- a/docs/MatrixOne/Reference/Functions-and-Operators/Datetime/timestampdiff.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/Datetime/timestampdiff.md
@@ -35,7 +35,6 @@ mysql> SELECT TIMESTAMPDIFF( MICROSECOND, '2017-12-01 12:15:12','2018-01-01 7:18
 
 - Example 2:
 
-<!-- validator-ignore-exec -->
 ```sql
 drop table if exists t1;
 create table t1(a date,  b date);

--- a/docs/MatrixOne/Reference/Functions-and-Operators/Datetime/to-date.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/Datetime/to-date.md
@@ -22,7 +22,6 @@
 
 ## **Examples**
 
-<!-- validator-ignore-exec -->
 ```sql
 mysql> SELECT TO_DATE('2022-01-06 10:20:30','%Y-%m-%d %H:%i:%s') as result;
 +---------------------+

--- a/docs/MatrixOne/Reference/Functions-and-Operators/Datetime/to-days.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/Datetime/to-days.md
@@ -24,7 +24,6 @@ For dates with two-digit years, for example, when querying `SELECT TO_DAYS('08-1
 
 ## **Examples**
 
-<!-- validator-ignore-exec -->
 ```sql
 -- The query will return an integer representing the number of days between the date '2023-07-12' and the start date of the Gregorian calendar.
 mysql> SELECT TO_DAYS('2023-07-12');

--- a/docs/MatrixOne/Reference/Functions-and-Operators/Datetime/to-seconds.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/Datetime/to-seconds.md
@@ -26,7 +26,6 @@ Similar to the `TO_DAYS()` function, for example, when querying `SELECT TO_SECON
 
 ## **Examples**
 
-<!-- validator-ignore-exec -->
 ```sql
 mysql> SELECT TO_SECONDS('0001-01-01');
 +------------------------+

--- a/docs/MatrixOne/Reference/Functions-and-Operators/Datetime/unix-timestamp.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/Datetime/unix-timestamp.md
@@ -26,7 +26,6 @@ The return value is an integer if no argument is given or the argument does not 
 
 If you use `UNIX_TIMESTAMP()` and `FROM_UNIXTIME()` to convert between values in a non-UTC time zone and Unix timestamp values, the conversion is lossy because the mapping is not one-to-one in both directions. For example, due to conventions for local time zone changes such as Daylight Saving Time (DST), it is possible for `UNIX_TIMESTAMP()` to map two values that are distinct in a non-UTC time zone to the same Unix timestamp value. `FROM_UNIXTIME()` maps that value back to only one of the original values. Here is an example, using values that are distinct in the MET time zone:
 
-<!-- validator-ignore-exec -->
 ```sql
 mysql> SET time_zone = 'MET';
 Query OK, 0 rows affected (0.01 sec)
@@ -58,7 +57,6 @@ mysql> SELECT FROM_UNIXTIME(1111885200);
 
 ## **Examples**
 
-<!-- validator-ignore-exec -->
 ```sql
 mysql> SELECT UNIX_TIMESTAMP("2016-07-11");
 +----------------------------+

--- a/docs/MatrixOne/Reference/Functions-and-Operators/Datetime/unix-timestamp.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/Datetime/unix-timestamp.md
@@ -26,6 +26,7 @@ The return value is an integer if no argument is given or the argument does not 
 
 If you use `UNIX_TIMESTAMP()` and `FROM_UNIXTIME()` to convert between values in a non-UTC time zone and Unix timestamp values, the conversion is lossy because the mapping is not one-to-one in both directions. For example, due to conventions for local time zone changes such as Daylight Saving Time (DST), it is possible for `UNIX_TIMESTAMP()` to map two values that are distinct in a non-UTC time zone to the same Unix timestamp value. `FROM_UNIXTIME()` maps that value back to only one of the original values. Here is an example, using values that are distinct in the MET time zone:
 
+<!-- validator-ignore-exec -->
 ```sql
 mysql> SET time_zone = 'MET';
 Query OK, 0 rows affected (0.01 sec)
@@ -57,6 +58,7 @@ mysql> SELECT FROM_UNIXTIME(1111885200);
 
 ## **Examples**
 
+<!-- validator-ignore-exec -->
 ```sql
 mysql> SELECT UNIX_TIMESTAMP("2016-07-11");
 +----------------------------+

--- a/docs/MatrixOne/Reference/Functions-and-Operators/Datetime/weekday.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/Datetime/weekday.md
@@ -20,7 +20,6 @@ Returns the weekday index for date (0 = Monday, 1 = Tuesday, … 6 = Sunday). Re
 
 - Example 1:
 
-<!-- validator-ignore-exec -->
 ```sql
 mysql> SELECT WEEKDAY('2008-02-03 22:23:00');
 +------------------------------+

--- a/docs/MatrixOne/Reference/Functions-and-Operators/Datetime/year.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/Datetime/year.md
@@ -35,7 +35,6 @@ mysql> select year(a) from t1;
 2 rows in set (0.00 sec)
 ```
 
-<!-- validator-ignore-exec -->
 ```sql
 DROP TABLE IF EXISTS t3;
 CREATE TABLE t3(c1 DATE NOT NULL);

--- a/docs/MatrixOne/Reference/Functions-and-Operators/Json/json_unquote.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/Json/json_unquote.md
@@ -27,7 +27,6 @@ In strings, certain sequences have special meanings. These sequences start with 
 
 ## **Example**
 
-<!-- validator-ignore-exec -->
 ```sql
 mysql> SET @j = '"abc"';
 Query OK, 0 rows affected (0.00 sec)

--- a/docs/MatrixOne/Reference/Functions-and-Operators/Mathematical/cot.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/Mathematical/cot.md
@@ -18,7 +18,6 @@ The COT() function returns the cotangent of input number(given in radians).
 
 ## **Examples**
 
-<!-- validator-ignore-exec -->
 ```sql
 mysql> SELECT COT(12);
 +---------------------+

--- a/docs/MatrixOne/Reference/Functions-and-Operators/String/Regular-Expressions/regexp-instr.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/String/Regular-Expressions/regexp-instr.md
@@ -32,7 +32,6 @@
 
 ## **Examples**
 
-<!-- validator-ignore-exec -->
 ```SQL
 mysql> SELECT REGEXP_INSTR('Hello, my number is 12345.', '[0-9]+');
 +--------------------------------------------------+

--- a/docs/MatrixOne/Reference/Functions-and-Operators/String/Regular-Expressions/regexp-like.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/String/Regular-Expressions/regexp-like.md
@@ -28,7 +28,6 @@ Returns `TRUE` if the string expr matches the regular expression specified by th
 
 ## **Examples**
 
-<!-- validator-ignore-exec -->
 ```SQL
 mysql> SELECT REGEXP_INSTR('Hello, my number is 12345.', '[0-9]+');
 +--------------------------------------------------+

--- a/docs/MatrixOne/Reference/Functions-and-Operators/String/Regular-Expressions/regexp-replace.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/String/Regular-Expressions/regexp-replace.md
@@ -32,7 +32,6 @@
 
 ## **Examples**
 
-<!-- validator-ignore-exec -->
 ```SQL
 mysql> SELECT REGEXP_REPLACE('Hello, World!', 'World', 'Universe');
 +------------------------------------------------+

--- a/docs/MatrixOne/Reference/Functions-and-Operators/String/Regular-Expressions/regexp-substr.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/String/Regular-Expressions/regexp-substr.md
@@ -30,7 +30,6 @@
 
 ## **Examples**
 
-<!-- validator-ignore-exec -->
 ```SQL
 mysql> SELECT REGEXP_SUBSTR('1a 2b 3c', '[0-9]a');
 +---------------------------------+

--- a/docs/MatrixOne/Reference/Functions-and-Operators/String/bit-length.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/String/bit-length.md
@@ -18,7 +18,6 @@ Returns the length of the string str in bits. Returns `NULL` if str is `NULL`.
 
 ## **Examples**
 
-<!-- validator-ignore-exec -->
 ```SQL
 > SELECT BIT_LENGTH('text');
 +------------------+

--- a/docs/MatrixOne/Reference/Functions-and-Operators/String/concat-ws.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/String/concat-ws.md
@@ -26,7 +26,6 @@ This function ``CONCAT_WS()`` stands for Concatenate With Separator and is a spe
 
 ## **Examples**
 
-<!-- validator-ignore-exec -->
 ```SQL
 SELECT CONCAT_WS(',','First name','Second name','Last Name');
 +--------------------------------------------------+

--- a/docs/MatrixOne/Reference/Functions-and-Operators/String/concat.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/String/concat.md
@@ -21,7 +21,6 @@ CONCAT(str1,str2,...)
 
 ## **Examples**
 
-<!-- validator-ignore-exec -->
 ```SQL
 mysql> SELECT CONCAT('My', 'S', 'QL');
 +-------------------+

--- a/docs/MatrixOne/Reference/Functions-and-Operators/String/empty.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/String/empty.md
@@ -23,7 +23,6 @@ Returns 1 for an empty string or 0 for a non-empty string.
 
 ## **Examples**
 
-<!-- validator-ignore-exec -->
 ```SQL
 > drop table if exists t1;
 > create table t1(a varchar(255),b varchar(255));

--- a/docs/MatrixOne/Reference/Functions-and-Operators/String/endswith.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/String/endswith.md
@@ -24,7 +24,6 @@ Returns whether to end with the specified suffix. Returns 1 if the string ends w
 
 ## **Examples**
 
-<!-- validator-ignore-exec -->
 ```sql
 > drop table if exists t1;
 > create table t1(a int,b varchar(100),c char(20));

--- a/docs/MatrixOne/Reference/Functions-and-Operators/String/field.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/String/field.md
@@ -33,7 +33,6 @@ If all arguments to `FIELD()` are strings, all arguments are compared as strings
 
 - Example 1:
 
-<!-- validator-ignore-exec -->
 ```sql
 mysql> SELECT FIELD('Bb', 'Aa', 'Bb', 'Cc', 'Dd', 'Ff');
 +-------------------------------+

--- a/docs/MatrixOne/Reference/Functions-and-Operators/String/format.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/String/format.md
@@ -20,7 +20,6 @@ Formats the number X to a format like '#,###,###.##', rounded to D decimal place
 
 ## **Examples**
 
-<!-- validator-ignore-exec -->
 ```SQL
 mysql> SELECT FORMAT(12332.123456, 4);
 +-------------------------+

--- a/docs/MatrixOne/Reference/Functions-and-Operators/String/from_base64.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/String/from_base64.md
@@ -18,7 +18,6 @@
 
 ## Examples
 
-<!-- validator-ignore-exec -->
 ```SQL
 mysql> select from_base64('MjU1');
 +-------------------+

--- a/docs/MatrixOne/Reference/Functions-and-Operators/String/hex.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/String/hex.md
@@ -23,7 +23,6 @@ For a `NULL` argument, this function returns `NULL`.
 
 ## **Examples**
 
-<!-- validator-ignore-exec -->
 ```SQL
 > SELECT HEX('abc');
 +----------+

--- a/docs/MatrixOne/Reference/Functions-and-Operators/String/instr.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/String/instr.md
@@ -33,7 +33,6 @@ The above query will return 0 because, in binary format, 'A' and 'a' are conside
 
 - Example 1
 
-<!-- validator-ignore-exec -->
 ```sql
 mysql> SELECT INSTR('foobarbar', 'bar');
 +-----------------------+
@@ -46,7 +45,6 @@ mysql> SELECT INSTR('foobarbar', 'bar');
 
 - Example 2
 
-<!-- validator-ignore-exec -->
 ```sql
 -- Using the INSTR function to find the first occurrence of 'o' in the string 'Hello World' will return 5, as 'o' first appears at the 5th position in 'Hello World'.
 mysql> SELECT INSTR('Hello World', 'o');

--- a/docs/MatrixOne/Reference/Functions-and-Operators/String/locate.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/String/locate.md
@@ -26,7 +26,6 @@ Regarding case, the `LOCATE()` function is case-insensitive.
 
 - Example 1
 
-<!-- validator-ignore-exec -->
 ```sql
 mysql> SELECT LOCATE('bar', 'footbarbar');
 +-------------------------+
@@ -39,7 +38,6 @@ mysql> SELECT LOCATE('bar', 'footbarbar');
 
 - Example 2
 
-<!-- validator-ignore-exec -->
 ```sql
 mysql>SELECT LOCATE('bar', 'footbarbar',6);
 +----------------------------+
@@ -52,7 +50,6 @@ mysql>SELECT LOCATE('bar', 'footbarbar',6);
 
 - Example 3
 
-<!-- validator-ignore-exec -->
 ```sql
 mysql>SELECT SUBSTRING('hello world',LOCATE('o','hello world'),5);
 +---------------------------------------------------+

--- a/docs/MatrixOne/Reference/Functions-and-Operators/String/space.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/String/space.md
@@ -18,7 +18,6 @@ SPACE(N) Returns a string consisting of N space characters.
 
 ## **Examples**
 
-<!-- validator-ignore-exec -->
 ```SQL
 > drop table if exists t1;
 > CREATE TABLE t1

--- a/docs/MatrixOne/Reference/Functions-and-Operators/String/startswith.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/String/startswith.md
@@ -24,7 +24,6 @@ Returns 1 whether string starts with the specified prefix, otherwise it returns 
 
 ## **Examples**
 
-<!-- validator-ignore-exec -->
 ```sql
 > drop table if exists t1;
 > create table t1(a int,b varchar(100),c char(20));

--- a/docs/MatrixOne/Reference/Functions-and-Operators/String/substring.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/String/substring.md
@@ -22,7 +22,6 @@ The forms without a len argument return a substring from string str starting at 
 
 ## **Examples**
 
-<!-- validator-ignore-exec -->
 ```SQL
 > CREATE TABLE IF NOT EXISTS t1 (
 pub_id varchar(8) COLLATE latin1_general_ci NOT NULL DEFAULT '',

--- a/docs/MatrixOne/Reference/Functions-and-Operators/String/to_base64.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/String/to_base64.md
@@ -20,7 +20,6 @@ You can decode a Base64 encoded string using the [`FROM_BASE64()`](from_base64.m
 
 ## Examples
 
-<!-- validator-ignore-exec -->
 ```SQL
 mysql> SELECT TO_BASE64('abc');
 +----------------+

--- a/docs/MatrixOne/Reference/Functions-and-Operators/String/unhex.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/String/unhex.md
@@ -20,7 +20,6 @@ The characters in the argument string must be legal hexadecimal digits: '0' .. '
 
 ## **Examples**
 
-<!-- validator-ignore-exec -->
 ```SQL
 mysql> SELECT UNHEX('4d6174726978204f726967696e');
 +-----------------------------------+

--- a/docs/MatrixOne/Reference/Functions-and-Operators/Vector/arithmetic.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/Vector/arithmetic.md
@@ -76,7 +76,6 @@ mysql> select cast("[1,2,3]" as vecf32(3)) + 5.0;
 
 ### **Examples**
 
-<!-- validator-ignore-exec -->
 ```sql
 drop table if exists vec_table;
 create table vec_table(a int, b vecf32(3), c vecf64(3));

--- a/docs/MatrixOne/Reference/Functions-and-Operators/Vector/subvector.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/Vector/subvector.md
@@ -19,7 +19,6 @@ The `SUBVECTOR()` function is used to extract subvectors from vectors.
 
 ## Examples
 
-<!-- validator-ignore-exec -->
 ```sql
 mysql> SELECT SUBVECTOR("[1,2,3]", 2);
 +-----------------------+

--- a/docs/MatrixOne/Reference/Functions-and-Operators/Window-Functions/dense_rank.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/Window-Functions/dense_rank.md
@@ -20,7 +20,6 @@ The `DENSE_RANK()` function handles ties (i.e., two or more rows with the same v
 
 ## **Examples**
 
-<!-- validator-ignore-exec -->
 ```sql
 -- Create a new table, 'SalesTable' with three fields: 'Department', 'Employee', and 'Sales'
 CREATE TABLE SalesTable (

--- a/docs/MatrixOne/Reference/Functions-and-Operators/Window-Functions/rank.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/Window-Functions/rank.md
@@ -20,7 +20,6 @@ The `RANK()` function has a unique behavior when it handles the case of equal va
 
 ## **Examples**
 
-<!-- validator-ignore-exec -->
 ```SQL
 -- Create a new table, 'SalesTable' with three fields: 'Department', 'Employee', and 'Sales'
 CREATE TABLE SalesTable (

--- a/docs/MatrixOne/Reference/Functions-and-Operators/Window-Functions/row_number.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/Window-Functions/row_number.md
@@ -20,7 +20,6 @@ Unlike the `RANK()` and `DENSE_RANK()` functions, `ROW_NUMBER()` gives each row 
 
 ## **Examples**
 
-<!-- validator-ignore-exec -->
 ```sql
 -- Create a new table, 'SalesTable' with three fields: 'Department', 'Employee', and 'Sales'
 CREATE TABLE SalesTable (

--- a/docs/MatrixOne/Reference/Operators/interval.md
+++ b/docs/MatrixOne/Reference/Operators/interval.md
@@ -64,7 +64,6 @@ We permits any punctuation delimiter in the expr format. Those shown in the tabl
 
 - Temporal intervals are used for `DATE_ADD()` and `DATE_SUB()`:
 
-<!-- validator-ignore-exec -->
 ```SQL
 mysql> SELECT DATE_SUB('2018-05-01',INTERVAL 1 YEAR);
 +-----------------------------------------+
@@ -135,7 +134,6 @@ mysql> SELECT DATE_ADD('1992-12-31 23:59:59.000002', INTERVAL '1.999999' SECOND_
 
 - Using INTERVAL together with the `+` or `-` operator
 
-<!-- validator-ignore-exec -->
 ```sql
 mysql> SELECT '2018-12-31 23:59:59' + INTERVAL 1 SECOND;
 +-------------------------------------------+
@@ -166,7 +164,6 @@ mysql> SELECT '2025-01-01' - INTERVAL 1 SECOND;
 
 If you add to or subtract from a date value something that contains a time part, the result is automatically converted to a datetime value:
 
-<!-- validator-ignore-exec -->
 ```sql
 mysql> SELECT DATE_ADD('2023-01-01', INTERVAL 1 DAY);
 +----------------------------------------+
@@ -189,7 +186,6 @@ mysql> SELECT DATE_ADD('2023-01-01', INTERVAL 1 HOUR);
 
 If you add MONTH, YEAR_MONTH, or YEAR and the resulting date has a day that is larger than the maximum day for the new month, the day is adjusted to the maximum days in the new month:
 
-<!-- validator-ignore-exec -->
 ```sql
 mysql> SELECT DATE_ADD('2019-01-30', INTERVAL 1 MONTH);
 +------------------------------------------+

--- a/docs/MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/assign-equal.md
+++ b/docs/MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/assign-equal.md
@@ -22,7 +22,6 @@ mysql> SELECT 2 = 2;
 1 row in set (0.01 sec)
 ```
 
-<!-- validator-ignore-exec -->
 ```sql
 create table t1 (spID smallint,userID bigint,score int);
 insert into t1 values (1,1,1);

--- a/docs/MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/coalesce.md
+++ b/docs/MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/coalesce.md
@@ -20,7 +20,6 @@ The `COALESCE()` function returns the first non-null value in a list.
 
 - Example: Calculate
 
-<!-- validator-ignore-exec -->
 ```sql
 mysql> SELECT COALESCE(1)+COALESCE(1);
 +---------------------------+

--- a/docs/MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/coalesce.md
+++ b/docs/MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/coalesce.md
@@ -173,7 +173,6 @@ mysql> SELECT * FROM ot1 LEFT JOIN ot2 ON ot1.a=ot2.a WHERE COALESCE(ot2.a,0) IN
 
 - Example: `HAVING`
 
-<!-- validator-ignore-exec -->
 ```sql
 drop table if exists t1;
 create table t1(a datetime);

--- a/docs/MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/function_isnull.md
+++ b/docs/MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/function_isnull.md
@@ -18,7 +18,6 @@ The `ISNULL()` function shares some special behaviors with the `IS NULL` compari
 
 - Example 1:
 
-<!-- validator-ignore-exec -->
 ```sql
 mysql> SELECT ISNULL(1+1);
 +---------------+

--- a/docs/MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/greater-than-or-equal.md
+++ b/docs/MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/greater-than-or-equal.md
@@ -22,7 +22,6 @@ mysql> SELECT 2 >= 2;
 1 row in set (0.01 sec)
 ```
 
-<!-- validator-ignore-exec -->
 ```sql
 create table t1 (spID smallint,userID bigint,score int);
 insert into t1 values (1,1,1);

--- a/docs/MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/greater-than.md
+++ b/docs/MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/greater-than.md
@@ -22,7 +22,6 @@ mysql> SELECT 2 > 2;
 1 row in set (0.00 sec)
 ```
 
-<!-- validator-ignore-exec -->
 ```sql
 create table t1 (spID smallint,userID bigint,score int);
 insert into t1 values (1,1,1);

--- a/docs/MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/less-than-or-equal.md
+++ b/docs/MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/less-than-or-equal.md
@@ -22,7 +22,6 @@ mysql> SELECT 2 <= 2;
 1 row in set (0.00 sec)
 ```
 
-<!-- validator-ignore-exec -->
 ```sql
 create table t1 (spID smallint,userID bigint,score int);
 insert into t1 values (1,1,1);

--- a/docs/MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/less-than.md
+++ b/docs/MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/less-than.md
@@ -22,7 +22,6 @@ mysql> SELECT 2 < 2;
 1 row in set (0.00 sec)
 ```
 
-<!-- validator-ignore-exec -->
 ```sql
 create table t1 (spID smallint,userID bigint,score int);
 insert into t1 values (1,1,1);

--- a/docs/MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/not-equal.md
+++ b/docs/MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/not-equal.md
@@ -22,7 +22,6 @@ mysql> SELECT 2 <> 2;
 1 row in set (0.01 sec)
 ```
 
-<!-- validator-ignore-exec -->
 ```sql
 create table t1 (spID smallint,userID bigint,score int);
 insert into t1 values (1,1,1);

--- a/docs/MatrixOne/Reference/Operators/operators/flow-control-functions/case-when.md
+++ b/docs/MatrixOne/Reference/Operators/operators/flow-control-functions/case-when.md
@@ -40,7 +40,6 @@ mysql> SELECT CASE WHEN 1>0 THEN 'true' ELSE 'false' END;
 1 row in set (0.00 sec)
 ```
 
-<!-- validator-ignore-exec -->
 ```sql
 CREATE TABLE t1 (a INT, b INT);
 Query OK, 0 rows affected (0.01 sec)

--- a/docs/MatrixOne/Reference/Operators/operators/flow-control-functions/function_if.md
+++ b/docs/MatrixOne/Reference/Operators/operators/flow-control-functions/function_if.md
@@ -26,7 +26,6 @@ The `IF()` function returns a value if a condition is `TRUE`, or another value i
 
 ## **Examples**
 
-<!-- validator-ignore-exec -->
 ```sql
 mysql> SELECT IF(1>2,2,3);
 +-----------------+

--- a/docs/MatrixOne/Reference/Operators/operators/flow-control-functions/function_ifnull.md
+++ b/docs/MatrixOne/Reference/Operators/operators/flow-control-functions/function_ifnull.md
@@ -13,7 +13,6 @@ The default return type of `IFNULL(expr1,expr2)` is the more "general" of the tw
 
 ## **Examples**
 
-<!-- validator-ignore-exec -->
 ```sql
 mysql> SELECT IFNULL(NULL,10);
 +------------------+

--- a/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/create-fulltext-index.md
+++ b/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/create-fulltext-index.md
@@ -52,7 +52,6 @@ MATCH (col1, col2, ...) AGAINST (expr [search_modifier]);
 
 ## Examples
 
-<!-- validator-ignore-exec -->
 ```sql
 CREATE TABLE example_table (
     id INT PRIMARY KEY,

--- a/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/create-fulltext-index.md
+++ b/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/create-fulltext-index.md
@@ -52,6 +52,7 @@ MATCH (col1, col2, ...) AGAINST (expr [search_modifier]);
 
 ## Examples
 
+<!-- validator-ignore-exec -->
 ```sql
 CREATE TABLE example_table (
     id INT PRIMARY KEY,

--- a/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/create-snapshot.md
+++ b/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/create-snapshot.md
@@ -21,7 +21,6 @@ CREATE SNAPSHOT <snapshot_name> FOR [CLUSTER]|[ACCOUNT [<account_name>]]|[DATABA
 
 **Example 1: Cluster admin creates a cluster-level snapshot**
 
-<!-- validator-ignore-exec -->
 ```sql
 CREATE SNAPSHOT cluster_sp FOR CLUSTER;
 mysql> SHOW SNAPSHOTS;

--- a/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/create-snapshot.md
+++ b/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/create-snapshot.md
@@ -21,6 +21,7 @@ CREATE SNAPSHOT <snapshot_name> FOR [CLUSTER]|[ACCOUNT [<account_name>]]|[DATABA
 
 **Example 1: Cluster admin creates a cluster-level snapshot**
 
+<!-- validator-ignore-exec -->
 ```sql
 CREATE SNAPSHOT cluster_sp FOR CLUSTER;
 mysql> SHOW SNAPSHOTS;

--- a/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/create-table-as-select.md
+++ b/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/create-table-as-select.md
@@ -58,7 +58,6 @@ For detailed permission operations, see [MatrixOne Permission Types](../../acces
 
 - Example 1: Copy entire table
 
-<!-- validator-ignore-exec -->
 ```sql
 CREATE TABLE t1(a INT DEFAULT 123, b CHAR(5));
 INSERT INTO t1 VALUES (1, '1'),(2,'2'),(0x7fffffff, 'max');
@@ -117,7 +116,6 @@ mysql> SELECT * FROM test;
 
 - Example 3: Copy schema only
 
-<!-- validator-ignore-exec -->
 ```sql
 CREATE TABLE t1(a INT DEFAULT 123, b CHAR(5));
 INSERT INTO t1 VALUES (1, '1'),(2,'2'),(0x7fffffff, 'max');
@@ -140,7 +138,6 @@ Empty set (0.00 sec)
 
 - Example 4: Aggregated values
 
-<!-- validator-ignore-exec -->
 ```sql
 CREATE TABLE t1(a INT DEFAULT 123, b CHAR(5));
 INSERT INTO t1 VALUES (1, '1'),(2,'2'),(0x7fffffff, 'max');
@@ -168,7 +165,6 @@ mysql> SELECT * FROM t4;
 
 - Example 5: DISTINCT rows
 
-<!-- validator-ignore-exec -->
 ```sql
 CREATE TABLE t5(n1 INT,n2 INT,n3 INT);
 INSERT INTO t5 VALUES(1,1,1),(1,1,1),(3,3,3);
@@ -188,7 +184,6 @@ mysql> SELECT * FROM t5_1;
 
 - Example 6: Sorted results
 
-<!-- validator-ignore-exec -->
 ```sql
 CREATE TABLE t6(n1 INT,n2 INT,n3 INT);
 INSERT INTO t6 VALUES(1,1,3),(2,2,2),(3,3,1);
@@ -209,7 +204,6 @@ mysql> SELECT * FROM t6_1;
 
 - Example 7: Grouped results
 
-<!-- validator-ignore-exec -->
 ```sql
 CREATE TABLE t7(n1 INT,n2 INT,n3 INT);
 INSERT INTO t7 VALUES(1,1,3),(1,2,2),(2,3,1),(2,3,1),(3,3,1);
@@ -229,7 +223,6 @@ mysql> SELECT * FROM t7_1;
 
 - Example 8: Limited rows
 
-<!-- validator-ignore-exec -->
 ```sql src/main.sql
 CREATE TABLE t8(n1 INT,n2 INT,n3 INT);
 INSERT INTO t8 VALUES(1,1,1),(2,2,2),(3,3,3);

--- a/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/create-table-as-select.md
+++ b/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/create-table-as-select.md
@@ -58,6 +58,7 @@ For detailed permission operations, see [MatrixOne Permission Types](../../acces
 
 - Example 1: Copy entire table
 
+<!-- validator-ignore-exec -->
 ```sql
 CREATE TABLE t1(a INT DEFAULT 123, b CHAR(5));
 INSERT INTO t1 VALUES (1, '1'),(2,'2'),(0x7fffffff, 'max');
@@ -116,6 +117,7 @@ mysql> SELECT * FROM test;
 
 - Example 3: Copy schema only
 
+<!-- validator-ignore-exec -->
 ```sql
 CREATE TABLE t1(a INT DEFAULT 123, b CHAR(5));
 INSERT INTO t1 VALUES (1, '1'),(2,'2'),(0x7fffffff, 'max');
@@ -138,6 +140,7 @@ Empty set (0.00 sec)
 
 - Example 4: Aggregated values
 
+<!-- validator-ignore-exec -->
 ```sql
 CREATE TABLE t1(a INT DEFAULT 123, b CHAR(5));
 INSERT INTO t1 VALUES (1, '1'),(2,'2'),(0x7fffffff, 'max');
@@ -165,6 +168,7 @@ mysql> SELECT * FROM t4;
 
 - Example 5: DISTINCT rows
 
+<!-- validator-ignore-exec -->
 ```sql
 CREATE TABLE t5(n1 INT,n2 INT,n3 INT);
 INSERT INTO t5 VALUES(1,1,1),(1,1,1),(3,3,3);
@@ -184,6 +188,7 @@ mysql> SELECT * FROM t5_1;
 
 - Example 6: Sorted results
 
+<!-- validator-ignore-exec -->
 ```sql
 CREATE TABLE t6(n1 INT,n2 INT,n3 INT);
 INSERT INTO t6 VALUES(1,1,3),(2,2,2),(3,3,1);
@@ -204,6 +209,7 @@ mysql> SELECT * FROM t6_1;
 
 - Example 7: Grouped results
 
+<!-- validator-ignore-exec -->
 ```sql
 CREATE TABLE t7(n1 INT,n2 INT,n3 INT);
 INSERT INTO t7 VALUES(1,1,3),(1,2,2),(2,3,1),(2,3,1),(3,3,1);
@@ -223,6 +229,7 @@ mysql> SELECT * FROM t7_1;
 
 - Example 8: Limited rows
 
+<!-- validator-ignore-exec -->
 ```sql src/main.sql
 CREATE TABLE t8(n1 INT,n2 INT,n3 INT);
 INSERT INTO t8 VALUES(1,1,1),(2,2,2),(3,3,3);

--- a/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/create-view.md
+++ b/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/create-view.md
@@ -69,7 +69,6 @@ mysql> SHOW CREATE VIEW v0;
 
 - Example 2:
 
-<!-- validator-ignore-exec -->
 ```sql
 drop table if exists t1;
 create table t1 (id int,ti tinyint unsigned,si smallint,bi bigint unsigned,fl float,dl double,de decimal,ch char(20),vch varchar(20),dd date,dt datetime);

--- a/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-create-en.md
+++ b/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-create-en.md
@@ -89,6 +89,7 @@ You can specify the data point in time using the following methods:
 
 Create a data branch from an existing table:
 
+<!-- validator-ignore-exec -->
 ```sql
 -- Expected-Rows: 0
 CREATE DATABASE test;
@@ -148,6 +149,7 @@ DATA BRANCH CREATE TABLE test.orders_dev FROM test.orders;
 
 Create a data branch from a specific point in time using a snapshot:
 
+<!-- validator-ignore-exec -->
 ```sql
 -- Expected-Rows: 0
 CREATE TABLE test.products (
@@ -187,6 +189,7 @@ DROP SNAPSHOT sp_products;
 
 Create a branch of an entire database:
 
+<!-- validator-ignore-exec -->
 ```sql
 -- Expected-Rows: 0
 CREATE DATABASE source_db;
@@ -227,6 +230,7 @@ SELECT * FROM dev_db.users;
 
 ### Example 4: Create Database Branch from Snapshot
 
+<!-- validator-ignore-exec -->
 ```sql
 -- Expected-Rows: 0
 CREATE SNAPSHOT sp_source FOR DATABASE source_db;
@@ -259,6 +263,7 @@ DROP SNAPSHOT sp_source;
 
 Create new branches from existing branches:
 
+<!-- validator-ignore-exec -->
 ```sql
 -- Expected-Rows: 0
 USE test;

--- a/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-create-en.md
+++ b/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-create-en.md
@@ -147,6 +147,7 @@ DATA BRANCH CREATE TABLE test.orders_dev FROM test.orders;
 ### Example 2: Create Table Branch from Snapshot
 
 Create a data branch from a specific point in time using a snapshot:
+
 ```sql
 -- Expected-Rows: 0
 CREATE TABLE test.products (
@@ -257,6 +258,7 @@ DROP SNAPSHOT sp_source;
 ### Example 5: Multi-level Branching
 
 Create new branches from existing branches:
+
 ```sql
 -- Expected-Rows: 0
 USE test;

--- a/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-create-en.md
+++ b/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-create-en.md
@@ -89,7 +89,6 @@ You can specify the data point in time using the following methods:
 
 Create a data branch from an existing table:
 
-<!-- validator-ignore-exec -->
 ```sql
 -- Expected-Rows: 0
 CREATE DATABASE test;
@@ -148,7 +147,6 @@ DATA BRANCH CREATE TABLE test.orders_dev FROM test.orders;
 ### Example 2: Create Table Branch from Snapshot
 
 Create a data branch from a specific point in time using a snapshot:
-<!-- validator-ignore-exec -->
 ```sql
 -- Expected-Rows: 0
 CREATE TABLE test.products (
@@ -188,7 +186,6 @@ DROP SNAPSHOT sp_products;
 
 Create a branch of an entire database:
 
-<!-- validator-ignore-exec -->
 ```sql
 -- Expected-Rows: 0
 CREATE DATABASE source_db;
@@ -229,7 +226,6 @@ SELECT * FROM dev_db.users;
 
 ### Example 4: Create Database Branch from Snapshot
 
-<!-- validator-ignore-exec -->
 ```sql
 -- Expected-Rows: 0
 CREATE SNAPSHOT sp_source FOR DATABASE source_db;
@@ -261,7 +257,6 @@ DROP SNAPSHOT sp_source;
 ### Example 5: Multi-level Branching
 
 Create new branches from existing branches:
-<!-- validator-ignore-exec -->
 ```sql
 -- Expected-Rows: 0
 USE test;

--- a/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-delete-en.md
+++ b/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-delete-en.md
@@ -165,6 +165,7 @@ DROP DATABASE source_db;
 
 ### Example 3: Metadata Status After Branch Deletion
 
+<!-- validator-ignore-exec -->
 ```sql
 -- Expected-Rows: 0
 CREATE DATABASE br_meta_db;
@@ -217,6 +218,7 @@ DROP DATABASE br_meta_db;
 
 ### Example 4: Batch Delete All Branch Tables in a Database
 
+<!-- validator-ignore-exec -->
 ```sql
 -- Expected-Rows: 0
 CREATE DATABASE src_db;

--- a/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-delete-en.md
+++ b/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-delete-en.md
@@ -165,7 +165,6 @@ DROP DATABASE source_db;
 
 ### Example 3: Metadata Status After Branch Deletion
 
-<!-- validator-ignore-exec -->
 ```sql
 -- Expected-Rows: 0
 CREATE DATABASE br_meta_db;
@@ -218,7 +217,6 @@ DROP DATABASE br_meta_db;
 
 ### Example 4: Batch Delete All Branch Tables in a Database
 
-<!-- validator-ignore-exec -->
 ```sql
 -- Expected-Rows: 0
 CREATE DATABASE src_db;

--- a/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-diff-en.md
+++ b/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-diff-en.md
@@ -79,7 +79,6 @@ The system automatically detects the branch relationship between two tables:
 
 Compare two tables without a common ancestor:
 
-<!-- validator-ignore-exec -->
 ```sql
 -- Expected-Rows: 0
 CREATE DATABASE test;
@@ -121,7 +120,6 @@ DROP TABLE test.t2;
 ```
 
 ### Example 2: Compare Branch Tables (With Common Ancestor)
-<!-- validator-ignore-exec -->
 ```sql
 -- Expected-Rows: 0
 CREATE TABLE test.t0 (a INT PRIMARY KEY, b INT);
@@ -156,7 +154,6 @@ DROP TABLE test.t2;
 ```
 
 ### Example 3: Compare Using Snapshots
-<!-- validator-ignore-exec -->
 ```sql
 -- Expected-Rows: 0
 CREATE TABLE test.t1 (a INT PRIMARY KEY, b INT);
@@ -194,7 +191,6 @@ DROP TABLE test.t1;
     When comparing two snapshots of the same table, the system compares based on incremental changes between snapshots. In this example, although the UPDATE operation modified the row where a=1, due to the special mechanism of snapshot comparison, only the newly inserted row is shown.
 
 ### Example 4: Get Only Difference Count
-<!-- validator-ignore-exec -->
 ```sql
 -- Expected-Rows: 0
 CREATE TABLE test.t1 (a INT PRIMARY KEY, b INT);
@@ -223,7 +219,6 @@ DROP TABLE test.t2;
 ```
 
 ### Example 5: Limit Returned Rows
-<!-- validator-ignore-exec -->
 ```sql
 -- Expected-Rows: 0
 CREATE TABLE test.t1 (a INT PRIMARY KEY, b INT);
@@ -258,7 +253,6 @@ DROP TABLE test.t2;
 
 ### Example 6: Export Differences as SQL File
 
-<!-- validator-ignore-exec -->
 ```sql
 -- Expected-Rows: 0
 CREATE TABLE test.t1 (a INT PRIMARY KEY, b INT);
@@ -319,7 +313,6 @@ LINES TERMINATED BY '\n';
 
 Stage is a logical object in MatrixOne for connecting to external storage (such as S3, HDFS). You can output difference files directly to object storage for cross-cluster/cross-environment data synchronization.
 
-<!-- validator-ignore-exec -->
 ```sql
 -- Expected-Rows: 0
 CREATE STAGE my_stage URL = 's3://my-bucket/diff-output/?region=us-east-1&access_key_id=xxx&secret_access_key=yyy';
@@ -347,7 +340,6 @@ Advantages of using Stage:
 
 ### Example 7: Detect Update Operations
 
-<!-- validator-ignore-exec -->
 ```sql
 -- Expected-Rows: 0
 CREATE TABLE test.t0 (a INT PRIMARY KEY, b INT, c INT);
@@ -388,7 +380,6 @@ DROP TABLE test.t2;
 
 ### Example 8: Difference Comparison for Composite Primary Key Tables
 
-<!-- validator-ignore-exec -->
 ```sql
 -- Expected-Rows: 0
 CREATE TABLE test.orders (

--- a/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-diff-en.md
+++ b/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-diff-en.md
@@ -79,6 +79,7 @@ The system automatically detects the branch relationship between two tables:
 
 Compare two tables without a common ancestor:
 
+<!-- validator-ignore-exec -->
 ```sql
 -- Expected-Rows: 0
 CREATE DATABASE test;
@@ -121,6 +122,7 @@ DROP TABLE test.t2;
 
 ### Example 2: Compare Branch Tables (With Common Ancestor)
 
+<!-- validator-ignore-exec -->
 ```sql
 -- Expected-Rows: 0
 CREATE TABLE test.t0 (a INT PRIMARY KEY, b INT);
@@ -156,6 +158,7 @@ DROP TABLE test.t2;
 
 ### Example 3: Compare Using Snapshots
 
+<!-- validator-ignore-exec -->
 ```sql
 -- Expected-Rows: 0
 CREATE TABLE test.t1 (a INT PRIMARY KEY, b INT);
@@ -194,6 +197,7 @@ DROP TABLE test.t1;
 
 ### Example 4: Get Only Difference Count
 
+<!-- validator-ignore-exec -->
 ```sql
 -- Expected-Rows: 0
 CREATE TABLE test.t1 (a INT PRIMARY KEY, b INT);
@@ -223,6 +227,7 @@ DROP TABLE test.t2;
 
 ### Example 5: Limit Returned Rows
 
+<!-- validator-ignore-exec -->
 ```sql
 -- Expected-Rows: 0
 CREATE TABLE test.t1 (a INT PRIMARY KEY, b INT);
@@ -257,6 +262,7 @@ DROP TABLE test.t2;
 
 ### Example 6: Export Differences as SQL File
 
+<!-- validator-ignore-exec -->
 ```sql
 -- Expected-Rows: 0
 CREATE TABLE test.t1 (a INT PRIMARY KEY, b INT);
@@ -317,6 +323,7 @@ LINES TERMINATED BY '\n';
 
 Stage is a logical object in MatrixOne for connecting to external storage (such as S3, HDFS). You can output difference files directly to object storage for cross-cluster/cross-environment data synchronization.
 
+<!-- validator-ignore-exec -->
 ```sql
 -- Expected-Rows: 0
 CREATE STAGE my_stage URL = 's3://my-bucket/diff-output/?region=us-east-1&access_key_id=xxx&secret_access_key=yyy';
@@ -344,6 +351,7 @@ Advantages of using Stage:
 
 ### Example 7: Detect Update Operations
 
+<!-- validator-ignore-exec -->
 ```sql
 -- Expected-Rows: 0
 CREATE TABLE test.t0 (a INT PRIMARY KEY, b INT, c INT);
@@ -384,6 +392,7 @@ DROP TABLE test.t2;
 
 ### Example 8: Difference Comparison for Composite Primary Key Tables
 
+<!-- validator-ignore-exec -->
 ```sql
 -- Expected-Rows: 0
 CREATE TABLE test.orders (

--- a/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-diff-en.md
+++ b/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-diff-en.md
@@ -307,7 +307,6 @@ mysql -h <mo_host> -P <mo_port> -u <user> -p <db_name> < diff_t2_t1_20241225.sql
 
 **Import CSV file (full sync)**:
 
-<!-- validator-ignore-exec -->
 ```sql
 -- Expected-Success: false
 LOAD DATA LOCAL INFILE '/tmp/diff_output/diff_xxx.csv'

--- a/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-diff-en.md
+++ b/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-diff-en.md
@@ -120,6 +120,7 @@ DROP TABLE test.t2;
 ```
 
 ### Example 2: Compare Branch Tables (With Common Ancestor)
+
 ```sql
 -- Expected-Rows: 0
 CREATE TABLE test.t0 (a INT PRIMARY KEY, b INT);
@@ -154,6 +155,7 @@ DROP TABLE test.t2;
 ```
 
 ### Example 3: Compare Using Snapshots
+
 ```sql
 -- Expected-Rows: 0
 CREATE TABLE test.t1 (a INT PRIMARY KEY, b INT);
@@ -191,6 +193,7 @@ DROP TABLE test.t1;
     When comparing two snapshots of the same table, the system compares based on incremental changes between snapshots. In this example, although the UPDATE operation modified the row where a=1, due to the special mechanism of snapshot comparison, only the newly inserted row is shown.
 
 ### Example 4: Get Only Difference Count
+
 ```sql
 -- Expected-Rows: 0
 CREATE TABLE test.t1 (a INT PRIMARY KEY, b INT);
@@ -219,6 +222,7 @@ DROP TABLE test.t2;
 ```
 
 ### Example 5: Limit Returned Rows
+
 ```sql
 -- Expected-Rows: 0
 CREATE TABLE test.t1 (a INT PRIMARY KEY, b INT);

--- a/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-merge-en.md
+++ b/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-merge-en.md
@@ -68,6 +68,7 @@ Conflicts occur when:
 
 ### Example 1: Simple Merge (No Conflicts)
 
+<!-- validator-ignore-exec -->
 ```sql
 -- Expected-Rows: 0
 CREATE DATABASE test;
@@ -128,6 +129,7 @@ DROP TABLE test.t2;
 
 ### Example 2: Handling INSERT Conflicts
 
+<!-- validator-ignore-exec -->
 ```sql
 -- Create base table
 -- Expected-Rows: 0
@@ -197,6 +199,7 @@ DROP TABLE test.t2;
 
 ### Example 3: Handling UPDATE Conflicts
 
+<!-- validator-ignore-exec -->
 ```sql
 -- Create base table
 -- Expected-Rows: 0
@@ -254,6 +257,7 @@ DROP TABLE test.t2;
 
 ### Example 4: Merge Without Common Ancestor
 
+<!-- validator-ignore-exec -->
 ```sql
 -- Create two independent tables
 -- Expected-Rows: 0
@@ -312,6 +316,7 @@ DROP TABLE test.t2;
 
 ### Example 5: Complex Merge Scenario
 
+<!-- validator-ignore-exec -->
 ```sql
 -- Create base table
 -- Expected-Rows: 0
@@ -384,6 +389,7 @@ DROP TABLE test.t3;
 
 ### Example 6: Merge with NULL Values
 
+<!-- validator-ignore-exec -->
 ```sql
 -- Create table with NULL values
 -- Expected-Rows: 0

--- a/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-merge-en.md
+++ b/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-merge-en.md
@@ -68,7 +68,6 @@ Conflicts occur when:
 
 ### Example 1: Simple Merge (No Conflicts)
 
-<!-- validator-ignore-exec -->
 ```sql
 -- Expected-Rows: 0
 CREATE DATABASE test;
@@ -129,7 +128,6 @@ DROP TABLE test.t2;
 
 ### Example 2: Handling INSERT Conflicts
 
-<!-- validator-ignore-exec -->
 ```sql
 -- Create base table
 -- Expected-Rows: 0
@@ -199,7 +197,6 @@ DROP TABLE test.t2;
 
 ### Example 3: Handling UPDATE Conflicts
 
-<!-- validator-ignore-exec -->
 ```sql
 -- Create base table
 -- Expected-Rows: 0
@@ -257,7 +254,6 @@ DROP TABLE test.t2;
 
 ### Example 4: Merge Without Common Ancestor
 
-<!-- validator-ignore-exec -->
 ```sql
 -- Create two independent tables
 -- Expected-Rows: 0
@@ -316,7 +312,6 @@ DROP TABLE test.t2;
 
 ### Example 5: Complex Merge Scenario
 
-<!-- validator-ignore-exec -->
 ```sql
 -- Create base table
 -- Expected-Rows: 0
@@ -389,7 +384,6 @@ DROP TABLE test.t3;
 
 ### Example 6: Merge with NULL Values
 
-<!-- validator-ignore-exec -->
 ```sql
 -- Create table with NULL values
 -- Expected-Rows: 0

--- a/docs/MatrixOne/Reference/SQL-Reference/Data-Manipulation-Language/case.md
+++ b/docs/MatrixOne/Reference/SQL-Reference/Data-Manipulation-Language/case.md
@@ -45,7 +45,6 @@ For the second syntax, each `WHEN` clause search_condition expression is evaluat
 
 ## **Examples**
 
-<!-- validator-ignore-exec -->
 ```sql
 CREATE TABLE t1(c0 INTEGER, c1 INTEGER, c2 INTEGER);
 INSERT INTO t1 VALUES(1, 1, 1), (1, 1, 1);

--- a/docs/MatrixOne/Reference/SQL-Reference/Data-Manipulation-Language/insert.md
+++ b/docs/MatrixOne/Reference/SQL-Reference/Data-Manipulation-Language/insert.md
@@ -18,7 +18,6 @@ Writing data.
 
 ## **Examples**
 
-<!-- validator-ignore-exec -->
 ```sql
 drop table if exists t1;
 create table t1(a int default (1+12), b int);

--- a/docs/MatrixOne/Reference/SQL-Reference/Data-Manipulation-Language/upsert/insert-on-duplicate.md
+++ b/docs/MatrixOne/Reference/SQL-Reference/Data-Manipulation-Language/upsert/insert-on-duplicate.md
@@ -21,6 +21,7 @@ It is important to note that using this syntax presupposes that a primary key co
 
 ## **Examples**
 
+<!-- validator-ignore-exec -->
 ```sql
 CREATE TABLE user (
     id INT(11) NOT NULL PRIMARY KEY,

--- a/docs/MatrixOne/Reference/SQL-Reference/Data-Manipulation-Language/upsert/insert-on-duplicate.md
+++ b/docs/MatrixOne/Reference/SQL-Reference/Data-Manipulation-Language/upsert/insert-on-duplicate.md
@@ -21,7 +21,6 @@ It is important to note that using this syntax presupposes that a primary key co
 
 ## **Examples**
 
-<!-- validator-ignore-exec -->
 ```sql
 CREATE TABLE user (
     id INT(11) NOT NULL PRIMARY KEY,

--- a/docs/MatrixOne/Reference/Variable/system-variables/illegal_login_restrictions.md
+++ b/docs/MatrixOne/Reference/Variable/system-variables/illegal_login_restrictions.md
@@ -42,7 +42,6 @@ set global password_reuse_interval=xx; -- unit is days
 
 ### connection_control_failed_connections_threshold & connection_control_max_connection_delay
 
-<!-- validator-ignore-exec -->
 ```sql
 mysql> SELECT @@global.connection_control_failed_connections_threshold;
 +---------------------------------------------------+
@@ -127,7 +126,6 @@ mysql>
 
 ### default_password_lifetime
 
-<!-- validator-ignore-exec -->
 ```sql
 mysql> SELECT @@global.default_password_lifetime;
 +-----------------------------+
@@ -194,7 +192,6 @@ Query OK, 1 row affected (0.03 sec)
 
 ### password_history
 
-<!-- validator-ignore-exec -->
 ```sql
 mysql> SELECT @@global.password_history;
 +--------------------+
@@ -235,7 +232,6 @@ Query OK, 0 rows affected (0.01 sec)
 
 ### password_reuse_interval
 
-<!-- validator-ignore-exec -->
 ```sql
 mysql> select @@global.password_reuse_interval;
 +---------------------------+

--- a/docs/MatrixOne/Reference/Variable/system-variables/password_complex.md
+++ b/docs/MatrixOne/Reference/Variable/system-variables/password_complex.md
@@ -71,7 +71,6 @@ set global validate_password.special_char_count==xx; -- Default is 1
 
 ### validate_password
 
-<!-- validator-ignore-exec -->
 ```sql
 mysql> select @@global.validate_password;
 +---------------------+
@@ -97,7 +96,6 @@ mysql> select @@global.validate_password;
 
 ### validate_password.changed_characters_percentage
 
-<!-- validator-ignore-exec -->
 ```sql
 mysql> select @@global.validate_password.changed_characters_percentage;
 +---------------------------------------------------+
@@ -138,7 +136,6 @@ Query OK, 0 rows affected (0.01 sec)
 
 The following parameters need to enable validate_password.policy to take effect.
 
-<!-- validator-ignore-exec -->
 ```sql
 mysql> select @@global.validate_password.policy;
 +----------------------------+
@@ -161,7 +158,6 @@ mysql> select @@global.validate_password.policy;
 
 #### validate_password.length
 
-<!-- validator-ignore-exec -->
 ```sql
 mysql> select @@global.validate_password.length;
 +----------------------------+
@@ -197,7 +193,6 @@ Query OK, 0 rows affected (0.02 sec)
 
 #### validate_password.mixed_case_count
 
-<!-- validator-ignore-exec -->
 ```sql
 mysql> select @@global.validate_password.mixed_case_count;
 +--------------------------------------+
@@ -234,7 +229,6 @@ Query OK, 0 rows affected (0.01 sec)
 
 #### validate_password.number_count
 
-<!-- validator-ignore-exec -->
 ```sql
 mysql> select @@global.validate_password.number_count;
 +----------------------------------+
@@ -270,7 +264,6 @@ Query OK, 0 rows affected (0.01 sec)
 
 #### validate_password.special_char_count
 
-<!-- validator-ignore-exec -->
 ```sql
 mysql> select @@global.validate_password.special_char_count;
 +----------------------------------------+

--- a/docs/MatrixOne/Tutorial/git4data-demo.md
+++ b/docs/MatrixOne/Tutorial/git4data-demo.md
@@ -347,6 +347,7 @@ Result:
 
 After branches are no longer needed, clean them up promptly:
 
+<!-- validator-ignore-exec -->
 ```sql
 DATA BRANCH DELETE TABLE orders_risk;
 DATA BRANCH DELETE TABLE orders_promo;

--- a/docs/MatrixOne/Tutorial/git4data-demo.md
+++ b/docs/MatrixOne/Tutorial/git4data-demo.md
@@ -99,6 +99,7 @@ Result:
 
 Before any modifications, take a snapshot of the main table first. This is your "safety net" — no matter what happens next, you can always return to this point.
 
+<!-- validator-ignore-exec -->
 ```sql
 CREATE SNAPSHOT sp_orders_v1 FOR TABLE demo_branch orders;
 ```
@@ -118,7 +119,6 @@ DATA BRANCH CREATE TABLE orders_promo FROM orders;
 
 At this point, all three tables have identical data. Let's verify:
 
-<!-- validator-ignore-exec -->
 ```sql
 SELECT * FROM orders_risk ORDER BY order_id;
 SELECT * FROM orders_promo ORDER BY order_id;
@@ -161,7 +161,6 @@ INSERT INTO orders_promo VALUES (1007, 'Grace', 39.90, 0, 'summer_sale');
 
 At this point, the main table is completely unaffected:
 
-<!-- validator-ignore-exec -->
 ```sql
 SELECT * FROM orders ORDER BY order_id;
 -- Still the original 5 rows, with no changes whatsoever
@@ -271,7 +270,6 @@ DATA BRANCH MERGE orders_risk INTO orders;
 
 Verify the main table:
 
-<!-- validator-ignore-exec -->
 ```sql
 SELECT * FROM orders ORDER BY order_id;
 ```
@@ -322,7 +320,6 @@ DATA BRANCH MERGE orders_promo INTO orders WHEN CONFLICT SKIP;
 
 Verify the final result:
 
-<!-- validator-ignore-exec -->
 ```sql
 SELECT * FROM orders ORDER BY order_id;
 ```
@@ -370,6 +367,7 @@ This is the value of snapshots — turning "rollback" from a high-risk operation
 
 ### Clean Up the Environment
 
+<!-- validator-ignore-exec -->
 ```sql
 DROP SNAPSHOT sp_orders_v1;
 DROP DATABASE demo_branch;

--- a/scripts/doc-validator/checkers/sql-runner.js
+++ b/scripts/doc-validator/checkers/sql-runner.js
@@ -1441,6 +1441,21 @@ export class SqlRunner {
         return SqlRunner.VOLATILE_COLUMNS.has(String(col).trim().toLowerCase())
     }
 
+    // SQL column identifiers are case-insensitive. The expected tables in docs
+    // follow the mysql CLI convention of lower-casing function-call column
+    // headers (`any_value(t1.b)`), while MO returns them with the function
+    // preserved as written (`ANY_VALUE(t1.b)`). Look up actual-row values by
+    // canonicalised name so the comparator does not flag these as mismatches.
+    static lookupCell(row, col) {
+        if (row == null) return undefined
+        if (Object.prototype.hasOwnProperty.call(row, col)) return row[col]
+        const want = String(col).trim().toLowerCase()
+        for (const key of Object.keys(row)) {
+            if (key.trim().toLowerCase() === want) return row[key]
+        }
+        return undefined
+    }
+
     /** Compare table output with actual query results */
     compareTableOutput(actualRows, expectedTableStr) {
         if (/^\s*Empty\s+set/i.test(expectedTableStr.trim())) {
@@ -1466,21 +1481,21 @@ export class SqlRunner {
 
         for (let i = 0; i < expected.rows.length; i++) {
             for (const col of expected.columns) {
+                const actualVal = SqlRunner.lookupCell(actualRows[i], col)
                 // Skip volatile columns — their values depend on the sandbox
                 // database, wall-clock time, assigned role/user id, etc.
                 // We only require the column to be present and non-null.
                 if (SqlRunner.isVolatileColumn(col)) {
-                    if (actualRows[i][col] === undefined) {
+                    if (actualVal === undefined) {
                         return { matched: false, reason: `Row ${i + 1}, column '${col}': column missing in actual result` }
                     }
                     continue
                 }
-                if (!this.valuesMatch(actualRows[i][col], expected.rows[i][col])) {
-                    // Serialize objects for display in error message
-                    const actualVal = typeof actualRows[i][col] === 'object' && actualRows[i][col] !== null
-                        ? JSON.stringify(actualRows[i][col])
-                        : actualRows[i][col]
-                    return { matched: false, reason: `Row ${i + 1}, column '${col}': expected '${expected.rows[i][col]}', but got '${actualVal}'` }
+                if (!this.valuesMatch(actualVal, expected.rows[i][col])) {
+                    const display = typeof actualVal === 'object' && actualVal !== null
+                        ? JSON.stringify(actualVal)
+                        : actualVal
+                    return { matched: false, reason: `Row ${i + 1}, column '${col}': expected '${expected.rows[i][col]}', but got '${display}'` }
                 }
             }
         }

--- a/scripts/doc-validator/dry-run-ignored.mjs
+++ b/scripts/doc-validator/dry-run-ignored.mjs
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+// Dry-run harness: bypass validator-ignore-exec and actually execute every
+// currently-ignored block. Produces a per-block PASS/FAIL report so we can tell
+// which ignore-exec labels are now obsolete.
+
+import { readFileSync, writeFileSync, readdirSync, statSync } from 'node:fs'
+import { join, relative } from 'node:path'
+import { extractSqlFromContent } from './utils/sql-extractor.js'
+import { SqlRunner } from './checkers/sql-runner.js'
+import { config } from './config.js'
+
+const ROOT = 'docs/MatrixOne'
+const OUT = 'tmp/dry-run/report.json'
+
+function walk(dir) {
+    const out = []
+    for (const name of readdirSync(dir)) {
+        const p = join(dir, name)
+        const s = statSync(p)
+        if (s.isDirectory()) out.push(...walk(p))
+        else if (name.endsWith('.md')) out.push(p)
+    }
+    return out
+}
+
+function blocksWithIgnore(filePath) {
+    const content = readFileSync(filePath, 'utf-8')
+    // Extract with original semantics first, then flip flag.
+    const all = extractSqlFromContent(content, filePath)
+    return all.filter(b => b.executionIgnored)
+}
+
+async function main() {
+    const runner = new SqlRunner()
+    runner.enable()
+    const ok = await runner.connect()
+    if (!ok) {
+        console.error('db connect failed')
+        process.exit(1)
+    }
+
+    const files = walk(ROOT)
+    const report = {
+        started: new Date().toISOString(),
+        dbImage: process.env.MO_IMAGE || 'unknown',
+        totalFiles: files.length,
+        results: [],
+    }
+
+    let filesWithIgnored = 0
+    let blocksTotal = 0
+
+    for (const file of files) {
+        let ignored
+        try { ignored = blocksWithIgnore(file) } catch (e) {
+            report.results.push({ file: relative('.', file), error: 'extract_failed', message: e.message })
+            continue
+        }
+        if (ignored.length === 0) continue
+        filesWithIgnored++
+        process.stderr.write(`[${filesWithIgnored}] ${relative('.', file)} (${ignored.length} blocks)\n`)
+
+        // Each file gets its own test database to keep state isolated.
+        const baseName = file.replace(/[^a-zA-Z0-9]/g, '_').substring(0, 30)
+        let testDb
+        try {
+            testDb = await runner.dbManager.createTestDatabase(baseName)
+            runner.currentTestDb = testDb
+            runner.userCreatedDatabases = new Set()
+        } catch (e) {
+            report.results.push({ file: relative('.', file), error: 'db_setup_failed', message: e.message })
+            continue
+        }
+
+        for (const block of ignored) {
+            blocksTotal++
+            // Bypass the skip flag.
+            const forced = { ...block, executionIgnored: false }
+            // Pre-filter: the SLEEP() / long-running / KILL examples will wedge or kill
+            // the MO connection. Skip them in dry-run harness; they need a multi-session
+            // test environment we don't have here. Record as SKIP_HARNESS.
+            const sqlUpper = (block.sql || '').toUpperCase()
+            const hang = /\bSLEEP\s*\(|\bKILL\s+\d|\bCREATE\s+PROCEDURE|\bWAITFOR\b/.test(sqlUpper)
+            if (hang) {
+                report.results.push({
+                    file: relative('.', file),
+                    startLine: block.startLine,
+                    endLine: block.endLine,
+                    format: block.format,
+                    sqlPreview: (block.sql || '').split('\n').slice(0, 2).join(' ⏎ ').slice(0, 160),
+                    verdict: 'SKIP_HARNESS',
+                    reason: 'hang-risk',
+                })
+                continue
+            }
+
+            let blockResults = []
+            let thrown = null
+            const timeoutMs = 20000
+            try {
+                blockResults = await Promise.race([
+                    runner.checkSqlBlock(forced),
+                    new Promise((_, rej) => setTimeout(() => rej(new Error('harness-timeout')), timeoutMs)),
+                ])
+            } catch (e) {
+                thrown = e.message || String(e)
+            }
+            const errors = blockResults.filter(r => r.status === 'ERROR')
+            const successes = blockResults.filter(r => r.status === 'SUCCESS' || r.status === 'SKIP')
+            let verdict
+            if (thrown) verdict = 'THROWN'
+            else if (blockResults.length === 0) verdict = 'NO_STATEMENTS'
+            else if (errors.length === 0) verdict = 'PASS'
+            else if (successes.length === 0) verdict = 'FAIL_ALL'
+            else verdict = 'FAIL_PARTIAL'
+
+            report.results.push({
+                file: relative('.', file),
+                startLine: block.startLine,
+                endLine: block.endLine,
+                format: block.format,
+                sqlPreview: (block.sql || '').split('\n').slice(0, 2).join(' ⏎ ').slice(0, 160),
+                statements: blockResults.length,
+                passed: successes.length,
+                failed: errors.length,
+                verdict,
+                firstError: errors[0]?.message || thrown || null,
+            })
+        }
+
+        // Teardown
+        for (const dbName of runner.userCreatedDatabases || []) {
+            try { await runner.dbManager.query(`DROP DATABASE IF EXISTS \`${dbName}\``) } catch {}
+        }
+        if (testDb) {
+            try { await runner.dbManager.dropTestDatabase(testDb) } catch {}
+        }
+        runner.currentTestDb = null
+        runner.userCreatedDatabases = null
+    }
+
+    await runner.disconnect()
+
+    report.finished = new Date().toISOString()
+    report.filesWithIgnored = filesWithIgnored
+    report.blocksTotal = blocksTotal
+    const tally = {}
+    for (const r of report.results) {
+        if (!r.verdict) continue
+        tally[r.verdict] = (tally[r.verdict] || 0) + 1
+    }
+    report.tally = tally
+
+    writeFileSync(OUT, JSON.stringify(report, null, 2))
+    console.log(JSON.stringify(tally, null, 2))
+    console.log(`files_with_ignored=${filesWithIgnored} blocks_total=${blocksTotal}`)
+    console.log(`report: ${OUT}`)
+}
+
+main().catch(e => { console.error(e); process.exit(1) })

--- a/scripts/doc-validator/re-ignore-failed.mjs
+++ b/scripts/doc-validator/re-ignore-failed.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+// Given the output of `node scripts/doc-validator/index.js --check=execution`,
+// locate each failing fence in the (already-stripped) docs and re-add
+// `<!-- validator-ignore-exec -->` above it. This recovers ignore-exec on
+// fences whose dry-run PASS verdict does not hold in the accumulated
+// per-file execution context.
+
+import { readFileSync, writeFileSync } from 'node:fs'
+
+const args = process.argv.slice(2).filter(a => !a.startsWith('--'))
+const INPUT = args[0] || 'tmp/dry-run/verify-stdout.log'
+const DRY = process.argv.includes('--dry-run')
+
+function parseFailures(text) {
+    const out = {}
+    const lines = text.split('\n')
+    let cur = null
+    for (const l of lines) {
+        const m = l.match(/^❌\s+(\S+)/)
+        if (m) { cur = m[1]; out[cur] = new Set(); continue }
+        const e = l.match(/^\s+:(\d+)\s+/)
+        if (e && cur) out[cur].add(+e[1])
+    }
+    return out
+}
+
+// For each failing line in a file, find the enclosing sql fence (```sql ... ```)
+// and return its start line (the fence opener line number, 1-indexed).
+function findFencesContaining(fileText, failingLines) {
+    const lines = fileText.split('\n')
+    const fences = [] // {fenceOpen: 1-based, fenceClose: 1-based}
+    let openAt = -1
+    for (let i = 0; i < lines.length; i++) {
+        if (/^\s*```sql\b/i.test(lines[i]) && openAt === -1) {
+            openAt = i
+        } else if (/^\s*```\s*$/.test(lines[i]) && openAt !== -1) {
+            fences.push({ open: openAt + 1, close: i + 1 })
+            openAt = -1
+        }
+    }
+    const targetOpens = new Set()
+    for (const ln of failingLines) {
+        const f = fences.find(f => f.open <= ln && ln <= f.close)
+        if (f) targetOpens.add(f.open)
+    }
+    return [...targetOpens].sort((a, b) => a - b)
+}
+
+function addIgnoreAbove(text, fenceOpen) {
+    const lines = text.split('\n')
+    const idx = fenceOpen - 1
+    if (idx < 0 || idx >= lines.length) return { text, changed: false, reason: 'oob' }
+    // Already inline-marked?
+    if (/<!--\s*validator-ignore-exec\s*-->/.test(lines[idx])) return { text, changed: false, reason: 'already_inline' }
+    // Already marked above (walk past blanks)?
+    let up = idx - 1
+    while (up >= 0 && lines[up].trim() === '') up--
+    if (up >= 0 && /^\s*<!--\s*validator-ignore-exec\s*-->\s*$/.test(lines[up])) {
+        return { text, changed: false, reason: 'already_above' }
+    }
+    // Preserve indentation of the fence.
+    const indentMatch = lines[idx].match(/^(\s*)/)
+    const indent = indentMatch ? indentMatch[1] : ''
+    lines.splice(idx, 0, `${indent}<!-- validator-ignore-exec -->`)
+    return { text: lines.join('\n'), changed: true }
+}
+
+function main() {
+    const failures = parseFailures(readFileSync(INPUT, 'utf-8'))
+    let filesChanged = 0, fencesReAdded = 0, skipped = 0
+    const misses = []
+    for (const [file, setLines] of Object.entries(failures)) {
+        if (!setLines.size) continue
+        let text = readFileSync(file, 'utf-8')
+        const opens = findFencesContaining(text, setLines)
+        if (!opens.length) {
+            misses.push({ file, lines: [...setLines], reason: 'no_fence_found' })
+            continue
+        }
+        // Add from largest to smallest to keep earlier line numbers stable.
+        opens.sort((a, b) => b - a)
+        let fileChanged = false
+        for (const open of opens) {
+            const res = addIgnoreAbove(text, open)
+            if (res.changed) {
+                text = res.text
+                fileChanged = true
+                fencesReAdded++
+            } else {
+                skipped++
+            }
+        }
+        if (fileChanged) {
+            if (!DRY) writeFileSync(file, text)
+            filesChanged++
+        }
+    }
+    console.log(JSON.stringify({
+        mode: DRY ? 'dry-run' : 'apply',
+        files_changed: filesChanged,
+        fences_re_added: fencesReAdded,
+        skipped,
+        misses: misses.length,
+    }, null, 2))
+    if (misses.length) { console.log('misses:'); for (const m of misses) console.log(' ', m) }
+}
+
+main()

--- a/scripts/doc-validator/strip-ignore-exec.mjs
+++ b/scripts/doc-validator/strip-ignore-exec.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+// Remove `<!-- validator-ignore-exec -->` markers from fences that already pass
+// execution in the dry-run harness. Only touches fences where every sub-block
+// reported verdict=PASS — mixed-outcome fences stay untouched.
+
+import { readFileSync, writeFileSync } from 'node:fs'
+
+const REPORT = 'tmp/dry-run/report.json'
+const DRY = process.argv.includes('--dry-run')
+
+function rollup(report) {
+    const fences = new Map()
+    for (const row of report.results) {
+        if (!row.verdict) continue
+        const key = `${row.file}::${row.startLine}-${row.endLine}`
+        const f = fences.get(key) || { file: row.file, start: row.startLine, end: row.endLine, verdicts: [] }
+        f.verdicts.push(row.verdict)
+        fences.set(key, f)
+    }
+    const allPass = []
+    for (const f of fences.values()) {
+        const s = new Set(f.verdicts)
+        if (s.size === 1 && s.has('PASS')) allPass.push(f)
+    }
+    return allPass
+}
+
+function stripFence(text, fenceLine) {
+    // fenceLine is 1-indexed and points at the ```sql line.
+    const lines = text.split('\n')
+    const idx = fenceLine - 1
+    if (idx < 0 || idx >= lines.length) return { text, changed: false, reason: 'oob' }
+    const fence = lines[idx]
+    if (!/^\s*```sql/i.test(fence)) return { text, changed: false, reason: 'not_sql_fence', got: fence }
+
+    let changed = false
+    // Case 1: marker inline on the fence line itself.
+    const inlineMarker = /\s*<!--\s*validator-ignore-exec\s*-->/
+    if (inlineMarker.test(fence)) {
+        lines[idx] = fence.replace(inlineMarker, '')
+        changed = true
+    }
+
+    // Case 2: marker on its own line immediately above. Walk upwards past
+    // blank lines, since some pages leave a blank between the comment and
+    // the fence.
+    let up = idx - 1
+    while (up >= 0 && lines[up].trim() === '') up--
+    if (up >= 0 && /^\s*<!--\s*validator-ignore-exec\s*-->\s*$/.test(lines[up])) {
+        lines.splice(up, 1)
+        changed = true
+    }
+
+    return { text: lines.join('\n'), changed, reason: changed ? 'ok' : 'no_marker' }
+}
+
+function main() {
+    const report = JSON.parse(readFileSync(REPORT, 'utf-8'))
+    const fences = rollup(report)
+
+    // Group by file, then strip highest-line first so earlier line numbers
+    // are not invalidated by earlier edits.
+    const byFile = new Map()
+    for (const f of fences) {
+        if (!byFile.has(f.file)) byFile.set(f.file, [])
+        byFile.get(f.file).push(f)
+    }
+
+    let filesChanged = 0
+    let fencesTouched = 0
+    let fencesMissed = 0
+    const missed = []
+
+    for (const [file, list] of byFile) {
+        list.sort((a, b) => b.start - a.start)
+        let text = readFileSync(file, 'utf-8')
+        let fileChanged = false
+        for (const f of list) {
+            // fence line = startLine - 1 (extractor uses lineNumber+1)
+            const res = stripFence(text, f.start - 1)
+            if (res.changed) {
+                text = res.text
+                fileChanged = true
+                fencesTouched++
+            } else {
+                fencesMissed++
+                missed.push({ file, start: f.start, reason: res.reason, got: res.got })
+            }
+        }
+        if (fileChanged) {
+            if (!DRY) writeFileSync(file, text)
+            filesChanged++
+        }
+    }
+
+    console.log(JSON.stringify({
+        mode: DRY ? 'dry-run' : 'apply',
+        files_changed: filesChanged,
+        fences_touched: fencesTouched,
+        fences_missed: fencesMissed,
+    }, null, 2))
+    if (missed.length) {
+        console.log('\nmissed fences (first 20):')
+        for (const m of missed.slice(0, 20)) console.log(' ', m)
+    }
+}
+
+main()

--- a/scripts/doc-validator/utils/db-connection.js
+++ b/scripts/doc-validator/utils/db-connection.js
@@ -26,6 +26,16 @@ export class DbConnectionManager {
                 port: this.config.port,
                 user: this.config.user,
                 password: this.config.password,
+                // Return DATE / DATETIME / TIMESTAMP / TIME as the raw strings
+                // MatrixOne emits, matching what the doc's expected tables
+                // show. Without this, mysql2 parses them into JS Date objects
+                // using the client's local timezone and re-serialises as UTC,
+                // producing a spurious offset (e.g. `2023-08-01T07:00:00.000Z`
+                // on a PDT host for a doc-declared `2023-08-01 00:00:00`).
+                // This is a driver-layer presentation concern, not a value
+                // difference, so keeping everything as strings keeps the
+                // comparator honest without relaxing any check.
+                dateStrings: true,
             })
             await this.connection.query('SELECT 1')
             return true


### PR DESCRIPTION
## What type of PR is this?
                                                                                                           
  - [x] Enhancement                                                                                        
  - [ ] Displaying
  - [ ] Typo                                                                                               
  - [ ] Doc Request    
                                                                                                           
  ## Which issue(s) this PR fixes:                                                                         
                                                                                                           
  issue #                                                                                                  
                       
  ## What this PR does / why we need it:                                                                   
   
  Triage the `validator-ignore-exec` backlog so more SQL examples actually run in CI, without altering any 
  documented SQL or relaxing what the validator checks for. Reduces ignored fences from **524 → 374** (net
  150 fences now under real execution validation).                                                         
                       
  **Two root-cause fixes to the validator (not the docs):**                                                
   
  1. `fix(doc-validator): match column names case-insensitively in output comparator` — SQL identifiers are
   case-insensitive. Doc expected tables follow the mysql CLI lower-casing convention (`any_value(t1.b)`),
  while MatrixOne preserves the user's casing (`ANY_VALUE(t1.b)`). The strict property lookup treated this 
  as `undefined`. Now looks up columns by canonicalised name. A wrong value still fails the assertion.
  2. `fix(doc-validator): return date/time columns as strings` — mysql2 defaults to parsing `DATE` /
  `DATETIME` / `TIMESTAMP` / `TIME` into JS `Date` using the client's local timezone, then re-serialises as
   UTC, producing a spurious offset (e.g. `2023-08-01 00:00:00` → `"2023-08-01T07:00:00.000Z"`).
  `dateStrings: true` keeps the raw string the server sent. A wrong date literal in the doc still fails.   
                       
  **Two triage helpers:**

  - `scripts/doc-validator/dry-run-ignored.mjs` — forces every currently-ignored fence through the executor
   and reports per-block verdicts.
  - `scripts/doc-validator/strip-ignore-exec.mjs` + `re-ignore-failed.mjs` — remove the marker from fences 
  that now pass, then restore it on those that still fail under accumulated per-file state.                
   
  **Two doc commits (0 changes to SQL examples):**                                                         
                       
  - Round 1: strip 129 fences, re-ignore 41 still-failing, net **+88** validated.                          
  - Round 2: after the driver fix, strip 92 more, re-ignore 30, net **+62** validated.
                                                                                                           
  Only `<!-- validator-ignore-exec -->` HTML comments are touched. Verified with `check:sql-exec` on all   
  touched files (round 1: 88/88 files, 682/682 statements; round 2: 51/51 files, 758/758 statements).      
  Full-suite `check:sql-exec:all` shows failing files drop from 36 → 12 as a side benefit — the driver fix 
  also unblocks previously-flaky date-function pages that were never ignored.