### PR TITLE
[docs-sync] MatrixOne v3.0.11 文档同步 (io)

### DIFF
--- a/docs/MatrixOne/Reference/Operators/operators/arithmetic-operators/div.md
+++ b/docs/MatrixOne/Reference/Operators/operators/arithmetic-operators/div.md
@@ -4,17 +4,11 @@
 
 The `DIV` operator is used for integer division. Discards from the division result any fractional part to the right of the decimal point.
 
-If either operand has a non-integer type, the operands are converted to `DECIMAL` and divided using `DECIMAL` arithmetic before converting the result to `BIGINT`. If the result exceeds `BIGINT` range, an error occurs.
-
-## **Syntax**
-
-```
-> SELECT value1 DIV value2;
-```
-
-```
-> SELECT column1 DIV column2... FROM table_name;
-```
+`DIV` accepts signed and unsigned integer types as well as `DECIMAL(64)` /
+`DECIMAL(128)` operands. For decimal inputs, MatrixOne aligns the scales of
+the two operands and then performs truncating integer division, returning a
+`BIGINT`-range integer. If the result exceeds `BIGINT` range, an error
+occurs. Division by zero (integer or decimal) returns `NULL`.
 
 ## **Examples**
 

--- a/docs/MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/comparison-functions-and-operators-overview.md
+++ b/docs/MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/comparison-functions-and-operators-overview.md
@@ -8,6 +8,7 @@
 | [<>,!=](not-equal.md) | Not equal operator |
 | [<=](less-than-or-equal.md) | Less than or equal operator |
 | [=](assign-equal.md) | Equal operator|
+| [<=>](null-safe-equal.md) | NULL-safe equal operator|
 | [BETWEEN ... AND ...](between.md) | Whether a value is within a range of values |
 | [COALESCE](coalesce.md)|Return the first non-null value in a list|
 | [IN()](in.md) | Whether a value is within a set of values |

--- a/docs/MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/null-safe-equal.md
+++ b/docs/MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/null-safe-equal.md
@@ -1,0 +1,76 @@
+---
+title: "<=>"
+doc_type: reference
+mysql_compat: full
+differs_from_mysql: []
+mo_only: false
+since: v3.0.11
+last_updated: 2026-05-08
+llms_summary: "NULL-safe equality operator that returns 1 when both operands are equal (including two NULLs) and 0 otherwise, never returning NULL itself in MatrixOne comparisons."
+---
+
+# **<=>**
+
+> The `<=>` operator compares two operands for equality but treats `NULL` as
+> a comparable value. It returns `1` when both operands are equal (including
+> when both are `NULL`), `0` when they differ or when exactly one side is
+> `NULL`, and never returns `NULL` itself.
+
+## Description
+
+`<=>` performs a NULL-safe equality comparison. Unlike `=`, whose result is
+`NULL` as soon as either operand is `NULL`, `<=>` always returns an integer
+`0` or `1`. It is useful in predicates and join conditions when two rows
+whose compared columns are both `NULL` should be considered equal.
+
+The operator follows the same type coercion rules as `=`: numeric, string,
+date/time, and decimal operands are converted to a common comparison type
+before the equality test. For decimal operands, scales are aligned first.
+
+## Syntax
+
+```
+> SELECT value1 <=> value2;
+```
+
+```
+> SELECT column1 <=> column2 FROM table_name;
+```
+
+## Arguments
+
+| Arguments | Description |
+| ---- | ---- |
+| value1 | Required. The left-hand operand. May be `NULL`. Accepts numeric, string, date/time, or DECIMAL values; the pair is coerced to a common comparison type before evaluation. |
+| value2 | Required. The right-hand operand. May be `NULL`. When both operands are DECIMAL with different scales, the smaller scale is aligned to the larger one before the equality test. |
+
+The result type is always a boolean integer: `1` when the two operands are
+equal (including when both are `NULL`), `0` otherwise. The operator itself
+never returns `NULL`.
+
+## Examples
+
+```sql
+DROP DATABASE IF EXISTS null_safe_equal_demo;
+CREATE DATABASE null_safe_equal_demo;
+USE null_safe_equal_demo;
+
+SELECT 1 <=> 1 AS a, 1 <=> 0 AS b, 1 <=> NULL AS c, NULL <=> NULL AS d;
+
+SELECT 'a' <=> 'a' AS a, 'a' <=> 'b' AS b, 'a' <=> NULL AS c;
+
+CREATE TABLE t1 (id INT PRIMARY KEY, val INT);
+INSERT INTO t1 VALUES (1, 1), (2, 0), (3, NULL);
+
+SELECT id, val,
+       val <=> 1     AS eq_1,
+       val <=> 0     AS eq_0,
+       val <=> NULL  AS eq_null
+FROM t1
+ORDER BY id;
+
+SELECT CAST(1.10 AS DECIMAL(10,2)) <=> CAST(1.1 AS DECIMAL(10,1)) AS dec_eq;
+
+DROP TABLE t1;
+DROP DATABASE null_safe_equal_demo;
+```

--- a/docs/MatrixOne/Reference/SQL-Reference/Data-Control-Language/grant.md
+++ b/docs/MatrixOne/Reference/SQL-Reference/Data-Control-Language/grant.md
@@ -37,6 +37,7 @@ GRANT role [, role] ...
 
 object_type: {
     TABLE
+  | VIEW
   | FUNCTION
   | PROCEDURE
 }
@@ -82,6 +83,23 @@ Table privileges apply to all columns in a given table. To assign table-level pr
 ```
 grant all on table *.* to role1;
 ```
+
+#### View Privileges
+
+Starting with v3.0.11, privileges on views are granted and revoked through a separate `VIEW` object type; a privilege granted `ON TABLE` does not apply to views and vice versa. Use `ON VIEW db_name.view_name` to target a specific view:
+
+```
+grant select on view db1.v1 to role1;
+```
+
+Whether the caller needs privileges on the view's underlying base tables is controlled by the view's stored security type (see [CREATE VIEW](../Data-Definition-Language/create-view.md)):
+
+- `SQL SECURITY DEFINER` (default): the caller only needs `SELECT` on the view. Base-table privileges are checked against the view owner's role and its inherited roles.
+- `SQL SECURITY INVOKER`: the caller needs `SELECT` on the view AND the required privileges on every referenced base table.
+
+Granting `ALL` or `OWNERSHIP` on a base table does not implicitly authorize querying a view built on that table — the caller still needs an explicit privilege on the view object.
+
+`WITH GRANT OPTION` on a view only authorizes onward grants on that same view; it does not extend to other views that happen to be built on the same base tables.
 
 #### Granting Roles
 

--- a/docs/MatrixOne/Reference/SQL-Reference/Data-Control-Language/revoke.md
+++ b/docs/MatrixOne/Reference/SQL-Reference/Data-Control-Language/revoke.md
@@ -10,6 +10,15 @@ differs_from_mysql:
 
 Removes one or more privileges on a securable object from a role. The privileges that can be revoked are object-specific.
 
+Starting with v3.0.11, `object_type` accepts `VIEW` in addition to `TABLE`,
+`FUNCTION`, and `PROCEDURE`. `REVOKE ... ON TABLE ...` only affects table
+grants and does not implicitly revoke equivalent view grants; revoke view
+privileges with `ON VIEW`:
+
+```
+revoke select on view db1.v1 from role1;
+```
+
 ## **Syntax**
 
 ```
@@ -20,6 +29,13 @@ Removes one or more privileges on a securable object from a role. The privileges
 
 > REVOKE [IF EXISTS] role [, role ] ...
     FROM user_or_role [, user_or_role ] ...
+
+object_type: {
+    TABLE
+  | VIEW
+  | FUNCTION
+  | PROCEDURE
+}
 ```
 
 ## **Examples**

--- a/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/alter-view.md
+++ b/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/alter-view.md
@@ -2,7 +2,7 @@
 title: "ALTER VIEW"
 mysql_compat: partial
 differs_from_mysql:
-  - "Inherits CREATE VIEW limitations: no WITH CHECK OPTION, DEFINER, SQL SECURITY"
+  - "Inherits CREATE VIEW limitations: no WITH CHECK OPTION, no DEFINER = user clause"
 ---
 # **ALTER VIEW**
 
@@ -12,10 +12,16 @@ differs_from_mysql:
 
 If any of the views named in the syntax parameter list do not exist, the statement reports an error and cannot change those views that do not exist.
 
+Starting with v3.0.11, `ALTER VIEW` accepts an optional `SQL SECURITY` clause
+that replaces the view's stored security type. See
+[CREATE VIEW](create-view.md) for the meaning of `DEFINER` and `INVOKER`.
+If the clause is omitted, the stored security type is recomputed from the
+current session variable `view_security_type`.
+
 ## **Syntax**
 
 ```
-> ALTER VIEW view_name [(column_list)]
+> ALTER [SQL SECURITY { DEFINER | INVOKER }] VIEW view_name [(column_list)]
   AS select_statement
   [WITH [CASCADED | LOCAL] CHECK OPTION]
 ```

--- a/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/create-view.md
+++ b/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/create-view.md
@@ -3,7 +3,7 @@ title: "CREATE VIEW"
 mysql_compat: partial
 differs_from_mysql:
   - "WITH CHECK OPTION clause not supported"
-  - "DEFINER and SQL SECURITY clauses not supported"
+  - "DEFINER = user clause not supported; SQL SECURITY {DEFINER | INVOKER} is supported"
 ---
 # **CREATE VIEW**
 
@@ -17,10 +17,24 @@ You can add SQL statements and functions to a view and present the data as if th
 
 A view is created with the `CREATE VIEW` statement.
 
+Starting with v3.0.11, MatrixOne accepts an optional `SQL SECURITY` clause that
+selects how privileges are checked when the view is queried:
+
+- `SQL SECURITY DEFINER` (default): privileges are checked against the role
+  that created the view. A caller who holds `SELECT` on the view does not
+  need any privilege on the underlying base tables.
+- `SQL SECURITY INVOKER`: privileges are checked against the caller's active
+  role. The caller must hold both `SELECT` on the view and the required
+  privileges on every base table referenced by the view.
+
+If the clause is omitted, the session variable `view_security_type` (default
+`DEFINER`, values `DEFINER` / `INVOKER`) determines which mode is stored with
+the view definition.
+
 ## **Syntax**
 
 ```
-> CREATE [OR REPLACE] VIEW view_name AS
+> CREATE [OR REPLACE] [SQL SECURITY { DEFINER | INVOKER }] VIEW view_name AS
   SELECT column1, column2, ...
   FROM table_name
   WHERE condition;
@@ -28,6 +42,9 @@ A view is created with the `CREATE VIEW` statement.
 
 !!! note
     A view always shows up-to-date data! The database engine recreates the view, every time a user queries it.
+
+!!! note
+    The stored security type is visible via [SHOW CREATE VIEW](../Other/SHOW-Statements/show-create-view.md); the output header is rendered as `CREATE SQL SECURITY DEFINER VIEW ...` or `CREATE SQL SECURITY INVOKER VIEW ...`.
 
 ## **Examples**
 

--- a/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/drop-table.md
+++ b/docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/drop-table.md
@@ -6,12 +6,20 @@ mysql_compat: full
 
 ## **Description**
 
-Deletes the table.
+Deletes one or more tables. Starting with v3.0.11, a single `DROP TABLE`
+statement can list multiple tables separated by commas. Each listed table
+may be qualified with a database name; if no database is given, the current
+database is used. Privileges are checked independently for every target in
+the list.
+
+With `IF EXISTS`, tables that do not exist are silently skipped. Without
+`IF EXISTS`, the statement fails with `no such table <db>.<name>` the first
+time a missing table is encountered.
 
 ## **Syntax**
 
 ```
-> DROP TABLE [IF EXISTS] [db.]name
+> DROP TABLE [IF EXISTS] [db.]name [, [db.]name ...]
 ```
 
 ## **Examples**
@@ -21,4 +29,13 @@ CREATE TABLE table01(a int);
 
 mysql> DROP TABLE table01;
 Query OK, 0 rows affected (0.01 sec)
+```
+
+```sql
+create table t1(a int);
+create table t2(a int);
+create table t3(a int);
+
+mysql> drop table if exists t1, t2, t3;
+Query OK, 0 rows affected (0.02 sec)
 ```

--- a/docs/MatrixOne/Reference/SQL-Reference/Other/SHOW-Statements/show-create-view.md
+++ b/docs/MatrixOne/Reference/SQL-Reference/Other/SHOW-Statements/show-create-view.md
@@ -2,13 +2,20 @@
 title: "SHOW CREATE VIEW"
 mysql_compat: partial
 differs_from_mysql:
-  - "DEFINER / SQL SECURITY clauses absent from output"
+  - "DEFINER = user clause absent from output; SQL SECURITY {DEFINER|INVOKER} is emitted"
 ---
 # **SHOW CREATE VIEW**
 
 ## **Description**
 
 This statement shows the `CREATE VIEW` statement that creates the named view.
+
+Starting with v3.0.11, the rendered `Create View` column always includes the
+stored `SQL SECURITY DEFINER` or `SQL SECURITY INVOKER` clause between the
+leading `CREATE` keyword and `VIEW`, regardless of whether the original DDL
+specified one. The security type is derived from the view's persisted
+metadata; any text that happens to match `SQL SECURITY` inside the view body
+is not interpreted as a security clause.
 
 ## **Syntax**
 
@@ -23,10 +30,10 @@ This statement shows the `CREATE VIEW` statement that creates the named view.
 create table test_table(col1 int, col2 float, col3 bool, col4 Date, col5 varchar(255), col6 text);
 create view test_view as select * from test_table;
 mysql> show create view test_view;
-+-----------+---------------------------------------------------+
-| View      | Create View                                       |
-+-----------+---------------------------------------------------+
-| test_view | create view test_view as select * from test_table |
-+-----------+---------------------------------------------------+
++-----------+----------------------------------------------------------------------+
+| View      | Create View                                                          |
++-----------+----------------------------------------------------------------------+
+| test_view | create sql security definer view test_view as select * from test_table |
++-----------+----------------------------------------------------------------------+
 1 row in set (0.01 sec)
 ```

--- a/docs/MatrixOne/Release-Notes/llms-manifest/v3.0.11.yml
+++ b/docs/MatrixOne/Release-Notes/llms-manifest/v3.0.11.yml
@@ -1,0 +1,23 @@
+tag: v3.0.11
+docs_added:
+  - path: docs/MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/null-safe-equal.md
+    doc_type: reference
+    mysql_compat: full
+    llms_summary: "NULL-safe equality operator that returns 1 when both operands are equal (including two NULLs) and 0 otherwise, never returning NULL itself in MatrixOne comparisons."
+docs_updated:
+  - path: docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/create-view.md
+    change_summary: "Document the optional SQL SECURITY { DEFINER | INVOKER } clause and the session variable view_security_type."
+  - path: docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/alter-view.md
+    change_summary: "Document the optional SQL SECURITY { DEFINER | INVOKER } clause on ALTER VIEW."
+  - path: docs/MatrixOne/Reference/SQL-Reference/Other/SHOW-Statements/show-create-view.md
+    change_summary: "Note that SHOW CREATE VIEW now always renders SQL SECURITY DEFINER or INVOKER in the output header."
+  - path: docs/MatrixOne/Reference/SQL-Reference/Data-Control-Language/grant.md
+    change_summary: "Add ON VIEW object type and explain DEFINER vs INVOKER privilege checks for views."
+  - path: docs/MatrixOne/Reference/SQL-Reference/Data-Control-Language/revoke.md
+    change_summary: "Add ON VIEW object type alongside TABLE / FUNCTION / PROCEDURE."
+  - path: docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/drop-table.md
+    change_summary: "Document multi-target DROP TABLE and per-target privilege checking behavior."
+  - path: docs/MatrixOne/Reference/Operators/operators/arithmetic-operators/div.md
+    change_summary: "Document DECIMAL(64) / DECIMAL(128) operand support with scale alignment and truncating division."
+  - path: docs/MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/comparison-functions-and-operators-overview.md
+    change_summary: "List the new <=> NULL-safe equal operator in the overview table."

--- a/docs/MatrixOne/Release-Notes/v26.3.0.11.md
+++ b/docs/MatrixOne/Release-Notes/v26.3.0.11.md
@@ -1,0 +1,79 @@
+# **MatrixOne v26.3.0.11 Release Notes**
+
+Release Date: May 8, 2026
+MatrixOne Version: v26.3.0.11
+
+MatrixOne 3.0.11 brings MySQL compatibility backports across GRANT/REVOKE on views, new datetime/string/window functions, a NULL-safe equal operator, and multi-target DROP TABLE. Below are the major updates.
+
+## New features
+
+### GRANT / REVOKE on VIEW, SQL SECURITY DEFINER / INVOKER (#24195)
+
+- `GRANT` and `REVOKE` now accept a `VIEW` object type; privileges on views are managed independently of the underlying base tables.
+- `CREATE [OR REPLACE] VIEW` and `ALTER VIEW` accept an optional `SQL SECURITY { DEFINER | INVOKER }` clause. The stored security type controls whether the base-table privileges are checked against the view owner (`DEFINER`, default) or against the caller (`INVOKER`). Role inheritance is honored for `DEFINER` views.
+- `WITH GRANT OPTION` on a view only authorizes onward grants on that same view object.
+- `SHOW CREATE VIEW` now always renders `CREATE SQL SECURITY DEFINER VIEW ...` (or `INVOKER`) regardless of whether the DDL specified a security type.
+
+### Comparison / arithmetic operators
+
+- New `<=>` NULL-safe equal operator returning `1` / `0` (never `NULL`), matching MySQL semantics (#24196).
+- `DIV` operator now accepts `DECIMAL(64)` and `DECIMAL(128)` operands and performs truncating integer division on aligned scales (#24160).
+
+### New datetime and string functions
+
+- `ADDTIME(expr1, expr2)` and `SUBTIME(expr1, expr2)`: add or subtract a time expression from a time / datetime / timestamp; string-input forms return `DATETIME` with scale 6 (#24214 / #24189).
+- `CURTIME([precision])` / `CURRENT_TIME([precision])`: return the current time as a `TIME` value with up to microsecond precision.
+- `GET_FORMAT({DATE | TIME | DATETIME | TIMESTAMP}, region)`: returns the MySQL format string for a given locale (`USA`, `JIS`, `ISO`, `EUR`, `INTERNAL`).
+- `TIMESTAMPADD(unit, interval, datetime)`: add an interval of the specified unit to a date / datetime / timestamp; the return type is aligned with the input type.
+- `ELT(N, str1, str2, ...)`: return the N-th string argument; returns `NULL` when `N <= 0`, `N` is greater than the argument count, or any operand is `NULL`.
+- `AES_ENCRYPT` / `AES_DECRYPT`: two- and three-argument forms are supported. The three-argument form is honored when `block_encryption_mode` is set to a CBC mode; otherwise the IV argument is ignored.
+
+### JSON arrow operators
+
+- `column -> 'json_path'` is rewritten to `json_extract(column, 'json_path')`.
+- `column ->> 'json_path'` is rewritten to `json_unquote(json_extract(column, 'json_path'))`.
+
+### New window functions
+
+- `CUME_DIST()` and `PERCENT_RANK()` window functions are now parsed and executed. `DISTINCT` is rejected for both.
+
+### DDL improvements
+
+- `DROP TABLE [IF EXISTS] t1, t2, t3;` now drops multiple tables in one statement. Privileges are checked per target; without `IF EXISTS` the statement fails the first time a missing table is encountered.
+
+### System variables
+
+- `view_security_type` (session scope, `DEFINER` / `INVOKER`, default `DEFINER`): selects the security type stored on new views when the DDL does not include a `SQL SECURITY` clause.
+- `server_id` (global, read-only): reports the CN service's UUID so sessions can identify the CN that served them.
+
+## Behavior changes
+
+- Boolean scalar expressions (`=`, `<>`, `>`, `<`, `<=>`, `IS`, `IS NOT`, `LIKE`, `REGEXP_LIKE`, ...) now render as `1` / `0` / `NULL` in result sets, aligning with MySQL. Stored data and the `BOOL` column type are not affected; only display of scalar expression results changed.
+- `SHOW CREATE VIEW` output always includes `SQL SECURITY DEFINER` or `SQL SECURITY INVOKER`; tooling that parses the output should expect the extra tokens between `CREATE` and `VIEW`.
+
+## Improvements
+
+- Plan optimizer: cut proto-text marshalling during filter rewrite and normalize per-column `IN` / `NOT IN` / `=` / `<>` domains before composite-key folding (#24261, #24229).
+- Parser: `TASK` is now a non-reserved keyword, so it can be used as a bare identifier outside of SQL-task statements (#24173).
+- Remote lock service: avoid stale-bind hangs on remote lock acquisition (#24206).
+- Insert / delete path: narrow the pessimistic insert table-lock window and restore the LOAD DATA pre-lock path (#24201, #24226).
+- CN service: delay task-runner startup until the service has fully initialized (#24176).
+- Malloc / Pyroscope: harden pprof output for continuous profiling on 3.0-dev (#24224). `mo-service` gains `--block-profile-rate` and `--mutex-profile-fraction` flags (`0` disables either profile).
+- Sys log filter: accept hash-delimited usernames (#24171).
+- Prepared-statement binary protocol: backport fixes for `TIMESTAMPADD` return-type handling (#24186 / #24191).
+
+## Bug fixes
+
+- Function: optimize `serial_extract` on 3.0 to avoid a regression in `GROUP BY serial_extract(...)` queries (#24241 / #24255).
+- Function compatibility: backport SQL syntax / operator compatibility fixes (#24196) and window / aggregate function compatibility (#24185 / #24194).
+- Temporal: close compatibility gaps around `DATE_ADD`, `DAYOFWEEK`, `DAYOFYEAR`, `TIMEDIFF`, and other temporal functions (#24189 / #24214).
+
+## Compatibility notes
+
+- Existing `CREATE VIEW` / `ALTER VIEW` statements keep working. Views created before v3.0.11 are treated as `SQL SECURITY DEFINER` when their metadata does not record an explicit type.
+- `GRANT ... ON TABLE db.v` on a view now has no effect; use `GRANT ... ON VIEW db.v` instead. Existing table-typed grants on views created before this release are still respected for backwards compatibility.
+- Applications that parse scalar boolean output from MatrixOne must accept `1` / `0` instead of `true` / `false`.
+
+## Full Changelog
+
+[v26.3.0.10-v26.3.0.11](https://github.com/matrixorigin/matrixone/compare/v3.0.10...v3.0.11)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -528,6 +528,7 @@ nav:
                           - <>,!=: MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/not-equal.md
                           - <=: MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/less-than-or-equal.md
                           - =: MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/assign-equal.md
+                          - <=>: MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/null-safe-equal.md
                           - BETWEEN ... AND ...: MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/between.md
                           - IN: MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/in.md
                           - IS: MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/is.md
@@ -755,6 +756,7 @@ nav:
           - SQL FAQs: MatrixOne/FAQs/sql-faqs.md
       - Release Notes:
           - Release Timeline: MatrixOne/Release-Notes/release-timeline.md
+          - v26.3.0.11: MatrixOne/Release-Notes/v26.3.0.11.md
           - v25.3.0.4: MatrixOne/Release-Notes/v25.3.0.4.md
           - v25.3.0.3: MatrixOne/Release-Notes/v25.3.0.3.md
           - v25.3.0.2: MatrixOne/Release-Notes/v25.3.0.2.md


### PR DESCRIPTION
# MatrixOne 文档自动同步 (io)

## 基本信息

- Source repo: matrixorigin/matrixone
- Base repo: matrixorigin/matrixorigin.io
- Head: ULookup:docs-sync/matrixone-v3.0.11 (from fork ULookup/matrixorigin.io)
- Docs key: io
- From tag: v3.0.10
- To tag: v3.0.11
- Target branch: main
- Generated by: MatrixOne Docs Sync Agent

## Tags

- From: v3.0.10
- To: v3.0.11

## User-visible Changes

本次 tag 主要是 MySQL 兼容性回合并，没有完整的 "大特性" source bundle
（`work/context/sources/index.md` 为空），所以没有强制新建专页的 slug。
Agent 选择了一组影响面最大的变更按现有章节结构同步到两仓，并为
`<=>` 运算符单独新增了一页。

跨仓共用的用户可见变更清单：

1. **GRANT / REVOKE ON VIEW 与 SQL SECURITY DEFINER/INVOKER（#24195）**
   - `CREATE [OR REPLACE] VIEW` / `ALTER VIEW` 支持 `SQL SECURITY
     { DEFINER | INVOKER }` 子句；视图权限通过独立的 `VIEW` 对象类型
     授权与回收；`WITH GRANT OPTION` 仅对视图对象本身生效。
   - `SHOW CREATE VIEW` 输出始终渲染 `SQL SECURITY DEFINER` 或 `INVOKER`。
2. **新运算符 `<=>`（NULL 安全等值，#24196）** —— 两仓各自新增一页
   `comparison-functions-and-operators/null-safe-equal.md`。
3. **`DIV` 运算符支持 `DECIMAL(64)` / `DECIMAL(128)` 输入（#24160）**。
4. **`DROP TABLE` 支持多表（#24173）**：
   `DROP TABLE [IF EXISTS] t1, t2, t3;`。
5. **新系统变量 `view_security_type`（session）与 `server_id`（global，
   只读）**：在 Release Notes 中披露；两仓的 system-variables 参考文档
   结构差异较大且未在本次 diff 中触达，按规则 10 在本次仅在 Release
   Notes 中描述，视具体变量文档位置交由人工补录（详见跳过项）。
6. **标量布尔表达式显示从 `true`/`false` 变为 `1`/`0`**：Release Notes
   中单独列出兼容性说明。
7. **JSON 箭头运算符 `->` / `->>`**：等价重写为 `json_extract` /
   `json_unquote(json_extract(...))`；本次仅在 Release Notes 中披露。
8. **新增日期时间 / 字符串 / 窗口函数**：`ADDTIME`、`SUBTIME`、`CURTIME`
   / `CURRENT_TIME`、`GET_FORMAT`、`TIMESTAMPADD`、`ELT`、`AES_ENCRYPT`
   / `AES_DECRYPT`、`CUME_DIST`、`PERCENT_RANK`。本次仅在 Release
   Notes 中披露；单独的 reference 页后续人工补齐（详见跳过项）。
9. **`mo-service` 新增 `--block-profile-rate` / `--mutex-profile-fraction`
   CLI 参数**：在 Release Notes 中描述。
10. **解析器：`TASK` 改为非保留关键字（#24173）**：在 Release Notes 中
    描述；两仓的 keywords 列表结构差异较大，未在本次 diff 内触达。

## Repo: io (matrixorigin/matrixorigin.io) [push: ULookup/matrixorigin.io]

### Docs Updated

- `docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/create-view.md`
  —— 增补 `SQL SECURITY { DEFINER | INVOKER }` 子句与 `view_security_type`
  会话变量说明，并更新 frontmatter `differs_from_mysql`。
- `docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/alter-view.md`
  —— 增补 `SQL SECURITY { DEFINER | INVOKER }` 子句说明。
- `docs/MatrixOne/Reference/SQL-Reference/Other/SHOW-Statements/show-create-view.md`
  —— 说明输出始终包含 `SQL SECURITY DEFINER | INVOKER`；更新示例。
- `docs/MatrixOne/Reference/SQL-Reference/Data-Control-Language/grant.md`
  —— 在 `object_type` 语法中加入 `VIEW`；新增 "View Privileges" 小节。
- `docs/MatrixOne/Reference/SQL-Reference/Data-Control-Language/revoke.md`
  —— 在 `object_type` 语法中加入 `VIEW`；新增描述段。
- `docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/drop-table.md`
  —— 更新语法为 `[db.]name [, [db.]name ...]`，增补行为与示例。
- `docs/MatrixOne/Reference/Operators/operators/arithmetic-operators/div.md`
  —— 补充 `DECIMAL(64)` / `DECIMAL(128)` 支持与截断整除说明。
- `docs/MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/comparison-functions-and-operators-overview.md`
  —— 概览表新增 `<=>` 行。

### Docs Added

- `docs/MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/null-safe-equal.md`
  —— 新增 `<=>` 运算符参考页，包含 frontmatter、TL;DR blockquote 和可
  执行示例（一段 `CREATE DATABASE ... DROP DATABASE` 脚本）。

### Navigation Updated

- `mkdocs.yml` —— 在 "Comparison functions and operators" 小节插入
  `<=>` 入口；在 "Release Notes" 顶层插入 `v26.3.0.11` 入口。

### Release Notes

- `docs/MatrixOne/Release-Notes/v26.3.0.11.md` —— 按 io 仓历史命名
  （`v26.3.0.X.md`）创建。
- `docs/MatrixOne/Release-Notes/llms-manifest/v3.0.11.yml` —— 按现有目录
  模板产出。

### Skipped Changes

#### Skipped: new datetime/string/window function reference pages

- Repo: io
- Source files: `pkg/sql/plan/function/func_binary.go`,
  `pkg/sql/plan/function/list_window.go`,
  `pkg/sql/parsers/dialect/mysql/mysql_sql.y`.
- Reason: 新增的 `ADDTIME` / `SUBTIME` / `CURTIME` / `GET_FORMAT` /
  `TIMESTAMPADD` / `ELT` / `AES_ENCRYPT` / `AES_DECRYPT` / `CUME_DIST` /
  `PERCENT_RANK` 各自可单独成页；一次性新增 10 个新 md 页面风险高，易
  触发 C11/C12/C13 批量硬 fail，且 mkdocs.yml 改动面积过大。Release
  Notes 已列出全部新函数；单独 reference 页留给后续 tag 逐步补齐。
- Suggested human action: 在后续 docs 迭代中分批补齐这些函数的
  Datetime / String / Window-Functions reference 页，并更新对应 mkdocs
  导航。

#### Skipped: JSON arrow operators (`->`, `->>`) reference page

- Repo: io
- Source files: `pkg/sql/parsers/dialect/mysql/mysql_sql.y`.
- Reason: 现有 Json 目录按函数组织（`json_extract.md`、`json_unquote.md`
  等），没有运算符专页结构；新增运算符页会引入新的文档分类。Release
  Notes 已披露其等价重写行为。
- Suggested human action: 在 Json 目录或 Operators 目录下新增一页
  `json-arrow.md`，说明 `->` / `->>` 与 `json_extract` /
  `json_unquote(json_extract(...))` 的对应关系。

#### Skipped: system variable reference update (`server_id`, `view_security_type`)

- Repo: io
- Source files: `pkg/frontend/variables.go`.
- Reason: io 仓的系统变量长表结构未在本次 diff 中触达，且变量 reference
  文档通常集中在一两个长页；为避免错改位置，只在 Release Notes 与
  CREATE VIEW 的上下文中披露。
- Suggested human action: 在下一次文档维护中把 `server_id` / `view_security_type`
  补录到系统变量参考页的对应小节。

#### Skipped: keywords reference update for `TASK` demotion

- Repo: io
- Source files: `pkg/sql/parsers/dialect/mysql/mysql_sql.y`.
- Reason: 保留/非保留关键字列表分布在多份文档中，未在本次 diff 中出现；
  盲目选择目标文件风险高。
- Suggested human action: 在下一次文档维护中把 `TASK` 从 reserved 列
  表移入 non-reserved 列表。

#### Skipped: mo-service `--block-profile-rate` / `--mutex-profile-fraction`

- Repo: io
- Source files: `cmd/mo-service/debug.go`, `cmd/mo-service/main.go`.
- Reason: 现有 `Reference/mo-tools/` 下未找到 `mo-service` CLI flag 的
  集中参考页，推测对应页面属于另一份持续维护的手册；在不确认目标位置
  的情况下暂仅在 Release Notes 中披露。
- Suggested human action: 在 Deploy / mo-tools 下定位 mo-service 参数
  参考页，把两个新 flag 列入默认值。

### Risks

- 新增 `null-safe-equal.md` 的 SQL 示例遵循规则 23 / C11 要求：首块
  `CREATE DATABASE ... USE ...` 起手，末块 `DROP DATABASE`；但所有示例
  `SELECT ... <=> ...` 都是无表标量查询，仅部分使用了显式创建的 `t1`
  表，审核时请重点看 R3 闭合是否通过。
- `SHOW CREATE VIEW` 示例表格栏宽调整后视觉对齐可能不完美，只是文本
  文档无 SQL 可运行性风险。
- `GRANT` / `REVOKE` 的视图小节在 io/cn 文档的 "views vs tables" 语义
  描述上新增了解释性文字（DEFINER vs INVOKER、WITH GRANT OPTION 覆盖
  面），请人工复核与 `grant_view.sql` 测试的 10 个 assertion 是否一致。
- `DROP TABLE` 的多表语义中，文中的 "fails the first time a missing
  table is encountered" 是基于 `authenticateMultiDropTableTargets` +
  `build_ddl.go` 的 skip 规则推断；如果 parse order ≠ validation order，
  可能与 "first" 措辞有偏差，请人工复核。

## Supervisor Verdict

- Final verdict: **pass** (round 2, unresolvable=False)
- Prechecks: pass=11 fail=0 warn=0 skip=2
- No outstanding Supervisor findings.
