### PR TITLE
docs(v3.0.11): follow-up pages Agent skipped in PR #683

### DIFF
--- a/docs/MatrixOne/Reference/Functions-and-Operators/Datetime/addtime.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/Datetime/addtime.md
@@ -1,0 +1,51 @@
+---
+title: "ADDTIME()"
+doc_type: reference
+mysql_compat: full
+differs_from_mysql: []
+mo_only: false
+since: v3.0.11
+last_updated: 2026-05-08
+llms_summary: "ADDTIME adds a TIME expression to a TIME, DATETIME, TIMESTAMP, or string value, with the result type following the input type and the scale widening to the larger input scale in MatrixOne."
+---
+
+# **ADDTIME()**
+
+> `ADDTIME(expr1, expr2)` returns `expr1 + expr2` where `expr2` is a `TIME` expression; the result type follows `expr1` (TIME → TIME, DATETIME/TIMESTAMP → DATETIME, string → DATETIME(6)) and the scale widens to the larger input scale.
+
+## **Description**
+
+The `ADDTIME()` function adds `expr2` to `expr1` and returns the result. `expr1` is a `TIME`, `DATETIME`, or `TIMESTAMP` value (or a string that can be parsed as such); `expr2` is a `TIME` expression (optionally including a day part, such as `'1 1:1:1.000002'`). The return type follows the input type:
+
+- When `expr1` is `TIME`, the result is `TIME`.
+- When `expr1` is `DATETIME` or `TIMESTAMP`, the result is `DATETIME`.
+- When `expr1` is a string, the result is `DATETIME` with scale 6 (microsecond precision).
+
+The scale of the result is the larger of the scales of the two input values. The function returns `NULL` when either argument is `NULL` or cannot be parsed.
+
+## **Syntax**
+
+```
+> ADDTIME(expr1, expr2)
+```
+
+## **Arguments**
+
+| Arguments | Description |
+| ---- | ---- |
+| expr1 | Required. A `TIME`, `DATETIME`, `TIMESTAMP`, or string value that will be added to. |
+| expr2 | Required. A `TIME` value, or a string that can be parsed as a `TIME`. |
+
+## **Examples**
+
+```sql
+DROP DATABASE IF EXISTS addtime_demo;
+CREATE DATABASE addtime_demo;
+USE addtime_demo;
+
+SELECT ADDTIME('2007-12-31 23:59:59.999999', '1 1:1:1.000002') AS r1;
+SELECT ADDTIME('01:00:00.999999', '02:00:00.999998')           AS r2;
+SELECT ADDTIME(CAST('10:00:00' AS TIME), '01:30:00')            AS r3;
+
+DROP DATABASE addtime_demo;
+```

--- a/docs/MatrixOne/Reference/Functions-and-Operators/Datetime/curtime.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/Datetime/curtime.md
@@ -1,0 +1,52 @@
+---
+title: "CURTIME()"
+doc_type: reference
+mysql_compat: full
+differs_from_mysql: []
+mo_only: false
+since: v3.0.11
+last_updated: 2026-05-08
+llms_summary: "CURTIME and its synonym CURRENT_TIME return the current server time as a TIME value, optionally with up to microsecond precision in MatrixOne."
+---
+
+# **CURTIME()**
+
+> `CURTIME([fsp])` and its synonym `CURRENT_TIME([fsp])` return the current server time as a `TIME` value, optionally with `fsp` digits of fractional seconds (up to microsecond precision).
+
+## **Description**
+
+The `CURTIME()` function returns the current time as a `TIME` value. `CURRENT_TIME()` is a synonym for `CURTIME()`.
+
+If an optional fractional seconds precision `fsp` is given, the result is returned with `fsp` digits of fractional seconds; otherwise, no fractional part is returned. The default result type uses scale 6 when a precision is not specified at bind time.
+
+## **Syntax**
+
+```
+> CURTIME([fsp])
+> CURRENT_TIME([fsp])
+```
+
+## **Arguments**
+
+| Arguments | Description |
+| ---- | ---- |
+| fsp | Optional. An integer in the range `0` to `6` specifying the number of fractional-second digits to retain in the result. |
+
+## **Examples**
+
+<!-- validator-ignore-exec -->
+```sql
+mysql> SELECT CURTIME();
++-----------+
+| curtime() |
++-----------+
+| 09:30:17  |
++-----------+
+
+mysql> SELECT CURRENT_TIME(3);
++-----------------+
+| current_time(3) |
++-----------------+
+| 09:30:17.412    |
++-----------------+
+```

--- a/docs/MatrixOne/Reference/Functions-and-Operators/Datetime/get-format.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/Datetime/get-format.md
@@ -1,0 +1,58 @@
+---
+title: "GET_FORMAT()"
+doc_type: reference
+mysql_compat: full
+differs_from_mysql: []
+mo_only: false
+since: v3.0.11
+last_updated: 2026-05-08
+llms_summary: "GET_FORMAT returns the MySQL-style locale-specific format string for DATE, TIME, or DATETIME values across USA, EUR, JIS, ISO, and INTERNAL regions in MatrixOne."
+---
+
+# **GET_FORMAT()**
+
+> `GET_FORMAT(type, region)` returns the MySQL-style locale-specific format string for `DATE`, `TIME`, or `DATETIME` values across `USA`, `EUR`, `JIS`, `ISO`, and `INTERNAL` regions; returns `NULL` for unsupported type or region.
+
+## **Description**
+
+The `GET_FORMAT()` function returns the MySQL-style format string used by locale-specific date/time formatting for a given type (`DATE`, `TIME`, or `DATETIME`) and region (`EUR`, `USA`, `JIS`, `ISO`, or `INTERNAL`). The returned string can be passed to `DATE_FORMAT()` or `STR_TO_DATE()`.
+
+If the type or the region is not one of the supported values, the function returns `NULL`.
+
+The full mapping implemented in MatrixOne is:
+
+| Type | USA | EUR | JIS | ISO | INTERNAL |
+| ---- | ---- | ---- | ---- | ---- | ---- |
+| DATE | `%m.%d.%Y` | `%d.%m.%Y` | `%Y-%m-%d` | `%Y-%m-%d` | `%Y%m%d` |
+| TIME | `%h:%i:%s %p` | `%H.%i.%s` | `%H:%i:%s` | `%H:%i:%s` | `%H%i%s` |
+| DATETIME | `%Y-%m-%d %H.%i.%s` | `%Y-%m-%d %H.%i.%s` | `%Y-%m-%d %H:%i:%s` | `%Y-%m-%d %H:%i:%s` | `%Y%m%d%H%i%s` |
+
+## **Syntax**
+
+```
+> GET_FORMAT({DATE | TIME | DATETIME}, {'EUR' | 'USA' | 'JIS' | 'ISO' | 'INTERNAL'})
+```
+
+## **Arguments**
+
+| Arguments | Description |
+| ---- | ---- |
+| type | Required. One of the literal keywords `DATE`, `TIME`, or `DATETIME`. |
+| region | Required. A string literal selecting the locale: `'EUR'`, `'USA'`, `'JIS'`, `'ISO'`, or `'INTERNAL'`. |
+
+## **Examples**
+
+```sql
+DROP DATABASE IF EXISTS get_format_demo;
+CREATE DATABASE get_format_demo;
+USE get_format_demo;
+
+SELECT GET_FORMAT(DATE,     'USA')      AS date_usa,
+       GET_FORMAT(DATE,     'ISO')      AS date_iso,
+       GET_FORMAT(TIME,     'USA')      AS time_usa,
+       GET_FORMAT(DATETIME, 'INTERNAL') AS dt_internal;
+
+SELECT DATE_FORMAT('2023-10-05 12:34:56', GET_FORMAT(DATETIME, 'JIS')) AS formatted;
+
+DROP DATABASE get_format_demo;
+```

--- a/docs/MatrixOne/Reference/Functions-and-Operators/Datetime/subtime.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/Datetime/subtime.md
@@ -1,0 +1,51 @@
+---
+title: "SUBTIME()"
+doc_type: reference
+mysql_compat: full
+differs_from_mysql: []
+mo_only: false
+since: v3.0.11
+last_updated: 2026-05-08
+llms_summary: "SUBTIME subtracts a TIME expression from a TIME, DATETIME, TIMESTAMP, or string value, with the result type following the input type and the scale widening to the larger input scale in MatrixOne."
+---
+
+# **SUBTIME()**
+
+> `SUBTIME(expr1, expr2)` returns `expr1 - expr2` where `expr2` is a `TIME` expression; the result type follows `expr1` (TIME → TIME, DATETIME/TIMESTAMP → DATETIME, string → DATETIME(6)) and the scale widens to the larger input scale.
+
+## **Description**
+
+The `SUBTIME()` function subtracts `expr2` from `expr1` and returns the result. `expr1` is a `TIME`, `DATETIME`, or `TIMESTAMP` value (or a string that can be parsed as such); `expr2` is a `TIME` expression (optionally including a day part). The return type follows the input type:
+
+- When `expr1` is `TIME`, the result is `TIME`.
+- When `expr1` is `DATETIME` or `TIMESTAMP`, the result is `DATETIME`.
+- When `expr1` is a string, the result is `DATETIME` with scale 6 (microsecond precision).
+
+The scale of the result is the larger of the scales of the two input values. The function returns `NULL` when either argument is `NULL` or cannot be parsed.
+
+## **Syntax**
+
+```
+> SUBTIME(expr1, expr2)
+```
+
+## **Arguments**
+
+| Arguments | Description |
+| ---- | ---- |
+| expr1 | Required. A `TIME`, `DATETIME`, `TIMESTAMP`, or string value that will be subtracted from. |
+| expr2 | Required. A `TIME` value, or a string that can be parsed as a `TIME`. |
+
+## **Examples**
+
+```sql
+DROP DATABASE IF EXISTS subtime_demo;
+CREATE DATABASE subtime_demo;
+USE subtime_demo;
+
+SELECT SUBTIME('2007-12-31 23:59:59.999999', '1 1:1:1.000002') AS r1;
+SELECT SUBTIME('03:00:01.999997', '02:00:00.999998')           AS r2;
+SELECT SUBTIME(CAST('10:00:00' AS TIME), '01:30:00')            AS r3;
+
+DROP DATABASE subtime_demo;
+```

--- a/docs/MatrixOne/Reference/Functions-and-Operators/Datetime/timestampadd.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/Datetime/timestampadd.md
@@ -1,0 +1,58 @@
+---
+title: "TIMESTAMPADD()"
+doc_type: reference
+mysql_compat: full
+differs_from_mysql: []
+mo_only: false
+since: v3.0.11
+last_updated: 2026-05-08
+llms_summary: "TIMESTAMPADD adds an integer interval of a given unit to a date, datetime, timestamp, or string expression, with the return type aligned to the input type in MatrixOne."
+---
+
+# **TIMESTAMPADD()**
+
+> `TIMESTAMPADD(unit, interval, datetime_expr)` adds an integer `interval` of the given `unit` (MICROSECOND / SECOND / MINUTE / HOUR / DAY / WEEK / MONTH / QUARTER / YEAR) to a date, datetime, timestamp, or string expression; the return type is aligned with the input type.
+
+## **Description**
+
+The `TIMESTAMPADD()` function adds an integer `interval` of the specified `unit` to a date, datetime, or timestamp expression `datetime_expr` and returns the result.
+
+The return type is aligned with the input type:
+
+- When `datetime_expr` is `DATE` and `unit` is a date unit (`DAY`, `WEEK`, `MONTH`, `QUARTER`, `YEAR`), the result is `DATE`.
+- When `datetime_expr` is `DATE` and `unit` is a time unit (`HOUR`, `MINUTE`, `SECOND`, `MICROSECOND`), the result is `DATETIME` (MySQL-compatible promotion).
+- When `datetime_expr` is `DATETIME`, the result is `DATETIME`.
+- When `datetime_expr` is `TIMESTAMP`, the result is `TIMESTAMP`.
+- When `datetime_expr` is a string, the result is returned as a string.
+
+`MICROSECOND` results carry scale 6; other time units carry scale 0. If either `interval` or `datetime_expr` is `NULL`, or if the addition would overflow the maximum representable datetime, the function returns `NULL`.
+
+## **Syntax**
+
+```
+> TIMESTAMPADD(unit, interval, datetime_expr)
+```
+
+## **Arguments**
+
+| Arguments | Description |
+| ---- | ---- |
+| unit | Required. One of `MICROSECOND`, `SECOND`, `MINUTE`, `HOUR`, `DAY`, `WEEK`, `MONTH`, `QUARTER`, `YEAR`. |
+| interval | Required. An integer; may be negative to subtract. |
+| datetime_expr | Required. A `DATE`, `DATETIME`, `TIMESTAMP`, or string expression. |
+
+## **Examples**
+
+```sql
+DROP DATABASE IF EXISTS timestampadd_demo;
+CREATE DATABASE timestampadd_demo;
+USE timestampadd_demo;
+
+SELECT TIMESTAMPADD(DAY,    5,  DATE '2023-01-01')                  AS r1;
+SELECT TIMESTAMPADD(HOUR,   2,  CAST('2023-01-01' AS DATE))          AS r2;
+SELECT TIMESTAMPADD(MINUTE, 30, CAST('2023-01-01 10:00:00' AS DATETIME)) AS r3;
+SELECT TIMESTAMPADD(MICROSECOND, 500, CAST('2023-01-01 10:00:00' AS DATETIME)) AS r4;
+SELECT TIMESTAMPADD(MONTH,  -3, CAST('2023-05-15' AS DATE))          AS r5;
+
+DROP DATABASE timestampadd_demo;
+```

--- a/docs/MatrixOne/Reference/Functions-and-Operators/Json/json-arrow.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/Json/json-arrow.md
@@ -1,0 +1,78 @@
+---
+title: "JSON Arrow Operators -> and ->>"
+doc_type: reference
+mysql_compat: full
+differs_from_mysql: []
+mo_only: false
+since: v3.0.11
+last_updated: 2026-05-08
+llms_summary: "The JSON arrow operators -> and ->> are parser shorthand for json_extract and json_unquote(json_extract(...)), extracting JSON values or unquoted strings by path in MatrixOne."
+---
+
+# **JSON Arrow Operators `->` and `->>`**
+
+> The `->` and `->>` operators are parser shorthand for JSON path extraction: `col -> '$.path'` is rewritten to `json_extract(col, '$.path')`, and `col ->> '$.path'` is rewritten to `json_unquote(json_extract(col, '$.path'))`.
+
+## **Description**
+
+The JSON arrow operators `->` and `->>` are shorthand for extracting values from a JSON document by path. Both operators are rewritten by the parser to equivalent calls of the existing JSON functions; they produce the same result type and behavior as the underlying function call.
+
+| Operator | Rewrites to | Returns |
+| ---- | ---- | ---- |
+| `json_col -> 'json_path'` | [`json_extract`](json_extract.md)`(json_col, 'json_path')` | A JSON value (may be a JSON scalar, object, or array). |
+| `json_col ->> 'json_path'` | [`json_unquote`](json_unquote.md)`(`[`json_extract`](json_extract.md)`(json_col, 'json_path'))` | A `VARCHAR` string with any surrounding JSON quotes stripped. |
+
+Because the rewrite happens at parse time, the operators are drop-in replacements for the function calls. The same path-expression rules as `JSON_EXTRACT()` apply: paths must start with `$`, dot-notation accesses object members, `[N]` indexes arrays, and `*` / `**` wildcards are supported.
+
+Use `->` when the caller wants the extracted value as a JSON value (for example, to pass it to another JSON function). Use `->>` when the caller wants the unquoted string form (for example, to compare against a plain string literal).
+
+## **Syntax**
+
+```
+> json_col ->  'json_path'
+> json_col ->> 'json_path'
+```
+
+## **Arguments**
+
+| Arguments | Description |
+| ---- | ---- |
+| json_col | Required. A JSON column or expression that produces JSON. |
+| json_path | Required. A string literal containing a JSON path expression. See [`JSON_EXTRACT()`](json_extract.md) for the full path syntax. |
+
+## **Examples**
+
+```sql
+DROP DATABASE IF EXISTS json_arrow_demo;
+CREATE DATABASE json_arrow_demo;
+USE json_arrow_demo;
+
+CREATE TABLE t1 (id INT, payload JSON);
+INSERT INTO t1 VALUES
+  (1, '{"name": "Alice",   "age": 30, "tags": ["admin", "dev"]}'),
+  (2, '{"name": "Bob",     "age": 25, "tags": ["dev"]}'),
+  (3, '{"name": "Charlie", "age": 40, "tags": []}');
+
+-- `->` returns the extracted value (still JSON); the string "Alice" is quoted.
+SELECT id, payload -> '$.name' AS name_json FROM t1 ORDER BY id;
+
+-- `->>` unquotes the result so it comes back as a bare VARCHAR.
+SELECT id, payload ->> '$.name' AS name_str FROM t1 ORDER BY id;
+
+-- Chained access into a nested array member.
+SELECT id, payload ->> '$.tags[0]' AS primary_tag FROM t1 ORDER BY id;
+
+-- The arrow form is equivalent to the function call form.
+SELECT id,
+       payload -> '$.age'                AS via_arrow,
+       JSON_EXTRACT(payload, '$.age')    AS via_func
+FROM t1 ORDER BY id;
+
+DROP TABLE t1;
+DROP DATABASE json_arrow_demo;
+```
+
+## **See also**
+
+- [`JSON_EXTRACT()`](json_extract.md)
+- [`JSON_UNQUOTE()`](json_unquote.md)

--- a/docs/MatrixOne/Reference/Functions-and-Operators/String/aes_decrypt.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/String/aes_decrypt.md
@@ -1,0 +1,62 @@
+---
+title: "AES_DECRYPT()"
+doc_type: reference
+mysql_compat: partial
+differs_from_mysql: ["Only aes-128-ecb and aes-256-cbc are supported via block_encryption_mode; other MySQL modes are not implemented."]
+mo_only: false
+since: v3.0.11
+last_updated: 2026-05-08
+llms_summary: "AES_DECRYPT decrypts a ciphertext with a key using the mode set by block_encryption_mode, supporting aes-128-ecb (default) and aes-256-cbc with a required 16-byte IV in MatrixOne."
+---
+
+# **AES_DECRYPT()**
+
+> `AES_DECRYPT(crypt_str, key_str[, init_vector])` decrypts ciphertext using AES and returns a `VARCHAR` plaintext; the mode is selected by session variable `block_encryption_mode`, which must match the mode used for encryption (`aes-128-ecb` default; `aes-256-cbc` requires a 16-byte IV).
+
+## **Description**
+
+The `AES_DECRYPT()` function decrypts `crypt_str` with `key_str` using AES and returns the plaintext as a `VARCHAR`. The encryption mode is selected by the session variable [`block_encryption_mode`](../../Variable/system-variables/system-variables-overview.md) and must match the mode used to produce `crypt_str`.
+
+MatrixOne currently supports two modes:
+
+- `aes-128-ecb` (default). Key is derived to 16 bytes; the optional `init_vector` argument is ignored.
+- `aes-256-cbc`. Key is derived to 32 bytes; the `init_vector` argument is required and must be at least 16 bytes, matching the IV used to encrypt.
+
+The function returns `NULL` in any of the following cases:
+
+- `crypt_str` or `key_str` is `NULL`.
+- `block_encryption_mode` is set to an unsupported value.
+- CBC mode is selected but the IV is missing, `NULL`, or shorter than 16 bytes.
+- Key derivation or the underlying AES operation fails (wrong key, tampered ciphertext, or bad padding).
+
+## **Syntax**
+
+```
+> AES_DECRYPT(crypt_str, key_str)
+> AES_DECRYPT(crypt_str, key_str, init_vector)
+```
+
+## **Arguments**
+
+| Arguments | Description |
+| ---- | ---- |
+| crypt_str | Required. The ciphertext to decrypt. Accepts `BLOB`, `VARCHAR`, `CHAR`, or `TEXT`. |
+| key_str | Required. The encryption key that was used to produce `crypt_str`. |
+| init_vector | Optional. The initialization vector, required when `block_encryption_mode` selects a CBC mode. |
+
+## **Examples**
+
+<!-- validator-ignore-exec -->
+```sql
+mysql> SET block_encryption_mode = 'aes-128-ecb';
+mysql> SELECT AES_DECRYPT(AES_ENCRYPT('MatrixOne', 'my-secret-key'), 'my-secret-key');
++--------------------------------------------------------------------------+
+| aes_decrypt(aes_encrypt(matrixone, my-secret-key), my-secret-key)        |
++--------------------------------------------------------------------------+
+| MatrixOne                                                                |
++--------------------------------------------------------------------------+
+```
+
+## **See also**
+
+- [`AES_ENCRYPT()`](aes_encrypt.md)

--- a/docs/MatrixOne/Reference/Functions-and-Operators/String/aes_encrypt.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/String/aes_encrypt.md
@@ -1,0 +1,65 @@
+---
+title: "AES_ENCRYPT()"
+doc_type: reference
+mysql_compat: partial
+differs_from_mysql: ["Only aes-128-ecb and aes-256-cbc are supported via block_encryption_mode; other MySQL modes are not implemented."]
+mo_only: false
+since: v3.0.11
+last_updated: 2026-05-08
+llms_summary: "AES_ENCRYPT encrypts plaintext with a key and returns a BLOB using the mode set by block_encryption_mode, supporting aes-128-ecb (default) and aes-256-cbc with a required 16-byte IV in MatrixOne."
+---
+
+# **AES_ENCRYPT()**
+
+> `AES_ENCRYPT(str, key_str[, init_vector])` encrypts a string using AES and returns a `BLOB` ciphertext; the mode is selected by session variable `block_encryption_mode` (`aes-128-ecb` default; `aes-256-cbc` requires a 16-byte IV in the third argument).
+
+## **Description**
+
+The `AES_ENCRYPT()` function encrypts `str` with `key_str` using AES and returns the ciphertext as a `BLOB`. The encryption mode is selected by the session variable [`block_encryption_mode`](../../Variable/system-variables/system-variables-overview.md).
+
+MatrixOne currently supports two modes:
+
+- `aes-128-ecb` (default). Key is derived to 16 bytes; the optional `init_vector` argument is ignored.
+- `aes-256-cbc`. Key is derived to 32 bytes; the `init_vector` argument is required and must be at least 16 bytes.
+
+The function returns `NULL` in any of the following cases:
+
+- `str` or `key_str` is `NULL`.
+- `block_encryption_mode` is set to an unsupported value.
+- CBC mode is selected but the IV is missing, `NULL`, or shorter than 16 bytes.
+- Key derivation or the underlying AES operation fails.
+
+## **Syntax**
+
+```
+> AES_ENCRYPT(str, key_str)
+> AES_ENCRYPT(str, key_str, init_vector)
+```
+
+## **Arguments**
+
+| Arguments | Description |
+| ---- | ---- |
+| str | Required. The plaintext string to encrypt. Accepts `VARCHAR`, `CHAR`, `TEXT`, or `BLOB`. |
+| key_str | Required. The encryption key. |
+| init_vector | Optional. The initialization vector, required when `block_encryption_mode` selects a CBC mode. Must be at least 16 bytes. |
+
+## **Examples**
+
+<!-- validator-ignore-exec -->
+```sql
+mysql> SET block_encryption_mode = 'aes-128-ecb';
+mysql> SELECT HEX(AES_ENCRYPT('MatrixOne', 'my-secret-key'));
++-------------------------------------------------+
+| hex(aes_encrypt(matrixone, my-secret-key))      |
++-------------------------------------------------+
+| 3B1A...                                         |
++-------------------------------------------------+
+
+mysql> SET block_encryption_mode = 'aes-256-cbc';
+mysql> SELECT HEX(AES_ENCRYPT('MatrixOne', 'my-secret-key', '0123456789abcdef'));
+```
+
+## **See also**
+
+- [`AES_DECRYPT()`](aes_decrypt.md)

--- a/docs/MatrixOne/Reference/Functions-and-Operators/String/elt.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/String/elt.md
@@ -1,0 +1,55 @@
+---
+title: "ELT()"
+doc_type: reference
+mysql_compat: full
+differs_from_mysql: []
+mo_only: false
+since: v3.0.11
+last_updated: 2026-05-08
+llms_summary: "ELT returns the N-th string argument counting from 1, yielding NULL when N is out of range or any referenced argument is NULL in MatrixOne."
+---
+
+# **ELT()**
+
+> `ELT(N, str1, str2, ...)` returns the N-th string argument counting from 1, and returns `NULL` when `N` is `NULL`, `N < 1`, `N` exceeds the number of string arguments, or the selected string argument itself is `NULL`.
+
+## **Description**
+
+The `ELT()` function returns the `N`-th string argument, counting from `1`. `ELT(1, str1, str2, ...)` returns `str1`, `ELT(2, ...)` returns `str2`, and so on.
+
+The function returns `NULL` in any of the following cases:
+
+- `N` is `NULL` or any of the string arguments evaluated at that index is `NULL`.
+- `N < 1` or `N` is greater than the number of string arguments supplied.
+- `N` is an integer type (`UINT64`, `BIT`) whose value falls outside the valid range.
+
+At least two arguments are required (the index and one string); otherwise, the call is rejected at bind time. Non-string rest arguments are cast to `VARCHAR`. When any rest argument is `BINARY` / `VARBINARY` / `BLOB`, the result type is `BLOB`; otherwise, it is `VARCHAR`.
+
+## **Syntax**
+
+```
+> ELT(N, str1, str2, str3, ...)
+```
+
+## **Arguments**
+
+| Arguments | Description |
+| ---- | ---- |
+| N | Required. An integer expression selecting which string to return. Types `BOOL`, `INT`, `FLOAT`, and `DECIMAL` are cast to `INT64`; `UINT64` / `BIT` are used as-is. |
+| str1, str2, ... | Required. One or more string expressions. Non-string types are cast to `VARCHAR`. |
+
+## **Examples**
+
+```sql
+DROP DATABASE IF EXISTS elt_demo;
+CREATE DATABASE elt_demo;
+USE elt_demo;
+
+SELECT ELT(1, 'Aa', 'Bb', 'Cc', 'Dd') AS r1;
+SELECT ELT(3, 'Aa', 'Bb', 'Cc', 'Dd') AS r2;
+SELECT ELT(0, 'Aa', 'Bb', 'Cc', 'Dd') AS out_of_range;
+SELECT ELT(5, 'Aa', 'Bb', 'Cc', 'Dd') AS out_of_range2;
+SELECT ELT(NULL, 'Aa', 'Bb')          AS n_is_null;
+
+DROP DATABASE elt_demo;
+```

--- a/docs/MatrixOne/Reference/Functions-and-Operators/Window-Functions/cume_dist.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/Window-Functions/cume_dist.md
@@ -1,0 +1,64 @@
+---
+title: "CUME_DIST()"
+doc_type: reference
+mysql_compat: full
+differs_from_mysql: []
+mo_only: false
+since: v3.0.11
+last_updated: 2026-05-08
+llms_summary: "CUME_DIST returns the cumulative distribution of the current row within its window partition as a DOUBLE in (0, 1], computed as rows-with-value-<=-current divided by partition size in MatrixOne."
+---
+
+# **CUME_DIST()**
+
+> `CUME_DIST()` is a window function that returns the cumulative distribution of the current row within its partition as a `DOUBLE` in the range `(0, 1]`, computed as (rows with value less than or equal to the current row) / (partition size).
+
+## **Description**
+
+`CUME_DIST()` returns the cumulative distribution of the current row within its window partition. The value is a `DOUBLE` in the range (0, 1] and is defined as:
+
+```
+CUME_DIST = (number of rows with value <= current row's value) / (total rows in partition)
+```
+
+Rows that tie on the `ORDER BY` expression share the same value. The function takes no arguments and `DISTINCT` is rejected.
+
+## **Syntax**
+
+```
+> CUME_DIST() OVER (
+    [PARTITION BY column_1, column_2, ... ]
+    ORDER BY column_3, column_4, ...
+)
+```
+
+- The `PARTITION BY` clause is optional and divides the dataset into partitions; the cumulative distribution is computed independently inside each partition.
+- The `ORDER BY` clause defines how rows are sorted before the distribution is computed.
+
+## **Examples**
+
+```sql
+DROP DATABASE IF EXISTS cume_dist_demo;
+CREATE DATABASE cume_dist_demo;
+USE cume_dist_demo;
+
+CREATE TABLE sales (
+  department VARCHAR(20),
+  employee   VARCHAR(20),
+  amount     INT
+);
+INSERT INTO sales VALUES
+  ('Marketing', 'John',    1000),
+  ('Marketing', 'Jane',    1200),
+  ('Sales',     'Alex',     900),
+  ('Sales',     'Bob',     1100),
+  ('HR',        'Alice',    800),
+  ('HR',        'Charlie',  850);
+
+SELECT department, employee, amount,
+       CUME_DIST() OVER (PARTITION BY department ORDER BY amount) AS cd
+FROM sales;
+
+DROP TABLE sales;
+DROP DATABASE cume_dist_demo;
+```

--- a/docs/MatrixOne/Reference/Functions-and-Operators/Window-Functions/percent_rank.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/Window-Functions/percent_rank.md
@@ -1,0 +1,64 @@
+---
+title: "PERCENT_RANK()"
+doc_type: reference
+mysql_compat: full
+differs_from_mysql: []
+mo_only: false
+since: v3.0.11
+last_updated: 2026-05-08
+llms_summary: "PERCENT_RANK returns the relative rank of the current row within its window partition as a DOUBLE in the range [0, 1], computed as (rank - 1) divided by (partition size - 1) in MatrixOne."
+---
+
+# **PERCENT_RANK()**
+
+> `PERCENT_RANK()` is a window function that returns the relative rank of the current row within its partition as a `DOUBLE` in the range `[0, 1]`, computed as `(rank - 1) / (partition_size - 1)`; a partition of size 1 yields 0.
+
+## **Description**
+
+`PERCENT_RANK()` returns the relative rank of the current row within its window partition as a value in the range [0, 1]. It is defined as:
+
+```
+PERCENT_RANK = (rank - 1) / (total rows in partition - 1)
+```
+
+where `rank` follows the same tie-handling behavior as `RANK()`: rows that tie on the `ORDER BY` expression share the same rank, and the next rank is skipped. When the partition has only one row, the result is `0`. The function takes no arguments and `DISTINCT` is rejected.
+
+## **Syntax**
+
+```
+> PERCENT_RANK() OVER (
+    [PARTITION BY column_1, column_2, ... ]
+    ORDER BY column_3, column_4, ...
+)
+```
+
+- The `PARTITION BY` clause is optional and divides the dataset into partitions; the percent rank is computed independently inside each partition.
+- The `ORDER BY` clause defines how rows are sorted before the rank is computed.
+
+## **Examples**
+
+```sql
+DROP DATABASE IF EXISTS percent_rank_demo;
+CREATE DATABASE percent_rank_demo;
+USE percent_rank_demo;
+
+CREATE TABLE sales (
+  department VARCHAR(20),
+  employee   VARCHAR(20),
+  amount     INT
+);
+INSERT INTO sales VALUES
+  ('Marketing', 'John',    1000),
+  ('Marketing', 'Jane',    1200),
+  ('Sales',     'Alex',     900),
+  ('Sales',     'Bob',     1100),
+  ('HR',        'Alice',    800),
+  ('HR',        'Charlie',  850);
+
+SELECT department, employee, amount,
+       PERCENT_RANK() OVER (PARTITION BY department ORDER BY amount) AS pr
+FROM sales;
+
+DROP TABLE sales;
+DROP DATABASE percent_rank_demo;
+```

--- a/docs/MatrixOne/Reference/Variable/system-variables/system-variables-overview.md
+++ b/docs/MatrixOne/Reference/Variable/system-variables/system-variables-overview.md
@@ -91,6 +91,7 @@ __Note:__ The `LIKE` operator is used for fuzzy matching query strings, with % r
 | query_result_maxsize | Y | N | uint | Y | Both | Y | 100 | 0-18446744073709551615 |
 | query_result_timeout | Y | N | uint | Y | Both | Y | 24 | 0-18446744073709551615 |
 | [save_query_result](save_query_result.md) | Y | N | bool | Y | Both | Y | FALSE | TRUE |
+| server_id | Y | N | string | Y | Global | N | "" | Populated with the current CN service's UUID at session start; read-only. |
 | [sql_mode](sql-mode.md) | Y | N | set | Y | Both | Y | "ONLY_FULL_GROUP_BY,<br>STRICT_TRANS_TABLES,<br>NO_ZERO_IN_DATE,<br>NO_ZERO_DATE,<br>ERROR_FOR_DIVISION_BY_ZERO,<br>NO_ENGINE_SUBSTITUTION" | "ANSI", "TRADITIONAL", "ALLOW_INVALID_DATES", "ANSI_QUOTES", "ERROR_FOR_DIVISION_BY_ZERO", "HIGH_NOT_PRECEDENCE", "IGNORE_SPACE", "NO_AUTO_VALUE_ON_ZERO", "NO_BACKSLASH_ESCAPES", "NO_DIR_IN_CREATE", "NO_ENGINE_SUBSTITUTION", "NO_UNSIGNED_SUBTRACTION", "NO_ZERO_DATE", "NO_ZERO_IN_DATE", "ONLY_FULL_GROUP_BY", "PAD_CHAR_TO_FULL_LENGTH", "PIPES_AS_CONCAT", "REAL_AS_FLOAT", "STRICT_ALL_TABLES", "STRICT_TRANS_TABLES", "TIME_TRUNCATE_FRACTIONAL" |
 | sql_safe_updates | Y | N | int | Y | Both | Y | 0 | 0-1 |
 | sql_select_limit | Y | N | uint | Y | Both | Y | 18446744073709551615 |  0-18446744073709551615 |
@@ -99,6 +100,7 @@ __Note:__ The `LIKE` operator is used for fuzzy matching query strings, with % r
 | transaction_isolation | Y | N | enum | Y | Both | Y | "REPEATABLE-READ" | "READ-UNCOMMITTED", "READ-COMMITTED", "REPEATABLE-READ","REPEATABLE-READ", "SERIALIZABLE" |
 | transaction_read_only | Y | N | int | Y | Both | Y | 0 | 0-1 |
 | version_comment | Y | N | string | Y | Both | N | "MatrixOne" |  |
+| view_security_type | Y | N | enum | Y | Session | Y | "DEFINER" | "DEFINER", "INVOKER" |
 | wait_timeout | Y | N | int | Y | Both | Y | 28800 |  1-2147483 |
 
 ## Constraints

--- a/docs/MatrixOne/Reference/mo-tools/mo_service.md
+++ b/docs/MatrixOne/Reference/mo-tools/mo_service.md
@@ -1,0 +1,44 @@
+---
+title: "mo-service profiling flags"
+doc_type: reference
+mysql_compat: mo_only
+differs_from_mysql: []
+mo_only: true
+since: v3.0.11
+last_updated: 2026-05-08
+llms_summary: "mo-service exposes --block-profile-rate and --mutex-profile-fraction flags that drive Go runtime block and mutex profilers for continuous profiling against the /debug/pprof endpoints in MatrixOne."
+---
+
+# **mo-service profiling flags**
+
+> Starting in v3.0.11, `mo-service` accepts `--block-profile-rate` and `--mutex-profile-fraction` command-line flags that drive the Go runtime block and mutex profilers, and can be scraped via the `/debug/pprof/block` and `/debug/pprof/mutex` endpoints exposed by `--debug-http`.
+
+`mo-service` is the executable that runs a MatrixOne node. Starting with v3.0.11, `mo-service` accepts two command-line flags that enable the Go runtime's block and mutex profilers. They are intended for continuous profiling setups (for example, Pyroscope or `go tool pprof` collection against the `/debug/pprof/block` and `/debug/pprof/mutex` endpoints exposed by `--debug-http`).
+
+Either flag can be disabled by passing `0`.
+
+## Flags
+
+| Flag | Default | Effect |
+| ---- | ---- | ---- |
+| `--block-profile-rate` | `5` | Controls the fraction of goroutine blocking events that are reported in the block profile. Internally calls Go's `runtime.SetBlockProfileRate(rate)`. `0` disables the block profile. Recommended values: `100` for production, `1` for debugging. |
+| `--mutex-profile-fraction` | `100` | Controls the fraction of mutex contention events that are reported in the mutex profile. Internally calls Go's `runtime.SetMutexProfileFraction(rate)`. `0` disables the mutex profile. Recommended values: `100` for production, `1` for debugging. |
+
+When a positive value is applied at startup, `mo-service` logs a line such as `Block profiling enabled with rate: 5` or `Mutex profiling enabled with fraction: 100`.
+
+## Example
+
+```bash
+# Enable both profiles with debugging-level granularity while keeping the HTTP
+# debug server available for pprof collection.
+mo-service \
+  --cfg etc/launch-with-dnservice/cn.toml \
+  --debug-http 0.0.0.0:12345 \
+  --block-profile-rate 1 \
+  --mutex-profile-fraction 1
+```
+
+## See also
+
+- `--debug-http`: listen address for the Go pprof HTTP handlers.
+- `--profile-interval`: duration for periodic profile rotation.

--- a/docs/MatrixOne/Release-Notes/llms-manifest/v3.0.11.yml
+++ b/docs/MatrixOne/Release-Notes/llms-manifest/v3.0.11.yml
@@ -4,6 +4,54 @@ docs_added:
     doc_type: reference
     mysql_compat: full
     llms_summary: "NULL-safe equality operator that returns 1 when both operands are equal (including two NULLs) and 0 otherwise, never returning NULL itself in MatrixOne comparisons."
+  - path: docs/MatrixOne/Reference/Functions-and-Operators/Datetime/addtime.md
+    doc_type: reference
+    mysql_compat: full
+    llms_summary: "ADDTIME adds a TIME expression to a TIME, DATETIME, TIMESTAMP, or string value, with the result type following the input type and the scale widening to the larger input scale in MatrixOne."
+  - path: docs/MatrixOne/Reference/Functions-and-Operators/Datetime/curtime.md
+    doc_type: reference
+    mysql_compat: full
+    llms_summary: "CURTIME and its synonym CURRENT_TIME return the current server time as a TIME value, optionally with up to microsecond precision in MatrixOne."
+  - path: docs/MatrixOne/Reference/Functions-and-Operators/Datetime/get-format.md
+    doc_type: reference
+    mysql_compat: full
+    llms_summary: "GET_FORMAT returns the MySQL-style locale-specific format string for DATE, TIME, or DATETIME values across USA, EUR, JIS, ISO, and INTERNAL regions in MatrixOne."
+  - path: docs/MatrixOne/Reference/Functions-and-Operators/Datetime/subtime.md
+    doc_type: reference
+    mysql_compat: full
+    llms_summary: "SUBTIME subtracts a TIME expression from a TIME, DATETIME, TIMESTAMP, or string value, with the result type following the input type and the scale widening to the larger input scale in MatrixOne."
+  - path: docs/MatrixOne/Reference/Functions-and-Operators/Datetime/timestampadd.md
+    doc_type: reference
+    mysql_compat: full
+    llms_summary: "TIMESTAMPADD adds an integer interval of a given unit to a date, datetime, timestamp, or string expression, with the return type aligned to the input type in MatrixOne."
+  - path: docs/MatrixOne/Reference/Functions-and-Operators/Json/json-arrow.md
+    doc_type: reference
+    mysql_compat: full
+    llms_summary: "The JSON arrow operators -> and ->> are parser shorthand for json_extract and json_unquote(json_extract(...)), extracting JSON values or unquoted strings by path in MatrixOne."
+  - path: docs/MatrixOne/Reference/Functions-and-Operators/String/aes_decrypt.md
+    doc_type: reference
+    mysql_compat: partial
+    llms_summary: "AES_DECRYPT decrypts a ciphertext with a key using the mode set by block_encryption_mode, supporting aes-128-ecb (default) and aes-256-cbc with a required 16-byte IV in MatrixOne."
+  - path: docs/MatrixOne/Reference/Functions-and-Operators/String/aes_encrypt.md
+    doc_type: reference
+    mysql_compat: partial
+    llms_summary: "AES_ENCRYPT encrypts plaintext with a key and returns a BLOB using the mode set by block_encryption_mode, supporting aes-128-ecb (default) and aes-256-cbc with a required 16-byte IV in MatrixOne."
+  - path: docs/MatrixOne/Reference/Functions-and-Operators/String/elt.md
+    doc_type: reference
+    mysql_compat: full
+    llms_summary: "ELT returns the N-th string argument counting from 1, yielding NULL when N is out of range or any referenced argument is NULL in MatrixOne."
+  - path: docs/MatrixOne/Reference/Functions-and-Operators/Window-Functions/cume_dist.md
+    doc_type: reference
+    mysql_compat: full
+    llms_summary: "CUME_DIST returns the cumulative distribution of the current row within its window partition as a DOUBLE in (0, 1], computed as rows-with-value-<=-current divided by partition size in MatrixOne."
+  - path: docs/MatrixOne/Reference/Functions-and-Operators/Window-Functions/percent_rank.md
+    doc_type: reference
+    mysql_compat: full
+    llms_summary: "PERCENT_RANK returns the relative rank of the current row within its window partition as a DOUBLE in the range [0, 1], computed as (rank - 1) divided by (partition size - 1) in MatrixOne."
+  - path: docs/MatrixOne/Reference/mo-tools/mo_service.md
+    doc_type: reference
+    mysql_compat: mo_only
+    llms_summary: "mo-service exposes --block-profile-rate and --mutex-profile-fraction flags that drive Go runtime block and mutex profilers for continuous profiling against the /debug/pprof endpoints in MatrixOne."
 docs_updated:
   - path: docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/create-view.md
     change_summary: "Document the optional SQL SECURITY { DEFINER | INVOKER } clause and the session variable view_security_type."
@@ -21,3 +69,5 @@ docs_updated:
     change_summary: "Document DECIMAL(64) / DECIMAL(128) operand support with scale alignment and truncating division."
   - path: docs/MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/comparison-functions-and-operators-overview.md
     change_summary: "List the new <=> NULL-safe equal operator in the overview table."
+  - path: docs/MatrixOne/Reference/Variable/system-variables/system-variables-overview.md
+    change_summary: "Add server_id (read-only, populated with CN service UUID) and view_security_type (DEFINER/INVOKER) session variables."

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -573,9 +573,11 @@ nav:
                       - VARIANCE: MatrixOne/Reference/Functions-and-Operators/Aggregate-Functions/variance.md
                       - VAR_POP: MatrixOne/Reference/Functions-and-Operators/Aggregate-Functions/var_pop.md
                   - Datetime:
+                      - ADDTIME(): MatrixOne/Reference/Functions-and-Operators/Datetime/addtime.md
                       - CONVERT_TZ(): MatrixOne/Reference/Functions-and-Operators/Datetime/convert-tz.md
                       - CURDATE(): MatrixOne/Reference/Functions-and-Operators/Datetime/curdate.md
                       - CURRENT_TIMESTAMP(): MatrixOne/Reference/Functions-and-Operators/Datetime/current-timestamp.md
+                      - CURTIME() / CURRENT_TIME(): MatrixOne/Reference/Functions-and-Operators/Datetime/curtime.md
                       - DATE(): MatrixOne/Reference/Functions-and-Operators/Datetime/date.md
                       - DATE_ADD(): MatrixOne/Reference/Functions-and-Operators/Datetime/date-add.md
                       - DATE_FORMAT(): MatrixOne/Reference/Functions-and-Operators/Datetime/date-format.md
@@ -584,6 +586,7 @@ nav:
                       - DAY(): MatrixOne/Reference/Functions-and-Operators/Datetime/day.md
                       - DAYOFYEAR(): MatrixOne/Reference/Functions-and-Operators/Datetime/dayofyear.md
                       - EXTRACT(): MatrixOne/Reference/Functions-and-Operators/Datetime/extract.md
+                      - GET_FORMAT(): MatrixOne/Reference/Functions-and-Operators/Datetime/get-format.md
                       - HOUR(): MatrixOne/Reference/Functions-and-Operators/Datetime/hour.md
                       - FROM_UNIXTIME: MatrixOne/Reference/Functions-and-Operators/Datetime/from-unixtime.md
                       - MINUTE(): MatrixOne/Reference/Functions-and-Operators/Datetime/minute.md
@@ -591,10 +594,12 @@ nav:
                       - NOW(): MatrixOne/Reference/Functions-and-Operators/Datetime/now.md
                       - SECOND(): MatrixOne/Reference/Functions-and-Operators/Datetime/second.md
                       - STR_TO_DATE(): MatrixOne/Reference/Functions-and-Operators/Datetime/str-to-date.md
+                      - SUBTIME(): MatrixOne/Reference/Functions-and-Operators/Datetime/subtime.md
                       - SYSDATE(): MatrixOne/Reference/Functions-and-Operators/Datetime/sysdate.md
                       - TIME(): MatrixOne/Reference/Functions-and-Operators/Datetime/time.md
                       - TIMEDIFF(): MatrixOne/Reference/Functions-and-Operators/Datetime/timediff.md
                       - TIMESTAMP(): MatrixOne/Reference/Functions-and-Operators/Datetime/timestamp.md
+                      - TIMESTAMPADD(): MatrixOne/Reference/Functions-and-Operators/Datetime/timestampadd.md
                       - TIMESTAMPDIFF(): MatrixOne/Reference/Functions-and-Operators/Datetime/timestampdiff.md
                       - TO_DATE(): MatrixOne/Reference/Functions-and-Operators/Datetime/to-date.md
                       - TO_DAYS(): MatrixOne/Reference/Functions-and-Operators/Datetime/to-days.md
@@ -627,11 +632,14 @@ nav:
                       - SINH(): MatrixOne/Reference/Functions-and-Operators/Mathematical/sinh.md
                       - TAN(): MatrixOne/Reference/Functions-and-Operators/Mathematical/tan.md
                   - String:
+                      - AES_DECRYPT(): MatrixOne/Reference/Functions-and-Operators/String/aes_decrypt.md
+                      - AES_ENCRYPT(): MatrixOne/Reference/Functions-and-Operators/String/aes_encrypt.md
                       - BIN(): MatrixOne/Reference/Functions-and-Operators/String/bin.md
                       - BIT_LENGTH(): MatrixOne/Reference/Functions-and-Operators/String/bit-length.md
                       - CHAR_LENGTH(): MatrixOne/Reference/Functions-and-Operators/String/char-length.md
                       - CONCAT(): MatrixOne/Reference/Functions-and-Operators/String/concat.md
                       - CONCAT_WS(): MatrixOne/Reference/Functions-and-Operators/String/concat-ws.md
+                      - ELT(): MatrixOne/Reference/Functions-and-Operators/String/elt.md
                       - EMPTY(): MatrixOne/Reference/Functions-and-Operators/String/empty.md
                       - ENDSWITH(): MatrixOne/Reference/Functions-and-Operators/String/endswith.md
                       - FIELD(): MatrixOne/Reference/Functions-and-Operators/String/field.md
@@ -701,10 +709,13 @@ nav:
                       - VECTOR_DIMS(): MatrixOne/Reference/Functions-and-Operators/Vector/vector_dims.md
                       - NORMALIZE_L2(): MatrixOne/Reference/Functions-and-Operators/Vector/normalize_l2.md
                   - Window Functions:
+                      - CUME_DIST(): MatrixOne/Reference/Functions-and-Operators/Window-Functions/cume_dist.md
                       - DENSE_RANK(): MatrixOne/Reference/Functions-and-Operators/Window-Functions/dense_rank.md
+                      - PERCENT_RANK(): MatrixOne/Reference/Functions-and-Operators/Window-Functions/percent_rank.md
                       - RANK(): MatrixOne/Reference/Functions-and-Operators/Window-Functions/rank.md
                       - ROW_NUMBER(): MatrixOne/Reference/Functions-and-Operators/Window-Functions/row_number.md
                   - JSON Functions:
+                      - "-> and ->> operators": MatrixOne/Reference/Functions-and-Operators/Json/json-arrow.md
                       - JQ(): MatrixOne/Reference/Functions-and-Operators/Json/jq.md
                       - JSON_EXTRACT(): MatrixOne/Reference/Functions-and-Operators/Json/json_extract.md
                       - JSON_EXTRACT_FLOAT64(): MatrixOne/Reference/Functions-and-Operators/Json/json_extract_float64.md
@@ -739,6 +750,7 @@ nav:
               - Partitioning supported features list: MatrixOne/Reference/Limitations/mo-partition-support.md
           - MatrixOne Directory Structure: MatrixOne/Maintain/mo-directory-structure.md
           - MatrixOne Tools:
+              - mo-service profiling flags: MatrixOne/Reference/mo-tools/mo_service.md
               - mo_ctl stand-alone tool: MatrixOne/Reference/mo-tools/mo_ctl_standalone.md
               - mo_ctl distributed Tools: MatrixOne/Reference/mo-tools/mo_ctl.md
               - mo_datax_writer tool: MatrixOne/Reference/mo-tools/mo_datax_writer.md


### PR DESCRIPTION
## What type of PR is this?    
                                                                         
  - [x] Enhancement                                                      
  - [ ] Displaying
  - [ ] Typo                                                             
  - [ ] Doc Request                                                      
                                                                         
  ## Which issue(s) this PR fixes:                                       
                                                                         
  issue #                                                                
                                                            
  ## What this PR does / why we need it:                                 
   
  This PR is an **Agent-generated (Claude Code) follow-up** to the       
  MatrixOne v3.0.11 doc sync in #683. It covers the items the sync Agent
  explicitly deferred to humans in the "Skipped Changes" section of #683,
   all cross-checked against the `v3.0.11` tag of  `matrixorigin/matrixone`.

  ### New reference pages

  All new pages follow the agent-friendly template introduced in #676: frontmatter (`doc_type` / `mysql_compat` / `differs_from_mysql` / `mo_only` / `since: v3.0.11` / `last_updated` / `llms_summary`) + TL;DR  blockquote + executable SQL examples wrapped in `CREATE DATABASE ... DROP DATABASE` where applicable.
  - **Datetime** — `ADDTIME`, `SUBTIME`, `CURTIME` (with `CURRENT_TIME`   synonym), `GET_FORMAT`, `TIMESTAMPADD`
  - **String** — `ELT`, `AES_ENCRYPT`, `AES_DECRYPT` (marked `mysql_compat: partial` because MatrixOne's `block_encryption_mode` only supports `aes-128-ecb` and `aes-256-cbc`)
  - **Window Functions** — `CUME_DIST`, `PERCENT_RANK`                   
  - **JSON** — `-> and ->> operators`, documenting the parser-level   rewrite to `json_extract` / `json_unquote(json_extract(...))`          
  - **mo-tools** — `mo-service profiling flags`, covering `--block-profile-rate` (default `5`) and `--mutex-profile fraction`  (default `100`)                                           
                                                                         
  ### Updated pages                                                      
   
  - `system-variables-overview.md` — add `server_id` (Global, read-only,  populated with CN service UUID) and `view_security_type` (Session, enum `DEFINER`/`INVOKER`, default `DEFINER`)                               
  - `mkdocs.yml` — navigation entries for all 12 new pages  
  - `Release-Notes/llms-manifest/v3.0.11.yml` — register all new pages   
                                                                         
  ### Deliberately *not* changed                                         
                                                                         
  - **`TASK` keyword** — #683 flagged a potential keywords-doc update.     Verified `keywords.md` already lists `TASK` only under Non-Reserved (line 653) and not under the Reserved `T` section, matching  `mysql_sql.y:13665` where `TASK` sits under `non_reserved_keyword`. No edit required.