### PR TITLE
feat: agent-friendly compat matrix (v3.0.12)

### DIFF
--- a/docs/MatrixOne/Reference/mysql-compatibility-matrix.json
+++ b/docs/MatrixOne/Reference/mysql-compatibility-matrix.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-27T08:38:44.924Z",
+  "generated_at": "2026-05-27T10:48:00.926Z",
   "summary": {
     "total": 373,
     "full": 131,


### PR DESCRIPTION
## Summary
Regenerate compat matrix with updated 3-column format and JSON sidecar for v3.0.12.

The script changes (generate-compat-matrix.js, agent_delivery.py) are already in main from #700.
This PR adds the regenerated output files specific to this version's frontmatter state.

## Files
- `docs/MatrixOne/Reference/mysql-compatibility-matrix.md` — regenerated
- `docs/MatrixOne/Reference/mysql-compatibility-matrix.json` — regenerated