### PR TITLE
fix(doc-validator): classify SHOW RULES ON ROLE as ADMIN

### DIFF
--- a/scripts/doc-validator/checkers/sql-runner.js
+++ b/scripts/doc-validator/checkers/sql-runner.js
@@ -1160,7 +1160,7 @@ export class SqlRunner {
         if (/^(GRANT|REVOKE)\s+/i.test(trimmed)) return SQL_TYPES.ADMIN
         // Note: SNAPSHOT is excluded from ADMIN - it should be executed as DDL to create test context
         if (/^(CREATE|DROP|ALTER)\s+(USER|ACCOUNT|ROLE|PITR|PUBLICATION|SUBSCRIPTION)\s+/i.test(trimmed)) return SQL_TYPES.ADMIN
-        if (/^SHOW\s+(PUBLICATIONS|SUBSCRIPTIONS|SNAPSHOTS|PITR|GRANTS)\b/i.test(trimmed)) return SQL_TYPES.ADMIN
+        if (/^SHOW\s+(PUBLICATIONS|SUBSCRIPTIONS|SNAPSHOTS|PITR|GRANTS|RULES)\b/i.test(trimmed)) return SQL_TYPES.ADMIN
         // SESSION commands (SET statements) - cannot be PREPAREd in MO
         if (/^SET\s+/i.test(trimmed)) return SQL_TYPES.SESSION
         // DDL (including SNAPSHOT - must be executed to create test context)


### PR DESCRIPTION
 ## What type of PR is this?   
                                                                                 
  - [x] Enhancement                                                                 
  - [ ] Displaying
  - [ ] Typo                                                                        
  - [ ] Doc Request                                                                 
                                                                                    
  ## Which issue(s) this PR fixes:                                                  
                                                                                    
  issue #              

  ## What this PR does / why we need it:

  Classify `SHOW RULES ON ROLE` as an ADMIN statement in the doc-validator so it no 
  longer produces false-positive failures on docs that demonstrate the `ALTER ROLE
  ... RULE` flow.                                                                   
                       
  ### Root cause                                                                    
   
  `CREATE / ALTER / DROP ROLE` are already classified as `ADMIN` and therefore only 
  **PREPARE-validated** — the validator checks syntax but does not actually execute
  them against MatrixOne. `SHOW RULES ON ROLE`, however, was missing from the ADMIN 
  `SHOW` allow-list in `sql-runner.js` and fell through to the `QUERY` path, which
  does execute.

  Result: on any doc page that demonstrates the role-rule lifecycle (e.g.           
  `docs/MatrixOne/Reference/SQL-Reference/Data-Control-Language/role-rule.md`), the
  validator would silently skip `CREATE ROLE demo_role`, then really run `SHOW RULES
   ON ROLE demo_role`, and report:

  Query execution failed: internal error: there is no role demo_role                
   
  The documentation itself is correct — the mismatch was entirely inside the        
  validator's classifier.