### PR TITLE
ci(cd): install Node deps before mike deploy

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -35,6 +35,21 @@ jobs:
         run: |
           git rev-parse --abbrev-ref HEAD
           pip install -r requirements.txt
+
+      # The mkdocs on_pre_build hook (docs/hooks/generate_compat_matrix.py)
+      # invokes `node scripts/generate-compat-matrix.js`, which imports
+      # `fast-glob` from node_modules. Install Node deps before `mike deploy`
+      # so the hook can resolve them.
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9.15.0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+      - name: Install Node deps
+        run: pnpm install --frozen-lockfile
+
       - name: Git Config
         run: |
           git fetch --all


### PR DESCRIPTION
 ## What type of PR is this?
                                                                                        
  - [x] Enhancement                                                                           
  - [ ] Displaying
  - [ ] Typo                                                                                  
  - [ ] Doc Request                                                                           
                                                                                              
  ## Which issue(s) this PR fixes:                                                            
                                                                                              
  issue #                                                                                     
                       
  ## What this PR does / why we need it:                                                      
   
  Fix the `build and push image` (cd.yml) workflow, which currently fails during `mike deploy 
  --push` with:        
                                                                                              
  Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'fast-glob' imported from                 
  .../scripts/generate-compat-matrix.js
  [compat-matrix] generate-compat-matrix.js failed with exit code 1                           
  error: Command '['mkdocs', 'build', ...]' returned non-zero exit status 1.                  
                                                                                              
  ### Root cause                                                                              
                                                                                              
  The MkDocs `on_pre_build` hook at `docs/hooks/generate_compat_matrix.py` shells out to `node
   scripts/generate-compat-matrix.js`, which `import`s `fast-glob` from `node_modules`. The
  existing `cd.yml` only sets up Python and runs `pip install -r requirements.txt` — Node     
  dependencies are never installed, so the hook aborts and `mkdocs build` (invoked via `mike
  deploy`) exits non-zero.

  This did not surface on previous releases because the `generate-compat-matrix` hook was     
  introduced with the agent-friendly SQL-Reference work that landed after v26.3.0.10;
  v26.3.0.11 is the first release build to exercise it.                                       
                                                            
  ### Fix                                                                                     
   
  Add a pnpm + Node.js setup step and `pnpm install --frozen-lockfile` between the Python env 
  setup and the `mike deploy` stage, so the hook can resolve its imports. No changes to deploy
   logic, tags, or registries.                                                                
                                                            
  ```yaml                                                                                     
  - uses: pnpm/action-setup@v4
    with:                                                                                     
      version: 9.15.0                                                                         
  - uses: actions/setup-node@v4                                                               
    with:                                                                                     
      node-version: '20'                                                                      
      cache: 'pnpm'                                                                           
  - name: Install Node deps                                                                   
    run: pnpm install --frozen-lockfile                                                       
  ```         