### PR TITLE
fix: remove stale hook references to deleted docs/hooks/ directory

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,9 +19,6 @@ theme:
 plugins:
   - search:
       separator: '[\s\-,:!=\[\]()"/]+|(?!\b)(?=[A-Z][a-z])|\.(?!\d)|&[lg]t;'
-hooks:
-  - docs/hooks/generate_compat_matrix.py
-  - docs/hooks/agent_delivery.py
 edit_uri: edit/main/docs/
 extra_css:
   - stylesheets/extra.css


### PR DESCRIPTION
The `docs/hooks/` directory was removed in a prior commit, but `mkdocs.yml` still references two hook files (`generate_compat_matrix.py` and `agent_delivery.py`). This causes `mike deploy` to fail with:

```
Config value 'hooks': The path 'docs/hooks/generate_compat_matrix.py' isn't an existing file.
```

This PR removes the stale hook references.