### PR TITLE
[docs-sync] MatrixOne v3.0.10 文档同步 (io)

### DIFF
--- a/docs/MatrixOne/Reference/SQL-Reference/Data-Control-Language/role-rule.md
+++ b/docs/MatrixOne/Reference/SQL-Reference/Data-Control-Language/role-rule.md
@@ -1,0 +1,96 @@
+---
+title: "Role Rewrite Rules (ALTER ROLE ... RULE / SHOW RULES)"
+doc_type: reference
+mysql_compat: mo_only
+differs_from_mysql: []
+mo_only: true
+since: v3.0.10
+last_updated: 2026-05-08
+llms_summary: "Attach per-table rewrite rules to a MatrixOne role via ALTER ROLE ADD RULE / DROP RULE and list them with SHOW RULES ON ROLE, enabled per session by enable_remap_hint."
+---
+
+# Role Rewrite Rules
+
+> Attach per-table rewrite rules to a role with `ALTER ROLE ... ADD RULE ... ON TABLE db.tbl`, remove them with `ALTER ROLE ... DROP RULE ON TABLE db.tbl`, and list them with `SHOW RULES ON ROLE role`. Rules are injected as a hint into queries issued by sessions whose default role owns the rule and that have enabled `enable_remap_hint`.
+
+## Description
+
+Role rewrite rules attach a replacement SQL fragment to a `(role, table)` pair inside `mo_catalog.mo_role_rule`. When a session whose default role owns matching rules has the `enable_remap_hint` session variable enabled, the frontend prepends a `/*+ {"rewrites": {...}} */` hint to outgoing SQL, letting downstream rewriters transparently redirect queries against the base table to the rule body (for example, to route reads to a view or a filtered subquery).
+
+The feature is controlled by three statements:
+
+- `ALTER ROLE <role> ADD RULE "<sql>" ON TABLE <db>.<tbl>` — upsert a rule.
+- `ALTER ROLE <role> DROP RULE ON TABLE <db>.<tbl>` — remove a rule.
+- `SHOW RULES ON ROLE <role>` — list all rules for a role.
+
+Rules live per role; one role can own at most one rule per `(db, tbl)` pair — adding a second rule for the same table replaces the first.
+
+## Syntax
+
+```text
+ALTER ROLE <role_name> ADD RULE "<rewrite_sql>" ON TABLE <db_name>.<table_name>
+ALTER ROLE <role_name> DROP RULE ON TABLE <db_name>.<table_name>
+SHOW RULES ON ROLE <role_name>
+```
+
+## Arguments
+
+| Parameter | Description |
+|-----------|-------------|
+| `role_name` | The role to attach or detach the rule on. Must already exist. |
+| `rewrite_sql` | Replacement SQL string, given as a double- or single-quoted literal. Stored verbatim in `mo_catalog.mo_role_rule.rule`. |
+| `db_name.table_name` | Fully qualified target table identifier. The two parts together make up the `rule_name` column in `mo_catalog.mo_role_rule`. |
+
+## Usage Notes
+
+- **Role must exist.** All three statements first look up the role by name. If the role does not exist, they fail with `there is no role <role_name>`.
+- **Target table need not exist at rule-creation time.** `ALTER ROLE ... ADD RULE` does not verify the table exists — the `db_name.table_name` pair is only used as the rule key and as the rewrite target for later queries.
+- **Upsert semantics.** Adding a rule for a `(role, db.table)` pair that already has a rule overwrites the previous rule body.
+- **DROP RULE requires an existing rule.** `ALTER ROLE ... DROP RULE ON TABLE db.tbl` fails with `rule '<db.table>' does not exist for role '<role>'` when no rule is attached.
+- **`enable_remap_hint`.** Rewrite hints are injected only when the session variable `enable_remap_hint` is `1` (or `ON`). Without it, rules are stored but have no runtime effect.
+- **Cache invalidation is per session.** Adding or dropping a rule invalidates the current session's cached rule map. Other sessions that already loaded their rule cache continue using the previous set until they reconnect or re-execute `SET ROLE`.
+- **Storage.** Rules live in `mo_catalog.mo_role_rule`, one row per `(role_id, rule_name)`. `SHOW RULES ON ROLE` returns the `rule_name` and `rule` columns.
+
+## Examples
+
+```sql
+DROP DATABASE IF EXISTS role_rule_demo;
+CREATE DATABASE role_rule_demo;
+USE role_rule_demo;
+
+CREATE TABLE t1 (a INT PRIMARY KEY, age INT);
+INSERT INTO t1 VALUES (1, 1), (2, 2), (100, 30);
+
+DROP ROLE IF EXISTS demo_rule_role;
+CREATE ROLE demo_rule_role;
+
+-- Example 1: add a rule and list the rules attached to the role.
+ALTER ROLE demo_rule_role ADD RULE 'select a, age from t1 where age > 28' ON TABLE role_rule_demo.t1;
+SHOW RULES ON ROLE demo_rule_role;
+
+-- Example 2: adding a second rule for the same (role, db.table) pair overwrites the previous body.
+ALTER ROLE demo_rule_role ADD RULE 'select a, age from t1 where age > 50' ON TABLE role_rule_demo.t1;
+SHOW RULES ON ROLE demo_rule_role;
+
+-- Example 3: DROP RULE removes the rule for the target table.
+ALTER ROLE demo_rule_role DROP RULE ON TABLE role_rule_demo.t1;
+SHOW RULES ON ROLE demo_rule_role;
+
+-- Example 4: dropping a rule that does not exist fails.
+-- Expected-Success: false
+ALTER ROLE demo_rule_role DROP RULE ON TABLE role_rule_demo.t1;
+
+-- Example 5: targeting a non-existent role fails on all three verbs.
+-- Expected-Success: false
+ALTER ROLE non_existent_role ADD RULE 'select 1' ON TABLE role_rule_demo.t1;
+
+DROP ROLE IF EXISTS demo_rule_role;
+DROP TABLE t1;
+DROP DATABASE role_rule_demo;
+```
+
+## Notes
+
+1. The hint format injected into rewritten queries is `/*+ {"rewrites": {"<db.table>": "<rule_sql>", ...}} */`. Downstream rewriters decide how to apply it; absent a matching rewriter, the hint is inert.
+2. Rule bodies are opaque strings — the server does not validate that `rewrite_sql` references the target table. Keep rules narrow and review `mo_catalog.mo_role_rule` periodically.
+3. Rules are resolved by the session's *default* role. Changing the default role on the same user (via `SET ROLE` or re-login) reloads the rule cache.

--- a/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-diff-en.md
+++ b/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-diff-en.md
@@ -19,10 +19,15 @@ The system automatically identifies the Lowest Common Ancestor (LCA) between two
 ## Syntax
 
 ```
-DATA BRANCH DIFF target_table [{ SNAPSHOT = 'snapshot_name' }] 
-    AGAINST base_table [{ SNAPSHOT = 'snapshot_name' }] 
+DATA BRANCH DIFF target_table [{ SNAPSHOT = 'snapshot_name' }]
+    AGAINST base_table [{ SNAPSHOT = 'snapshot_name' }]
+    [COLUMNS ( col1 [, col2 ...] )]
     [OUTPUT output_option]
 ```
+
+### COLUMNS projection (since v3.0.10)
+
+`COLUMNS (col1, col2, ...)` restricts the value columns returned per diff row to the listed subset. Primary-key columns are always present in the output because they identify the row; non-PK columns not listed in `COLUMNS` are omitted. Use this to reduce payload size on wide tables when only a few columns matter for the diff.
 
 ### Output Options
 
@@ -32,6 +37,7 @@ output_option:
   | LIMIT number                    -- Limit the number of returned difference rows
   | FILE 'directory_path'           -- Export differences as SQL file
   | AS table_name                   -- Save differences to a table (not yet supported)
+  | SUMMARY                         -- Return aggregated INSERT / DELETE / UPDATE counts
 ```
 
 ## Arguments
@@ -46,6 +52,8 @@ output_option:
 | `OUTPUT COUNT` | Return only the count of differences |
 | `OUTPUT LIMIT number` | Limit the number of returned difference rows |
 | `OUTPUT FILE 'path'` | Export differences as SQL file to specified directory, supports local path or Stage path (e.g., `stage://stage_name/`) |
+| `OUTPUT SUMMARY` | Return an aggregated INSERT / DELETE / UPDATE breakdown instead of the row-by-row diff |
+| `COLUMNS (col1, col2, ...)` | Since v3.0.10. Restrict non-PK columns in the diff output to the listed subset. Primary-key columns are always included. |
 
 ### Output Column Description
 
@@ -433,6 +441,52 @@ DROP TABLE test.orders;
 DROP TABLE test.orders_branch;
 -- Expected-Rows: 0
 DROP DATABASE test;
+```
+
+### Example 9: COLUMNS projection (v3.0.10)
+
+`COLUMNS (col1, ..., colN)` restricts the non-PK columns returned by the diff. The primary-key column(s) are always present.
+
+```sql
+DROP DATABASE IF EXISTS data_branch_diff_columns_demo;
+CREATE DATABASE data_branch_diff_columns_demo;
+USE data_branch_diff_columns_demo;
+
+CREATE TABLE c1 (
+    id INT PRIMARY KEY,
+    name VARCHAR(30),
+    balance DECIMAL(12,2),
+    created_at TIMESTAMP,
+    birthday DATE
+);
+INSERT INTO c1 VALUES
+    (1, 'alice', 1000.50, '2024-01-01 10:00:00', '1990-03-15'),
+    (2, 'bob',   2000.75, '2024-01-02 11:00:00', '1985-07-20'),
+    (3, 'carol', 3000.00, '2024-01-03 12:00:00', '1992-11-08');
+
+DATA BRANCH CREATE TABLE c1_br FROM c1;
+UPDATE c1_br SET balance = 1500.50, name = 'alice_v2' WHERE id = 1;
+DELETE FROM c1_br WHERE id = 2;
+INSERT INTO c1_br VALUES (4, 'dave', 4000.00, '2024-02-01 09:00:00', '1988-12-25');
+
+-- Full diff, all columns.
+DATA BRANCH DIFF c1_br AGAINST c1;
+
+-- Project only the "name" column: primary key + name, no balance/created_at/birthday.
+DATA BRANCH DIFF c1_br AGAINST c1 COLUMNS (name);
+
+-- Project two non-PK columns.
+DATA BRANCH DIFF c1_br AGAINST c1 COLUMNS (name, balance);
+
+-- Project the PK together with a non-PK column; the PK column is always returned.
+DATA BRANCH DIFF c1_br AGAINST c1 COLUMNS (id, balance);
+
+-- Combine COLUMNS with OUTPUT LIMIT.
+DATA BRANCH DIFF c1_br AGAINST c1 COLUMNS (balance) OUTPUT LIMIT 5;
+
+DROP TABLE c1_br;
+DROP TABLE c1;
+DROP DATABASE data_branch_diff_columns_demo;
 ```
 
 ## Notes

--- a/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-pick.md
+++ b/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-pick.md
@@ -1,0 +1,200 @@
+---
+title: "DATA BRANCH PICK"
+doc_type: reference
+mysql_compat: mo_only
+differs_from_mysql: []
+mo_only: true
+since: v3.0.10
+last_updated: 2026-05-08
+llms_summary: "Cherry-pick specific rows from a source table into a target table by primary key or snapshot range inside a MatrixOne data branch, with configurable conflict handling."
+---
+
+# DATA BRANCH PICK
+
+> Cherry-pick rows from a source table into a target table inside a MatrixOne data branch without merging the whole diff. Rows are selected by a literal `KEYS` list, a subquery, or a `BETWEEN SNAPSHOT` time range; conflicts on the same primary key can fail, be skipped, or accepted from the source.
+
+## Description
+
+`DATA BRANCH PICK` copies a subset of rows between two tables that participate in the data-branch lineage (with or without a common ancestor). It reuses the diff machinery behind `DATA BRANCH DIFF` / `DATA BRANCH MERGE`, but narrows the scope to the keys or snapshot window you supply and writes INSERT/DELETE changes to the destination table.
+
+The statement is useful for selective synchronization — for example, promoting a single new row, back-porting one fix to another branch, or propagating only the changes that happened between two snapshots.
+
+## Syntax
+
+```
+DATA BRANCH PICK source_table [{ SNAPSHOT = 'snapshot_name' }]
+    INTO destination_table
+    [BETWEEN SNAPSHOT snapshot_from AND snapshot_to]
+    [KEYS ( key_list | subquery )]
+    [WHEN CONFLICT conflict_option]
+```
+
+At least one of `KEYS (...)` or `BETWEEN SNAPSHOT ... AND ...` is required.
+
+### KEYS clause
+
+```
+key_list   ::= expr [, expr ...]
+             | ( col1_val, col2_val [, ...] ) [, ( ... ) ...]
+subquery   ::= SELECT ... FROM ...
+```
+
+### Conflict options
+
+```
+conflict_option:
+    FAIL                            -- Default. Fail on conflict.
+  | SKIP                            -- Keep destination row, drop the picked change.
+  | ACCEPT                          -- Overwrite destination with source row.
+```
+
+## Arguments
+
+| Parameter | Description |
+|-----------|-------------|
+| `source_table` | Table the rows are picked from. May carry a `{SNAPSHOT = 'snap'}` source-time option. |
+| `destination_table` | Table that receives the picked rows. Must exist and must share the same schema as the source. A snapshot option on the destination is rejected. |
+| `KEYS (expr, ...)` | Literal list of primary-key values to pick. For a single-column primary key, each entry is a scalar; for a composite primary key, each entry must be a tuple `(c1, c2, ...)` with one element per PK column. |
+| `KEYS (SELECT ...)` | Subquery whose result columns define the primary-key values. For a composite primary key, the subquery must project the PK columns in order. `NULL` values are rejected. |
+| `BETWEEN SNAPSHOT a AND b` | Restrict picked rows to changes that occurred on the source between snapshots `a` and `b`. Snapshot names may be bare identifiers or string literals. Cannot be combined with a source-table `SNAPSHOT` option. |
+| `WHEN CONFLICT FAIL` | Return an error when a picked key already exists in the destination with a different value. This is the default when the clause is omitted. |
+| `WHEN CONFLICT SKIP` | Keep the destination row unchanged; drop both the DELETE and INSERT for the conflicting key. |
+| `WHEN CONFLICT ACCEPT` | Apply the source row over the destination row (delete old, insert source value). |
+
+## Usage Notes
+
+- **Primary key required for single-row semantics.** The statement uses the source and destination primary key to match rows. Tables without an explicit primary key fall back to the internal fake primary key and are supported, but key matching is then row-level only.
+- **Destination snapshot is not supported.** Specifying `{SNAPSHOT = ...}` on `destination_table` raises `destination snapshot option is not supported for DATA BRANCH PICK`.
+- **Explicit transactions are rejected.** Running `DATA BRANCH PICK` inside a `BEGIN ... COMMIT` block raises `DATA BRANCH PICK is not supported in explicit transactions`.
+- **Mutual exclusion of source snapshot and `BETWEEN`.** Using `source_table{SNAPSHOT = ...}` together with `BETWEEN SNAPSHOT a AND b` raises `BETWEEN SNAPSHOT and source table snapshot option cannot be used together`.
+- **At least one scope clause is required.** Omitting both `KEYS` and `BETWEEN SNAPSHOT` raises `DATA BRANCH PICK requires a KEYS or BETWEEN SNAPSHOT clause`.
+- **Conflict default is FAIL.** Without `WHEN CONFLICT`, the first conflicting key aborts the statement and leaves the destination unchanged for the remaining picked keys.
+- **Non-existent keys are no-ops.** If a listed key is not present in the source (or not in the source change set in `BETWEEN SNAPSHOT` mode), the row is silently skipped.
+- **KEYS subquery rules.** The subquery must return the same number of columns as the primary key (one for single-column PK, N for N-column composite PK). Each row is coerced into the PK type; unsupported types raise `KEYS subquery column type X is not supported for primary-key coercion`, and `NULL` values raise `KEYS subquery returned NULL, but DATA BRANCH PICK primary keys cannot be NULL`.
+- **Composite primary key.** For a composite PK, literal keys must be tuples with exactly as many elements as PK columns; a mismatch raises `KEYS tuple has N elements but composite primary key has M columns`.
+- **Privileges.** The caller needs SELECT-style privilege on the source table and modify privilege on the destination table; otherwise the statement raises `do not have privilege to execute the statement`.
+
+## Examples
+
+```sql
+DROP DATABASE IF EXISTS data_branch_pick_demo;
+CREATE DATABASE data_branch_pick_demo;
+USE data_branch_pick_demo;
+
+-- Example 1: Pick specific rows from an independent source table.
+CREATE TABLE t1 (a INT, b INT, PRIMARY KEY(a));
+INSERT INTO t1 VALUES (1,1),(3,3),(5,5);
+
+CREATE TABLE t2 (a INT, b INT, PRIMARY KEY(a));
+INSERT INTO t2 VALUES (1,1),(2,2),(4,4);
+
+-- Pick only pk=2 from t2 into t1.
+DATA BRANCH PICK t2 INTO t1 KEYS(2);
+SELECT * FROM t1 ORDER BY a ASC;
+
+-- Pick another key; absent keys are silently ignored.
+DATA BRANCH PICK t2 INTO t1 KEYS(4);
+DATA BRANCH PICK t2 INTO t1 KEYS(99);
+SELECT * FROM t1 ORDER BY a ASC;
+
+DROP TABLE t1;
+DROP TABLE t2;
+
+-- Example 2: Conflict handling with WHEN CONFLICT SKIP / ACCEPT.
+CREATE TABLE t0 (a INT, b INT, PRIMARY KEY(a));
+INSERT INTO t0 VALUES (1,1),(2,2);
+
+DATA BRANCH CREATE TABLE t1 FROM t0;
+INSERT INTO t1 VALUES (3,30);
+
+DATA BRANCH CREATE TABLE t2 FROM t0;
+INSERT INTO t2 VALUES (3,40);
+
+-- Both branches inserted pk=3 with different values; the default FAIL mode
+-- aborts the statement.
+-- Expected-Success: false
+DATA BRANCH PICK t2 INTO t1 KEYS(3);
+
+-- SKIP keeps t1's (3,30).
+DATA BRANCH PICK t2 INTO t1 KEYS(3) WHEN CONFLICT SKIP;
+SELECT * FROM t1 ORDER BY a ASC;
+
+-- ACCEPT overwrites with t2's (3,40).
+DATA BRANCH PICK t2 INTO t1 KEYS(3) WHEN CONFLICT ACCEPT;
+SELECT * FROM t1 ORDER BY a ASC;
+
+DROP TABLE t0;
+DROP TABLE t1;
+DROP TABLE t2;
+
+-- Example 3: Cherry-pick with a KEYS subquery.
+CREATE TABLE t1 (a INT, b INT, PRIMARY KEY(a));
+INSERT INTO t1 VALUES (1,1);
+
+CREATE TABLE t2 (a INT, b INT, PRIMARY KEY(a));
+INSERT INTO t2 VALUES (1,1),(2,2),(3,3),(4,4),(5,5);
+
+-- Pick only the even-keyed rows from t2 into t1.
+DATA BRANCH PICK t2 INTO t1 KEYS(SELECT a FROM t2 WHERE a % 2 = 0);
+SELECT * FROM t1 ORDER BY a ASC;
+
+DROP TABLE t1;
+DROP TABLE t2;
+
+-- Example 4: Composite primary key with tuple keys.
+CREATE TABLE t0 (id INT, name VARCHAR(20), val INT, PRIMARY KEY(id, name));
+INSERT INTO t0 VALUES (1,'alice',10),(2,'bob',20);
+
+DATA BRANCH CREATE TABLE t1 FROM t0;
+DATA BRANCH CREATE TABLE t2 FROM t0;
+
+INSERT INTO t2 VALUES (4,'dave',40),(5,'eve',50),(6,'frank',60);
+
+-- Pick two composite keys out of three new rows.
+DATA BRANCH PICK t2 INTO t1 KEYS((4,'dave'),(6,'frank'));
+SELECT * FROM t1 ORDER BY id, name;
+
+DROP TABLE t0;
+DROP TABLE t1;
+DROP TABLE t2;
+
+-- Example 5: Pick changes that happened between two snapshots.
+DROP SNAPSHOT IF EXISTS sp1;
+DROP SNAPSHOT IF EXISTS sp2;
+
+CREATE TABLE t0 (a INT, b INT, PRIMARY KEY(a));
+INSERT INTO t0 VALUES (1,1),(2,2),(3,3);
+
+DATA BRANCH CREATE TABLE t1 FROM t0;
+
+CREATE SNAPSHOT sp1 FOR ACCOUNT sys;
+
+INSERT INTO t1 VALUES (4,4),(5,5);
+
+CREATE SNAPSHOT sp2 FOR ACCOUNT sys;
+
+INSERT INTO t1 VALUES (6,6),(7,7);
+
+-- Only rows changed between sp1 and sp2 are picked (pk=4,5).
+-- Rows inserted after sp2 (pk=6,7) are not.
+DATA BRANCH PICK t1 INTO t0 BETWEEN SNAPSHOT sp1 AND sp2;
+SELECT * FROM t0 ORDER BY a ASC;
+
+-- BETWEEN can be combined with KEYS for an intersection of time and key set.
+DATA BRANCH PICK t1 INTO t0 BETWEEN SNAPSHOT sp1 AND sp2 KEYS(5);
+SELECT * FROM t0 ORDER BY a ASC;
+
+DROP SNAPSHOT sp1;
+DROP SNAPSHOT sp2;
+DROP TABLE t0;
+DROP TABLE t1;
+
+DROP DATABASE data_branch_pick_demo;
+```
+
+## Notes
+
+1. `DATA BRANCH PICK` writes INSERT / DELETE statements to the destination; the statement is not an atomic snapshot copy — partial conflict handling is enforced per row.
+2. When both `BETWEEN SNAPSHOT` and `KEYS` are supplied, the picked set is the intersection of the snapshot-range change set and the key set.
+3. Picking a key that exists in the destination but not in the source is a no-op. Picking a key that was deleted on the source with the destination unchanged propagates the DELETE to the destination.
+4. For `WHEN CONFLICT FAIL`, the reported error message has the form `conflict: <dst_table> INSERT and <src_table> INSERT on pk(<pk>) with different values`.

--- a/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/sql-task.md
+++ b/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/sql-task.md
@@ -1,0 +1,165 @@
+---
+title: "CREATE TASK (SQL Task)"
+doc_type: reference
+mysql_compat: mo_only
+differs_from_mysql: []
+mo_only: true
+since: v3.0.10
+last_updated: 2026-05-08
+llms_summary: "Define, alter, drop, execute, and inspect MatrixOne SQL tasks that run a SQL body on a cron schedule or on demand, with optional gate, retry, and timeout options."
+---
+
+# CREATE TASK / ALTER TASK / DROP TASK / EXECUTE TASK / SHOW TASKS
+
+> Create, alter, drop, execute, and inspect MatrixOne SQL tasks. A SQL task is a named server-side job that runs a SQL body on a cron schedule or on demand, with optional WHEN gate, RETRY count, and TIMEOUT; run history is exposed via SHOW TASKS and SHOW TASK RUNS.
+
+## Description
+
+A SQL task is a MatrixOne-managed scheduled job that runs a user-supplied SQL body. Tasks are owned by the account that created them; each task has an optional cron schedule, an optional `WHEN` gate that must evaluate truthy before a run is allowed, a retry limit, a timeout, and a SQL body placed between `BEGIN` and `END`.
+
+Task runs can be triggered:
+
+- automatically by the scheduler whenever the cron expression fires, or
+- manually with `EXECUTE TASK`.
+
+Run history is persisted in `mo_task.sql_task_run` and is also exposed via `SHOW TASK RUNS`.
+
+## Syntax
+
+### CREATE TASK
+
+```text
+CREATE TASK [IF NOT EXISTS] <task_name>
+    [SCHEDULE '<cron_expr>' [TIMEZONE '<tz_name>']]
+    [WHEN ( <gate_expr> )]
+    [RETRY <retry_limit>]
+    [TIMEOUT '<duration>']
+    AS BEGIN
+        <sql_statement>;
+        [<sql_statement>; ...]
+    END;
+```
+
+### ALTER TASK
+
+```text
+ALTER TASK <task_name> SUSPEND
+ALTER TASK <task_name> RESUME
+ALTER TASK <task_name> SET SCHEDULE '<cron_expr>' [TIMEZONE '<tz_name>']
+ALTER TASK <task_name> SET WHEN ( <gate_expr> )
+ALTER TASK <task_name> SET RETRY <retry_limit>
+ALTER TASK <task_name> SET TIMEOUT '<duration>'
+```
+
+### DROP TASK
+
+```text
+DROP TASK [IF EXISTS] <task_name>
+```
+
+### EXECUTE TASK
+
+```text
+EXECUTE TASK <task_name>
+```
+
+### SHOW TASKS / SHOW TASK RUNS
+
+```text
+SHOW TASKS
+SHOW TASK RUNS [FOR <task_name>] [LIMIT <n>]
+```
+
+## Arguments
+
+| Parameter | Description |
+|-----------|-------------|
+| `task_name` | Identifier of the task. Unique per account. |
+| `SCHEDULE 'cron_expr'` | Cron expression parsed by the `robfig/cron/v3` library (6-field form with seconds is supported). Omit to create a manual-only task. |
+| `TIMEZONE 'tz_name'` | IANA time-zone name applied to the cron schedule (e.g. `'UTC'`, `'Asia/Shanghai'`). Defaults to the server default when omitted. |
+| `WHEN ( gate_expr )` | Optional gate expression re-evaluated at every run. The run body executes only when the expression returns a non-zero / non-empty result; otherwise the run is recorded with `GATE_BLOCKED` status and does not consume a retry attempt. |
+| `RETRY retry_limit` | Maximum number of extra retry attempts after a failing run. Default is `0` (no retry). Each attempt is recorded as a separate row in `mo_task.sql_task_run`. |
+| `TIMEOUT 'duration'` | Per-run timeout, parsed by Go's `time.ParseDuration` (`'500ms'`, `'30s'`, `'5m'`, `'1h'`). The value must be non-negative. |
+| `AS BEGIN ... END` | SQL body. Each inner statement ends with `;`; statements execute sequentially inside the run. |
+| `SUSPEND` / `RESUME` | Disable or re-enable scheduler firing for the task. `SUSPEND` does not affect manual `EXECUTE TASK`. |
+
+## Usage Notes
+
+- **Name uniqueness.** `CREATE TASK` fails with `sql task <name> already exists` when a task with the same name already exists for the account. `IF NOT EXISTS` turns re-creation into a no-op.
+- **Missing task.** `ALTER TASK`, `DROP TASK`, and `EXECUTE TASK` fail with `sql task <name> not found` when the task does not exist. `DROP TASK IF EXISTS` turns this into a no-op.
+- **Non-overlapping runs.** At most one run of a given task executes at a time; `EXECUTE TASK` on a task that is already running fails with `sql task is already running`.
+- **Task service readiness.** If the task service has not yet initialized on the current CN, the statement fails with `task service not ready yet, please try again later.` and can be retried once the service comes up.
+- **Timeout format.** `'1h30m'`, `'90s'`, `'500ms'`, `'0'` are all accepted. A malformed duration returns the underlying `time.ParseDuration` error; a negative value fails with `invalid argument timeout`.
+- **Gate semantics.** The `WHEN` expression is re-evaluated at every run. A skipped run is recorded with status `GATE_BLOCKED`; it does not consume a retry attempt.
+- **SHOW TASKS columns.** `task_name`, `schedule`, `enabled`, `gate_condition`, `retry_limit`, `timeout`, `created_at`, `last_run_status`, `last_run_time`.
+- **SHOW TASK RUNS columns.** `run_id`, `task_name`, `trigger_type`, `status`, `started_at`, `finished_at`, `duration`, `attempt`, `rows_affected`, `error_message`. `trigger_type` is `MANUAL` for `EXECUTE TASK` and `SCHEDULE` for cron-fired runs. `LIMIT n` caps the most recent rows; `FOR task_name` filters by task.
+- **Manual and scheduled history share `mo_task.sql_task_run`.** Filter on `trigger_type` to distinguish them.
+
+## Examples
+
+> The task body is delimited by `BEGIN` / `END` and contains embedded `;` terminators, so the statement cannot be sent through a plain `;`-delimited client without a custom delimiter. Treat the following SQL blocks as templates; in practice, use a client that supports a delimiter switch (for example the `mysql` client's `DELIMITER` command) to issue the `CREATE TASK` statements.
+
+Example 1 — scheduled task with a cron expression:
+
+<!-- validator-ignore -->
+```sql
+CREATE TASK IF NOT EXISTS <task_name>
+    SCHEDULE '0 0 0 1 1 *'
+    TIMEZONE 'UTC'
+AS BEGIN
+    INSERT INTO <target_table>(<marker_col>) VALUES ('cron');
+END;
+```
+
+Example 2 — manual-only task (no `SCHEDULE`), fired via `EXECUTE TASK`:
+
+<!-- validator-ignore -->
+```sql
+CREATE TASK IF NOT EXISTS <task_name>
+AS BEGIN
+    INSERT INTO <target_table>
+    SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM <target_table> WHERE id = 1);
+END;
+```
+
+Example 3 — gated task with `WHEN`, retry, and per-run timeout:
+
+<!-- validator-ignore -->
+```sql
+CREATE TASK IF NOT EXISTS <task_name>
+    WHEN (EXISTS (SELECT 1 FROM <gate_table> WHERE id = 1))
+    RETRY 1
+    TIMEOUT '30s'
+AS BEGIN
+    INSERT INTO <sink_table>
+    SELECT 'gate-ok'
+    WHERE NOT EXISTS (SELECT 1 FROM <sink_table> WHERE tag = 'gate-ok');
+END;
+```
+
+Example 4 — alter, suspend, resume, execute, inspect, drop:
+
+<!-- validator-ignore -->
+```sql
+ALTER TASK <task_name> SET SCHEDULE '*/1 * * * * *' TIMEZONE 'UTC';
+ALTER TASK <task_name> SET WHEN (EXISTS (SELECT 1 FROM <gate_table> WHERE id = 1));
+ALTER TASK <task_name> SET RETRY 2;
+ALTER TASK <task_name> SET TIMEOUT '1m';
+
+ALTER TASK <task_name> SUSPEND;
+ALTER TASK <task_name> RESUME;
+
+EXECUTE TASK <task_name>;
+
+SHOW TASKS;
+SHOW TASK RUNS FOR <task_name> LIMIT 5;
+
+DROP TASK IF EXISTS <task_name>;
+```
+
+## Notes
+
+1. `SCHEDULE` accepts the 6-field cron form used by `robfig/cron/v3` (including seconds); classic 5-field expressions may be rejected. Use `TIMEZONE` to anchor the schedule to a specific IANA zone.
+2. The SQL body runs with the creating user's role and default database; cross-account access is not granted implicitly.
+3. A `TIMEOUT` that elapses mid-run aborts the current statement and records the run as a timeout in `mo_task.sql_task_run`. Retries (if any) are performed up to `RETRY retry_limit` additional attempts.
+4. Dropping a task removes its definition but does not delete rows already written to `mo_task.sql_task_run`.

--- a/docs/MatrixOne/Release-Notes/llms-manifest/v3.0.10.yml
+++ b/docs/MatrixOne/Release-Notes/llms-manifest/v3.0.10.yml
@@ -1,0 +1,17 @@
+tag: v3.0.10
+docs_added:
+  - path: docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-pick.md
+    doc_type: reference
+    mysql_compat: mo_only
+    llms_summary: "Cherry-pick specific rows from a source table into a target table by primary key or snapshot range inside a MatrixOne data branch, with configurable conflict handling."
+  - path: docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/sql-task.md
+    doc_type: reference
+    mysql_compat: mo_only
+    llms_summary: "Define, alter, drop, execute, and inspect MatrixOne SQL tasks that run a SQL body on a cron schedule or on demand, with optional gate, retry, and timeout options."
+  - path: docs/MatrixOne/Reference/SQL-Reference/Data-Control-Language/role-rule.md
+    doc_type: reference
+    mysql_compat: mo_only
+    llms_summary: "Attach per-table rewrite rules to a MatrixOne role via ALTER ROLE ADD RULE / DROP RULE and list them with SHOW RULES ON ROLE, enabled per session by enable_remap_hint."
+docs_updated:
+  - path: docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-diff-en.md
+    change_summary: "Document COLUMNS projection clause and OUTPUT SUMMARY option added to DATA BRANCH DIFF."

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -371,6 +371,8 @@ nav:
                   - DELETE BRANCH: MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-delete-en.md
                   - DIFF BRANCH: MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-diff-en.md
                   - MERGE BRANCH: MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-merge-en.md
+                  - DATA BRANCH PICK: MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-pick.md
+                  - CREATE TASK (SQL Task): MatrixOne/Reference/SQL-Reference/Data-Definition-Language/sql-task.md
                   - ALTER TABLE: MatrixOne/Reference/SQL-Reference/Data-Definition-Language/alter-table.md
                   - ALTER TABLE ... ALTER REINDEX: MatrixOne/Reference/SQL-Reference/Data-Definition-Language/alter-reindex.md
                   - ALTER PITR: MatrixOne/Reference/SQL-Reference/Data-Definition-Language/alter-pitr.md
@@ -440,6 +442,7 @@ nav:
                   - CREATE ACCOUNT: MatrixOne/Reference/SQL-Reference/Data-Control-Language/create-account.md
                   - ALTER ACCOUNT: MatrixOne/Reference/SQL-Reference/Data-Control-Language/alter-account.md
                   - CREATE ROLE: MatrixOne/Reference/SQL-Reference/Data-Control-Language/create-role.md
+                  - Role Rewrite Rules: MatrixOne/Reference/SQL-Reference/Data-Control-Language/role-rule.md
                   - CREATE USER: MatrixOne/Reference/SQL-Reference/Data-Control-Language/create-user.md
                   - ALTER USER: MatrixOne/Reference/SQL-Reference/Data-Control-Language/alter-user.md
                   - DROP ACCOUNT: MatrixOne/Reference/SQL-Reference/Data-Control-Language/drop-account.md


### PR DESCRIPTION
# MatrixOne 文档自动同步 (io)

## 基本信息

- Source repo: matrixorigin/matrixone
- Base repo: matrixorigin/matrixorigin.io
- Head: ULookup:docs-sync/matrixone-v3.0.10 (from fork ULookup/matrixorigin.io)
- Docs key: io
- From tag: v3.0.9
- To tag: v3.0.10
- Target branch: main
- Generated by: MatrixOne Docs Sync Agent

## Tags

- From: v3.0.9
- To: v3.0.10

## User-visible Changes

- **DATA BRANCH PICK（新 SQL 语句）**：新增按主键或快照时间窗口从源表拣取指定行写入目标表的语句，提供 `KEYS (...)`、`KEYS (SELECT ...)`、`BETWEEN SNAPSHOT a AND b` 三种行圈定方式，以及 `WHEN CONFLICT FAIL|SKIP|ACCEPT` 三种冲突处理策略；禁止在显式事务中执行，目标表不支持快照选项。源码：`pkg/frontend/data_branch_pick.go`、`pkg/sql/parsers/dialect/mysql/mysql_sql.y`、`test/distributed/cases/git4data/branch/pick/pick_*.sql`（slug: `data_branch_pick`）。
- **DATA BRANCH DIFF 新增 `COLUMNS (...)` 投影与 `OUTPUT SUMMARY` 输出**：`COLUMNS (col1, col2, ...)` 限制 diff 输出中的非主键列子集；`OUTPUT SUMMARY` 返回 INSERT/DELETE/UPDATE 聚合计数。源码：`pkg/sql/parsers/dialect/mysql/mysql_sql.y`（`diff_columns_opt`）、`pkg/sql/parsers/tree/data_branch.go`、`test/distributed/cases/git4data/branch/diff/diff_11.sql` 与 `diff_9.sql` / `diff_10.sql`（slug: `git4data`）。
- **SQL 任务家族语句**：`CREATE TASK` / `ALTER TASK` / `DROP TASK` / `EXECUTE TASK` / `SHOW TASKS` / `SHOW TASK RUNS`。任务可带 `SCHEDULE 'cron_expr' [TIMEZONE 'tz']`、`WHEN (gate_expr)` 门限、`RETRY n` 重试次数、`TIMEOUT 'duration'` 超时；执行历史写入 `mo_task.sql_task_run`。源码：`pkg/sql/parsers/tree/sql_task.go`、`pkg/sql/parsers/dialect/mysql/mysql_sql.y`、`pkg/frontend/sql_task_handler.go`、`pkg/taskservice/sql_task*.go`、`test/distributed/cases/task/sql_task.sql`（slug: `sql_task`）。
- **角色重写规则**：`ALTER ROLE role ADD RULE "<sql>" ON TABLE db.tbl` / `ALTER ROLE role DROP RULE ON TABLE db.tbl` / `SHOW RULES ON ROLE role`。规则落在 `mo_catalog.mo_role_rule`；会话在 `enable_remap_hint=1` 时把规则体注入为 SQL hint。源码：`pkg/sql/parsers/tree/alter.go`、`pkg/sql/parsers/tree/show.go`、`pkg/sql/parsers/dialect/mysql/mysql_sql.y`、`pkg/frontend/rewrite_rule.go`、`test/distributed/cases/zz_accesscontrol/role_rule.sql`（slug: `rewrite_rule`）。
- **内部实现，无独立用户入口**：`data_branch_fullscan`（slug 存在，但 `pkg/frontend/data_branch_fullscan.go` 是 DIFF/MERGE/PICK 的共享内部 fullscan 执行器，没有独立 SQL 入口），Reason: internal component, no public SQL surface。
- **已在 Release Notes 覆盖的 bugfix / 内部改进**：已预写入仓内的 `v26.3.0.10.md`，详见各仓 Release Notes 章节。

## Repo: io (matrixorigin/matrixorigin.io)

### Docs Updated

- `docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-diff-en.md`
  - 新增 `COLUMNS (col1, col2, ...)` 投影章节、`OUTPUT SUMMARY` 说明，以及 Example 9（COLUMNS 投影完整可执行示例）。主键列始终返回；`COLUMNS` 可与 `OUTPUT LIMIT` 组合使用。 （slug: `git4data`）

### Docs Added

- `docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-pick.md` （slug: `data_branch_pick`） —— `DATA BRANCH PICK` 参考页，含 Description / Syntax / Arguments / Usage Notes / 5 个可运行示例（基本 KEYS、冲突处理、KEYS 子查询、复合主键、BETWEEN SNAPSHOT 时间窗口）/ Notes。
- `docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/sql-task.md` （slug: `sql_task`） —— SQL 任务家族（CREATE / ALTER / DROP / EXECUTE / SHOW TASKS / SHOW TASK RUNS）参考页。因 `CREATE TASK ... AS BEGIN ... END` 体内嵌 `;`，无法在纯 `;` 分隔的客户端中单次提交，Examples 的 SQL 块均标注 `<!-- validator-ignore -->` 并采用 `<task_name>` 等占位符；`## Syntax` 用 ```text``` 模板块呈现。
- `docs/MatrixOne/Reference/SQL-Reference/Data-Control-Language/role-rule.md` （slug: `rewrite_rule`） —— 角色重写规则参考页（`ALTER ROLE ... ADD RULE` / `DROP RULE` / `SHOW RULES ON ROLE`），含 `enable_remap_hint` 会话变量说明及可运行示例。
- `docs/MatrixOne/Release-Notes/llms-manifest/v3.0.10.yml` —— 本次新增三页的 llms-manifest 登记文件，`tag`、`since`、`llms_summary` 与各 md frontmatter 一致。

### Navigation Updated

- `mkdocs.yml`：在 Data Definition Language 的 DATA BRANCH 家族之后追加：
  - `DATA BRANCH PICK`
  - `CREATE TASK (SQL Task)`
- `mkdocs.yml`：在 Data Control Language 的 `CREATE ROLE` 之后追加：
  - `Role Rewrite Rules`

### Release Notes

- `docs/MatrixOne/Release-Notes/v26.3.0.10.md` 本次 tag 同步时已在仓内预置，覆盖了 Data Branch 家族、SQL 任务、角色规则以及配套的 bugfix / 内部修复（#24092 SHOW ACCOUNTS 优化、#24102 fulltext 快速路径等）。本轮未对该文件再做改动。

### Skipped Changes

- 无 per-item skip。

### Risks

- `CREATE TASK ... AS BEGIN ... END;` 的完整可运行示例未进入 io 仓 Examples（采用占位符模板 + `validator-ignore`）。需要人工在文档评审时核实 `DELIMITER` 相关描述是否与仓内其他存储过程 / 触发器文档风格一致。
- `DATA BRANCH PICK ... BETWEEN SNAPSHOT ... KEYS(...)` 子句顺序按 parser 产生式为权威；若未来调整顺序需要同步本页。
- `role-rule.md` 中 `mo_catalog.mo_role_rule` 表的公开性未在源码中显式说明；如后续希望隐藏该表结构，需要评审本页的 Storage 小节。

## Supervisor Verdict

- Final verdict: **pass** (round 1, unresolvable=False)
- Prechecks: pass=13 fail=0 warn=0 skip=0
- No outstanding Supervisor findings.
