### PR TITLE
feat: agent-friendly compat matrix JSON + llms-func/op indexes (main)

### DIFF
--- a/docs/MatrixOne/Reference/mysql-compatibility-matrix.json
+++ b/docs/MatrixOne/Reference/mysql-compatibility-matrix.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-27T08:38:44.924Z",
+  "generated_at": "2026-05-27T08:51:33.168Z",
   "summary": {
     "total": 373,
     "full": 131,


### PR DESCRIPTION
## Summary
- Add `mysql-compatibility-matrix.json` sidecar with structured data and unique entry IDs for agent consumption
- Add `llms-func.txt` and `llms-op.txt` flat indexes (same format as `llms-sql.txt`)
- Merge "Differences from MySQL" + "MatrixOne-only" columns into single "Notes" column
- Regenerate compat matrix for main branch frontmatter state

## Affected files
- `scripts/generate-compat-matrix.js` — JSON output + 3-column markdown format
- `docs/hooks/agent_delivery.py` — `_build_func_index()` + `_build_op_index()` generators
- `docs/MatrixOne/Reference/mysql-compatibility-matrix.md` — regenerated
- `docs/MatrixOne/Reference/mysql-compatibility-matrix.json` — new