### PR TITLE
feat: add agent-friendly compat matrix JSON + llms-func/op indexes (v3.0.13)

### DIFF
--- a/docs/MatrixOne/Reference/mysql-compatibility-matrix.json
+++ b/docs/MatrixOne/Reference/mysql-compatibility-matrix.json
@@ -1,0 +1,3369 @@
+{
+  "generated_at": "2026-05-27T08:38:44.924Z",
+  "summary": {
+    "total": 373,
+    "full": 131,
+    "partial": 97,
+    "none": 1,
+    "mo_only": 96,
+    "unknown": 48
+  },
+  "sections": [
+    {
+      "id": "sql-reference",
+      "label": "SQL Statements",
+      "summary": {
+        "full": 21,
+        "partial": 58,
+        "none": 1,
+        "mo_only": 53,
+        "unknown": 0
+      },
+      "categories": [
+        {
+          "id": "_root",
+          "label": "SQL Statements",
+          "entries": [
+            {
+              "id": "sql.sql_type",
+              "title": "Type of SQL Statements",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/SQL-Type.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] Index page describing MatrixOne's own SQL statement taxonomy; not a MySQL-equivalent concept."
+              ]
+            }
+          ]
+        },
+        {
+          "id": "data_control_language",
+          "label": "Data Control Language (DCL)",
+          "entries": [
+            {
+              "id": "sql.data_control_language.alter_account",
+              "title": "ALTER ACCOUNT",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Control-Language/alter-account.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] ALTER ACCOUNT"
+              ]
+            },
+            {
+              "id": "sql.data_control_language.alter_user",
+              "title": "ALTER USER",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Control-Language/alter-user.md",
+              "compat": "partial",
+              "notes": [
+                "Only ALTER USER can change passwords; account-limit clauses not honoured",
+                "Password management options (PASSWORD EXPIRE, PASSWORD HISTORY, PASSWORD REUSE INTERVAL, PASSWORD REQUIRE CURRENT, FAILED_LOGIN_ATTEMPTS, PASSWORD_LOCK_TIME) not supported",
+                "Account locking (ACCOUNT LOCK/UNLOCK) not supported",
+                "REQUIRE clause (TLS/SSL enforcement) not supported",
+                "COMMENT and ATTRIBUTE modification not supported",
+                "Multiple users per statement not supported (MySQL 8.0 allows user [, user] ...)"
+              ]
+            },
+            {
+              "id": "sql.data_control_language.create_account",
+              "title": "CREATE ACCOUNT",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Control-Language/create-account.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] CREATE ACCOUNT … ADMIN_NAME …"
+              ]
+            },
+            {
+              "id": "sql.data_control_language.create_role",
+              "title": "CREATE ROLE",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Control-Language/create-role.md",
+              "compat": "partial",
+              "notes": [
+                "Role exists inside MatrixOne's multi-account model; roles are account-scoped, not server-global as in MySQL."
+              ]
+            },
+            {
+              "id": "sql.data_control_language.create_user",
+              "title": "CREATE USER",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Control-Language/create-user.md",
+              "compat": "partial",
+              "notes": [
+                "IDENTIFIED BY is the only supported password form; IDENTIFIED WITH plugins not supported",
+                "Connection-IP whitelists and connection-limit clauses not supported",
+                "COMMENT and ATTRIBUTE clauses not supported",
+                "'user'@'host' syntax is accepted and host is stored in mo_catalog.mo_user.user_host but may not restrict connections; users are scoped to the current account, not server-global as in MySQL",
+                "Password management options (PASSWORD EXPIRE, PASSWORD HISTORY, PASSWORD REUSE INTERVAL, PASSWORD REQUIRE CURRENT) not supported",
+                "Account locking (ACCOUNT LOCK/UNLOCK) not supported",
+                "REQUIRE clause (TLS/SSL enforcement) not supported"
+              ]
+            },
+            {
+              "id": "sql.data_control_language.drop_account",
+              "title": "DROP ACCOUNT",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Control-Language/drop-account.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] DROP ACCOUNT"
+              ]
+            },
+            {
+              "id": "sql.data_control_language.drop_role",
+              "title": "DROP ROLE",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Control-Language/drop-role.md",
+              "compat": "partial",
+              "notes": [
+                "Role exists inside MatrixOne's multi-account model; roles are account-scoped, not server-global as in MySQL."
+              ]
+            },
+            {
+              "id": "sql.data_control_language.drop_user",
+              "title": "DROP USER",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Control-Language/drop-user.md",
+              "compat": "partial",
+              "notes": [
+                "User identifier is a bare username scoped to the current account; MySQL uses 'user'@'host' tuples."
+              ]
+            },
+            {
+              "id": "sql.data_control_language.grant",
+              "title": "GRANT",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Control-Language/grant.md",
+              "compat": "partial",
+              "notes": [
+                "Authorization logic differs from MySQL — MatrixOne evaluates via its role/account model",
+                "User identifier is a bare username scoped to the current account; MySQL uses 'user'@'host' tuples",
+                "AS user [WITH ROLE ...] clause (MySQL 8.0 privilege restriction) not supported",
+                "GRANT privilege ... TO only accepts roles; users receive privileges indirectly through role membership (GRANT role TO user)",
+                "WITH ADMIN OPTION for role grants is not supported",
+                "[MO-only] `GRANT ... ON ACCOUNT *` — account-level privileges have no MySQL counterpart",
+                "[MO-only] `GRANT ... ON DATABASE *` — MatrixOne-specific database-level grant target",
+                "[MO-only] GRANT ... ON VIEW db_name.view_name (separate VIEW object_type; MySQL 8.0 only supports TABLE, FUNCTION, PROCEDURE)"
+              ]
+            },
+            {
+              "id": "sql.data_control_language.revoke",
+              "title": "REVOKE",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Control-Language/revoke.md",
+              "compat": "partial",
+              "notes": [
+                "Recovery logic differs from MySQL — privileges return to the role/account graph",
+                "User identifier is a bare username scoped to the current account; MySQL uses 'user'@'host' tuples",
+                "IGNORE UNKNOWN USER clause (MySQL 8.0.30+) not supported",
+                "[MO-only] `REVOKE ... ON ACCOUNT *` — account-level privileges have no MySQL counterpart",
+                "[MO-only] `REVOKE ... ON DATABASE *` — MatrixOne-specific database-level revoke target",
+                "[MO-only] REVOKE ... ON VIEW db_name.view_name (separate VIEW object_type)"
+              ]
+            },
+            {
+              "id": "sql.data_control_language.role_rule",
+              "title": "Role Rewrite Rules (ALTER ROLE ... RULE / SHOW RULES)",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Control-Language/role-rule.md",
+              "compat": "mo_only",
+              "notes": []
+            }
+          ]
+        },
+        {
+          "id": "data_definition_language",
+          "label": "Data Definition Language (DDL)",
+          "entries": [
+            {
+              "id": "sql.data_definition_language.alter_pitr",
+              "title": "ALTER PITR",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/alter-pitr.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] ALTER PITR"
+              ]
+            },
+            {
+              "id": "sql.data_definition_language.alter_publication",
+              "title": "ALTER PUBLICATION",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/alter-publication.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] ALTER PUBLICATION"
+              ]
+            },
+            {
+              "id": "sql.data_definition_language.alter_reindex",
+              "title": "ALTER REINDEX",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/alter-reindex.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] ALTER … REINDEX (rebuild vector index)"
+              ]
+            },
+            {
+              "id": "sql.data_definition_language.alter_sequence",
+              "title": "ALTER SEQUENCE",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/alter-sequence.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] ALTER SEQUENCE"
+              ]
+            },
+            {
+              "id": "sql.data_definition_language.alter_stage",
+              "title": "ALTER STAGE",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/alter-stage.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] ALTER STAGE"
+              ]
+            },
+            {
+              "id": "sql.data_definition_language.alter_table",
+              "title": "ALTER TABLE",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/alter-table.md",
+              "compat": "partial",
+              "notes": [
+                "Multiple ALTER TABLE operations can be combined in one statement, with limitation: DROP PRIMARY KEY cannot be combined with RENAME COLUMN, CHANGE COLUMN, or DROP COLUMN (causes server panic); DROP PK + ADD COLUMN and DROP PK + MODIFY COLUMN work correctly",
+                "Temporary tables cannot be altered",
+                "ALTER TABLE does not support PARTITION operations"
+              ]
+            },
+            {
+              "id": "sql.data_definition_language.alter_view",
+              "title": "ALTER VIEW",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/alter-view.md",
+              "compat": "partial",
+              "notes": [
+                "WITH CHECK OPTION is accepted in CREATE VIEW (syntax only, views are read-only) but rejected as a syntax error in ALTER VIEW"
+              ]
+            },
+            {
+              "id": "sql.data_definition_language.branch_protect_snapshots",
+              "title": "Branch Protect Snapshots",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/branch-protect-snapshots.md",
+              "compat": "mo_only",
+              "notes": []
+            },
+            {
+              "id": "sql.data_definition_language.create_clone",
+              "title": "CREATE CLONE",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/create-clone.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] CREATE TABLE … CLONE db.table [TO ACCOUNT …]"
+              ]
+            },
+            {
+              "id": "sql.data_definition_language.create_cluster_table",
+              "title": "CREATE CLUSTER TABLE",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/create-cluster-table.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] CREATE CLUSTER TABLE"
+              ]
+            },
+            {
+              "id": "sql.data_definition_language.create_database",
+              "title": "CREATE DATABASE",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/create-database.md",
+              "compat": "partial",
+              "notes": [
+                "Only utf8mb4 / utf8mb4_bin are functional; other charsets/collations are syntactically accepted but have no effect",
+                "ENCRYPTION clause accepted but inert"
+              ]
+            },
+            {
+              "id": "sql.data_definition_language.create_dynamic_table",
+              "title": "CREATE DYNAMIC TABLE",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/create-dynamic-table.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] CREATE DYNAMIC TABLE"
+              ]
+            },
+            {
+              "id": "sql.data_definition_language.create_external_table",
+              "title": "CREATE EXTERNAL TABLE",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/create-external-table.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] CREATE EXTERNAL TABLE"
+              ]
+            },
+            {
+              "id": "sql.data_definition_language.create_fulltext_index",
+              "title": "Create Fulltext Index",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/create-fulltext-index.md",
+              "compat": "partial",
+              "notes": [
+                "MatrixOne full-text index is implemented on TAE storage with CJK/English optimizations; MySQL implements it on InnoDB/MyISAM with different stopword and parser semantics."
+              ]
+            },
+            {
+              "id": "sql.data_definition_language.create_function_python",
+              "title": "CREATE FUNCTION...LANGUAGE PYTHON AS",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/create-function-python.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] CREATE FUNCTION … LANGUAGE PYTHON AS …"
+              ]
+            },
+            {
+              "id": "sql.data_definition_language.create_function_sql",
+              "title": "CREATE FUNCTION...LANGUAGE SQL AS",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/create-function-sql.md",
+              "compat": "partial",
+              "notes": [
+                "Only LANGUAGE SQL and LANGUAGE PYTHON are supported; usage differs significantly from MySQL stored functions",
+                "CREATE OR REPLACE FUNCTION is supported; MySQL 8.0 does not support OR REPLACE for functions (only IF NOT EXISTS since 8.0.29)"
+              ]
+            },
+            {
+              "id": "sql.data_definition_language.create_index",
+              "title": "CREATE INDEX",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/create-index.md",
+              "compat": "partial",
+              "notes": [
+                "Secondary indexes are supported and participate in query optimization (as of MO 3.0.12, EXPLAIN shows Index Table Scan for secondary index queries). Does not support index hints (USE INDEX, FORCE INDEX, IGNORE INDEX), function-based indexes, or FULLTEXT index via CREATE INDEX syntax (use CREATE FULLTEXT INDEX instead).",
+                "[MO-only] USING IVFFLAT — vector index for approximate nearest neighbour",
+                "[MO-only] USING HNSW — vector index for approximate nearest neighbour",
+                "[MO-only] USING MASTER — composite master index"
+              ]
+            },
+            {
+              "id": "sql.data_definition_language.create_index_hnsw",
+              "title": "CREATE INDEX USING HNSW",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/create-index-hnsw.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] CREATE INDEX … USING HNSW"
+              ]
+            },
+            {
+              "id": "sql.data_definition_language.create_index_ivfflat",
+              "title": "CREATE INDEX USING IVFFLAT",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/create-index-ivfflat.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] CREATE INDEX … USING IVFFLAT"
+              ]
+            },
+            {
+              "id": "sql.data_definition_language.create_pitr",
+              "title": "CREATE PITR",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/create-pitr.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] CREATE PITR … RANGE N {h|d|mo|y}"
+              ]
+            },
+            {
+              "id": "sql.data_definition_language.create_publication",
+              "title": "CREATE PUBLICATION",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/create-publication.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] CREATE PUBLICATION"
+              ]
+            },
+            {
+              "id": "sql.data_definition_language.create_sequence",
+              "title": "CREATE SEQUENCE",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/create-sequence.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] CREATE SEQUENCE (PostgreSQL-style)"
+              ]
+            },
+            {
+              "id": "sql.data_definition_language.create_snapshot",
+              "title": "CREATE SNAPSHOT",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/create-snapshot.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] CREATE SNAPSHOT FOR {ACCOUNT|DATABASE|TABLE|CLUSTER}"
+              ]
+            },
+            {
+              "id": "sql.data_definition_language.create_source",
+              "title": "CREATE SOURCE",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/create-source.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] CREATE SOURCE (stream/Kafka connector)"
+              ]
+            },
+            {
+              "id": "sql.data_definition_language.create_stage",
+              "title": "CREATE STAGE",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/create-stage.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] CREATE STAGE (external file-system binding)"
+              ]
+            },
+            {
+              "id": "sql.data_definition_language.create_table",
+              "title": "CREATE TABLE",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/create-table.md",
+              "compat": "partial",
+              "notes": [
+                "ENGINE= clause is syntactically accepted but ignored; MatrixOne uses TAE exclusively",
+                "Spatial type names (GEOMETRY, POINT, etc.) are syntactically accepted but non-functional; MEDIUMINT is syntactically accepted but treated as INT",
+                "BOOL is a native boolean type, not an INT alias as in MySQL",
+                "AUTO_INCREMENT step is always 1; @@auto_increment_increment is syntactically accepted but inert",
+                "Partitioning accepts syntax but only HASH and KEY participate in partition pruning (RANGE/LIST/RANGE COLUMNS/LIST COLUMNS are syntax-only); subpartitioning causes an internal error; ADD/DROP/TRUNCATE PARTITION not supported",
+                "CHECK constraints are syntactically accepted but not enforced; MySQL 8.0.16+ enforces them",
+                "[MO-only] CLUSTER BY (col, …) — pre-sort columns to accelerate queries",
+                "[MO-only] START TRANSACTION table option — non-standard table option with no MySQL 8.0 equivalent"
+              ]
+            },
+            {
+              "id": "sql.data_definition_language.create_table_like",
+              "title": "CREATE TABLE ... LIKE",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/create-table-like.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "sql.data_definition_language.create_table_as_select",
+              "title": "CREATE TABLE AS SELECT",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/create-table-as-select.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "sql.data_definition_language.sql_task",
+              "title": "CREATE TASK (SQL Task)",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/sql-task.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] CREATE TASK / ALTER TASK / DROP TASK / EXECUTE TASK / SHOW TASKS (MO-specific scheduled SQL tasks; MySQL uses CREATE EVENT instead)"
+              ]
+            },
+            {
+              "id": "sql.data_definition_language.create_view",
+              "title": "CREATE VIEW",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/create-view.md",
+              "compat": "partial",
+              "notes": [
+                "WITH CHECK OPTION is syntactically accepted but not enforced",
+                "Views are read-only; MySQL 8.0 supports INSERT/UPDATE/DELETE through views that meet updatability criteria"
+              ]
+            },
+            {
+              "id": "sql.data_definition_language.create_subscription",
+              "title": "CREATE...FROM...PUBLICATION...",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/create-subscription.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] CREATE DATABASE … FROM … PUBLICATION …"
+              ]
+            },
+            {
+              "id": "sql.data_definition_language.data_branch_create_en",
+              "title": "DATA BRANCH CREATE",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-create-en.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] DATA BRANCH CREATE (Git-for-Data)"
+              ]
+            },
+            {
+              "id": "sql.data_definition_language.data_branch_delete_en",
+              "title": "DATA BRANCH DELETE",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-delete-en.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] DATA BRANCH DELETE"
+              ]
+            },
+            {
+              "id": "sql.data_definition_language.data_branch_diff_en",
+              "title": "DATA BRANCH DIFF",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-diff-en.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] DATA BRANCH DIFF"
+              ]
+            },
+            {
+              "id": "sql.data_definition_language.data_branch_merge_en",
+              "title": "DATA BRANCH MERGE",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-merge-en.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] DATA BRANCH MERGE"
+              ]
+            },
+            {
+              "id": "sql.data_definition_language.data_branch_pick",
+              "title": "DATA BRANCH PICK",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-pick.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] DATA BRANCH PICK (cherry-pick specific rows between branch tables, Git-for-Data feature)"
+              ]
+            },
+            {
+              "id": "sql.data_definition_language.drop_database",
+              "title": "DROP DATABASE",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/drop-database.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "sql.data_definition_language.drop_function",
+              "title": "DROP FUNCTION",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/drop-function.md",
+              "compat": "partial",
+              "notes": [
+                "Drops MatrixOne-style SQL / Python functions, not MySQL stored procedures/functions",
+                "Requires argument type list on DROP (e.g. DROP FUNCTION py_add(int, int)); MySQL 8.0 accepts only the function name"
+              ]
+            },
+            {
+              "id": "sql.data_definition_language.drop_index",
+              "title": "DROP INDEX",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/drop-index.md",
+              "compat": "partial",
+              "notes": [
+                "MO accepts DROP INDEX IF EXISTS syntax (MySQL 8.0 does not), but IF EXISTS does not suppress errors for missing indexes; it returns internal error 20101 instead of a silent skip"
+              ]
+            },
+            {
+              "id": "sql.data_definition_language.drop_pitr",
+              "title": "DROP PITR",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/drop-pitr.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] DROP PITR"
+              ]
+            },
+            {
+              "id": "sql.data_definition_language.drop_publication",
+              "title": "DROP PUBLICATION",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/drop-publication.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] DROP PUBLICATION"
+              ]
+            },
+            {
+              "id": "sql.data_definition_language.drop_sequence",
+              "title": "DROP SEQUENCE",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/drop-sequence.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] DROP SEQUENCE"
+              ]
+            },
+            {
+              "id": "sql.data_definition_language.drop_snapshot",
+              "title": "DROP SNAPSHOT",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/drop-snapshot.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] DROP SNAPSHOT"
+              ]
+            },
+            {
+              "id": "sql.data_definition_language.drop_stage",
+              "title": "DROP STAGE",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/drop-stage.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] DROP STAGE"
+              ]
+            },
+            {
+              "id": "sql.data_definition_language.drop_table",
+              "title": "DROP TABLE",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/drop-table.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "sql.data_definition_language.drop_view",
+              "title": "DROP VIEW",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/drop-view.md",
+              "compat": "partial",
+              "notes": [
+                "MO does not support dropping multiple views in a single statement; only a single view per DROP VIEW. MySQL 8.0 supports dropping multiple views (e.g., DROP VIEW v1, v2)."
+              ]
+            },
+            {
+              "id": "sql.data_definition_language.rename_table",
+              "title": "Rename Table",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/rename-table.md",
+              "compat": "partial",
+              "notes": [
+                "MO does not support RENAME TABLE across databases; when given cross-database syntax, MO renames the table within its current database instead of raising an error. MySQL 8.0 supports cross-database RENAME TABLE."
+              ]
+            },
+            {
+              "id": "sql.data_definition_language.restore_pitr",
+              "title": "RESTORE ... FROM PITR",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/restore-pitr.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] RESTORE … FROM PITR"
+              ]
+            },
+            {
+              "id": "sql.data_definition_language.restore_snapshot",
+              "title": "RESTORE ... SNAPSHOT",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/restore-snapshot.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] RESTORE … FROM SNAPSHOT"
+              ]
+            },
+            {
+              "id": "sql.data_definition_language.truncate_table",
+              "title": "TRUNCATE TABLE",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/truncate-table.md",
+              "compat": "full",
+              "notes": []
+            }
+          ]
+        },
+        {
+          "id": "data_manipulation_language",
+          "label": "Data Manipulation Language (DML)",
+          "entries": [
+            {
+              "id": "sql.data_manipulation_language.case",
+              "title": "CASE",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Manipulation-Language/case.md",
+              "compat": "full",
+              "notes": [
+                "This page describes the CASE operator (expression), not the stored-program CASE statement. MatrixOne does not support stored programs, so the stored-program CASE STATEMENT is unavailable; the CASE OPERATOR behaves compatibly."
+              ]
+            },
+            {
+              "id": "sql.data_manipulation_language.information_functions.current_role",
+              "title": "CURRENT_ROLE()",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Manipulation-Language/information-functions/current_role.md",
+              "compat": "partial",
+              "notes": [
+                "Returns a single active role name; MySQL 8.0 can return multiple comma-separated active roles or 'NONE'."
+              ]
+            },
+            {
+              "id": "sql.data_manipulation_language.delete",
+              "title": "DELETE",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Manipulation-Language/delete.md",
+              "compat": "partial",
+              "notes": [
+                "LOW_PRIORITY, QUICK, IGNORE modifiers are syntactically accepted but have no effect",
+                "PARTITION clause not supported"
+              ]
+            },
+            {
+              "id": "sql.data_manipulation_language.insert",
+              "title": "INSERT",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Manipulation-Language/insert.md",
+              "compat": "partial",
+              "notes": [
+                "Modifiers LOW_PRIORITY / DELAYED / HIGH_PRIORITY not supported",
+                "PARTITION clause not supported"
+              ]
+            },
+            {
+              "id": "sql.data_manipulation_language.upsert.insert_on_duplicate",
+              "title": "INSERT ... ON DUPLICATE KEY UPDATE",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Manipulation-Language/upsert/insert-on-duplicate.md",
+              "compat": "partial",
+              "notes": [
+                "ON DUPLICATE KEY UPDATE only triggers on PRIMARY KEY conflicts; UNIQUE index conflicts are detected but result in errors (ERROR 1062 or ERROR 20102) rather than triggering ON DUPLICATE KEY UPDATE"
+              ]
+            },
+            {
+              "id": "sql.data_manipulation_language.upsert.insert_ignore",
+              "title": "INSERT IGNORE",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Manipulation-Language/upsert/insert-ignore.md",
+              "compat": "partial",
+              "notes": [
+                "LOW_PRIORITY / DELAYED / HIGH_PRIORITY modifiers not supported",
+                "Duplicates are silently ignored; MySQL emits a warning for each skipped row.",
+                "Does not ignore NULL-into-NOT-NULL, type-conversion, or partition-mismatch errors as MySQL does.",
+                "PARTITION clause not supported"
+              ]
+            },
+            {
+              "id": "sql.data_manipulation_language.insert_into_select",
+              "title": "INSERT INTO SELECT",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Manipulation-Language/insert-into-select.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "sql.data_manipulation_language.information_functions.last_insert_id",
+              "title": "LAST_INSERT_ID()",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Manipulation-Language/information-functions/last-insert-id.md",
+              "compat": "partial",
+              "notes": [
+                "Multi-row INSERT returns the last inserted auto-increment value; MySQL returns the first inserted value."
+              ]
+            },
+            {
+              "id": "sql.data_manipulation_language.information_functions.last_query_id",
+              "title": "LAST_QUERY_ID",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Manipulation-Language/information-functions/last-query-id.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] LAST_QUERY_ID()"
+              ]
+            },
+            {
+              "id": "sql.data_manipulation_language.load_data_infile",
+              "title": "LOAD DATA",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Manipulation-Language/load-data-infile.md",
+              "compat": "partial",
+              "notes": [
+                "SET clause only accepts columns_name = nullif(expr1, expr2)",
+                "JSONLines import uses MatrixOne-specific syntax",
+                "Object-storage import (S3/URL) uses MatrixOne-specific syntax",
+                "LOW_PRIORITY and CONCURRENT modifiers not supported",
+                "REPLACE and IGNORE modifiers not supported",
+                "[MO-only] PARALLEL clause (controls parallel file loading)",
+                "[MO-only] STRICT clause (controls parallel splitting mode)"
+              ]
+            },
+            {
+              "id": "sql.data_manipulation_language.load_data_inline",
+              "title": "LOAD DATA INLINE",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Manipulation-Language/load-data-inline.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] LOAD DATA INLINE (stage-sourced import)"
+              ]
+            },
+            {
+              "id": "sql.data_manipulation_language.replace",
+              "title": "REPLACE",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Manipulation-Language/replace.md",
+              "compat": "partial",
+              "notes": [
+                "node-sql-parser rejects REPLACE … WHERE (parser bug, not MatrixOne)",
+                "PARTITION clause not supported",
+                "LOW_PRIORITY and DELAYED modifiers not supported",
+                "REPLACE only detects conflicts on PRIMARY KEY; secondary UNIQUE index conflicts throw ERROR 1062 (MySQL 8.0 handles both). Constraints section incorrectly states UNIQUE index can also trigger REPLACE; this is wrong per actual MO behavior."
+              ]
+            },
+            {
+              "id": "sql.data_manipulation_language.upsert.replace",
+              "title": "REPLACE",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Manipulation-Language/upsert/replace.md",
+              "compat": "partial",
+              "notes": [
+                "node-sql-parser rejects REPLACE … WHERE (parser bug, not MatrixOne)",
+                "PARTITION clause not supported",
+                "LOW_PRIORITY and DELAYED modifiers not supported",
+                "REPLACE only detects conflicts on PRIMARY KEY; secondary UNIQUE index conflicts throw ERROR 1062 (MySQL 8.0 handles both). Constraints section incorrectly states UNIQUE index can also trigger REPLACE; this is wrong per actual MO behavior."
+              ]
+            },
+            {
+              "id": "sql.data_manipulation_language.update",
+              "title": "UPDATE",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Manipulation-Language/update.md",
+              "compat": "partial",
+              "notes": [
+                "LOW_PRIORITY and IGNORE modifiers are syntactically accepted but have no effect",
+                "PARTITION clause not supported"
+              ]
+            },
+            {
+              "id": "sql.data_manipulation_language.upsert.upsert",
+              "title": "UPSERT",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Manipulation-Language/upsert/upsert.md",
+              "compat": "partial",
+              "notes": [
+                "INSERT IGNORE does not suppress NOT NULL or type-conversion errors (MySQL 8.0 does)",
+                "INSERT ON DUPLICATE KEY UPDATE only triggers on PRIMARY KEY conflicts; UNIQUE index conflicts are detected but result in errors (ERROR 1062 or ERROR 20102) rather than triggering ON DUPLICATE KEY UPDATE",
+                "REPLACE does not support REPLACE ... WHERE (parser bug)"
+              ]
+            }
+          ]
+        },
+        {
+          "id": "data_query_language",
+          "label": "Data Query Language (DQL)",
+          "entries": [
+            {
+              "id": "sql.data_query_language.by_rank_with_option",
+              "title": "BY RANK WITH OPTION",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Query-Language/by-rank-with-option.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] BY RANK WITH OPTION (IVF vector ranking)"
+              ]
+            },
+            {
+              "id": "sql.data_query_language.union_intersect_minus_overview",
+              "title": "Combining Queries (UNION, INTERSECT, MINUS)",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Query-Language/union-intersect-minus-overview.md",
+              "compat": "partial",
+              "notes": [
+                "MINUS keyword is MO-specific; MySQL 8.0.31+ uses EXCEPT for the same set-difference semantics. MINUS ALL is not yet implemented in MO while MySQL 8.0.31+ supports EXCEPT ALL.",
+                "INTERSECT was added in MySQL 8.0.31; both MO and MySQL support INTERSECT and INTERSECT ALL with matching semantics.",
+                "UNION is standard across both, but MO's type coercion in UNION columns is stricter (errors on incompatible types where MySQL silently coerces).",
+                "[MO-only] MINUS keyword (MO-specific syntax; MySQL 8.0.31+ offers equivalent EXCEPT)"
+              ]
+            },
+            {
+              "id": "sql.data_query_language.subqueries.comparisons_using_subqueries",
+              "title": "Comparisons Using Subqueries",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Query-Language/subqueries/comparisons-using-subqueries.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "sql.data_query_language.apply.cross_apply",
+              "title": "CROSS APPLY",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Query-Language/apply/cross-apply.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] CROSS APPLY (SQL Server-style, not in MySQL)"
+              ]
+            },
+            {
+              "id": "sql.data_query_language.join.cross_join",
+              "title": "CROSS JOIN",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Query-Language/join/cross-join.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "sql.data_query_language.subqueries.derived_tables",
+              "title": "Derived Tables",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Query-Language/subqueries/derived-tables.md",
+              "compat": "partial",
+              "notes": [
+                "LATERAL derived tables are not supported in MO (MySQL 8.0.14+ supports LATERAL for correlated subqueries in FROM clause)"
+              ]
+            },
+            {
+              "id": "sql.data_query_language.join.full_join",
+              "title": "FULL JOIN",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Query-Language/join/full-join.md",
+              "compat": "none",
+              "notes": [
+                "FULL JOIN with ON clause produces different errors on MO (missing FROM-clause entry) vs MySQL 8.0 (Unknown column in ON clause). FULL JOIN with USING returns INNER JOIN results on both (neither returns unmatched rows). FULL OUTER JOIN produces a syntax error on both. MySQL 8.0 does not natively support either FULL JOIN or FULL OUTER JOIN."
+              ]
+            },
+            {
+              "id": "sql.data_query_language.join.inner_join",
+              "title": "INNER JOIN",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Query-Language/join/inner-join.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "sql.data_query_language.intersect",
+              "title": "INTERSECT",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Query-Language/intersect.md",
+              "compat": "partial",
+              "notes": [
+                "INTERSECT was added in MySQL 8.0.31; MO INTERSECT and INTERSECT ALL semantics match MySQL 8.0 (both return identical results for common test cases including duplicate handling)"
+              ]
+            },
+            {
+              "id": "sql.data_query_language.join.join",
+              "title": "JOIN",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Query-Language/join/join.md",
+              "compat": "partial",
+              "notes": [
+                "FULL JOIN and FULL OUTER JOIN are not fully supported (FULL JOIN with ON produces errors, FULL JOIN with USING returns INNER JOIN results, FULL OUTER JOIN is a syntax error); MySQL 8.0 also does not support FULL JOIN/OUTER JOIN natively"
+              ]
+            },
+            {
+              "id": "sql.data_query_language.join.left_join",
+              "title": "LEFT JOIN",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Query-Language/join/left-join.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "sql.data_query_language.minus",
+              "title": "MINUS",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Query-Language/minus.md",
+              "compat": "mo_only",
+              "notes": [
+                "MINUS keyword is MO-specific; MySQL 8.0.31+ uses EXCEPT for the same set-difference semantics (MINUS is not a recognized keyword in MySQL)",
+                "MINUS ALL is not yet implemented in MO; MySQL 8.0.31+ supports EXCEPT ALL with full duplicate-preserving semantics",
+                "[MO-only] MINUS keyword (MO's set-difference operator; MySQL 8.0.31+ offers equivalent functionality via EXCEPT)"
+              ]
+            },
+            {
+              "id": "sql.data_query_language.join.natural_join",
+              "title": "NATURAL JOIN",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Query-Language/join/natural-join.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "sql.data_query_language.apply.outer_apply",
+              "title": "OUTER APPLY",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Query-Language/apply/outer-apply.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] OUTER APPLY (SQL Server-style, not in MySQL)"
+              ]
+            },
+            {
+              "id": "sql.data_query_language.join.outer_join",
+              "title": "OUTER JOIN",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Query-Language/join/outer-join.md",
+              "compat": "partial",
+              "notes": [
+                "Overview page that includes FULL OUTER JOIN; neither MO nor MySQL 8.0 natively support FULL OUTER JOIN (MO produces syntax error, same as MySQL)"
+              ]
+            },
+            {
+              "id": "sql.data_query_language.join.right_join",
+              "title": "RIGHT JOIN",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Query-Language/join/right-join.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "sql.data_query_language.select",
+              "title": "SELECT",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Query-Language/select.md",
+              "compat": "partial",
+              "notes": [
+                "SELECT … FOR UPDATE only supports single-table queries",
+                "SELECT INTO OUTFILE is only partially supported",
+                "AS OF TIMESTAMP time-travel queries require PITR/snapshot to be enabled on the database; without PITR the syntax produces an error",
+                "SELECT ... FOR SHARE is not supported",
+                "FOR UPDATE NOWAIT and SKIP LOCKED modifiers are not supported",
+                "GROUP BY ... WITH ROLLUP row ordering differs: MO places rollup summary rows at the top of the result set, while MySQL 8.0 places them at the bottom (standard MySQL grouping order)",
+                "[MO-only] { AS OF TIMESTAMP 'YYYY-MM-DD HH:MM:SS' } — time-travel query against enabled snapshot/PITR",
+                "[MO-only] ORDER BY ... NULLS { FIRST | LAST } — PostgreSQL-style NULL ordering not available in MySQL"
+              ]
+            },
+            {
+              "id": "sql.data_query_language.subqueries.subquery_with_all",
+              "title": "Subqueries with ALL",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Query-Language/subqueries/subquery-with-all.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "sql.data_query_language.subqueries.subquery_with_any_some",
+              "title": "Subqueries with ANY or SOME",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Query-Language/subqueries/subquery-with-any-some.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "sql.data_query_language.subqueries.subquery_with_exists",
+              "title": "Subqueries with EXISTS or NOT EXISTS",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Query-Language/subqueries/subquery-with-exists.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "sql.data_query_language.subqueries.subquery_with_in",
+              "title": "Subqueries with IN",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Query-Language/subqueries/subquery-with-in.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "sql.data_query_language.subqueries.subquery",
+              "title": "SUBQUERY",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Query-Language/subqueries/subquery.md",
+              "compat": "partial",
+              "notes": [
+                "Multi-column scalar subquery comparisons (e.g., WHERE (a,b) = (SELECT ...)) are not supported; use multi-column IN instead"
+              ]
+            },
+            {
+              "id": "sql.data_query_language.union",
+              "title": "UNION",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Query-Language/union.md",
+              "compat": "partial",
+              "notes": [
+                "UNION type coercion is strict: MO errors on incompatible types in UNION columns (e.g., INT vs VARCHAR), while MySQL 8.0 silently coerces (e.g., varchar to int converts to 0)",
+                "UNION ALL type coercion is similarly strict compared to MySQL 8.0's lenient coercion"
+              ]
+            },
+            {
+              "id": "sql.data_query_language.with_cte",
+              "title": "WITH (Common Table Expressions)",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Query-Language/with-cte.md",
+              "compat": "partial",
+              "notes": [
+                "Outer joins (LEFT JOIN, RIGHT JOIN, OUTER JOIN) are not allowed in recursive CTE members; MySQL 8.0 permits them except when the recursive CTE is on the right side of a LEFT JOIN (MySQL allows LEFT JOIN with CTE on the left side; MO rejects all outer joins in recursive CTEs regardless of position)"
+              ]
+            }
+          ]
+        },
+        {
+          "id": "other",
+          "label": "Other",
+          "entries": [
+            {
+              "id": "sql.other.prepared_statements.deallocate",
+              "title": "DEALLOCATE PREPARE",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Other/Prepared-Statements/deallocate.md",
+              "compat": "partial",
+              "notes": [
+                "DEALLOCATE PREPARE on a non-existent statement silently succeeds; MySQL returns ERROR 1243 (Unknown prepared statement handler)."
+              ]
+            },
+            {
+              "id": "sql.other.describe",
+              "title": "DESCRIBE / DESC",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Other/describe.md",
+              "compat": "partial",
+              "notes": [
+                "DESCRIBE/DESC output includes an extra `Comment` column (7 columns total vs MySQL's 6).",
+                "Type names are displayed in uppercase with display widths (e.g., `INT(32)`, `FLOAT(0)`, `TIMESTAMP(0)`) instead of MySQL's lowercase without widths (e.g., `int`, `float`, `timestamp`).",
+                "Column name filter (`DESC tbl_name col_name`) is non-functional; all columns are returned.",
+                "Wild pattern (`DESC tbl_name 'pattern'`) not supported; produces syntax error.",
+                "For TIMESTAMP columns with DEFAULT CURRENT_TIMESTAMP, MO does not show `DEFAULT_GENERATED` in the Extra column as MySQL does."
+              ]
+            },
+            {
+              "id": "sql.other.prepared_statements.execute",
+              "title": "EXECUTE",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Other/Prepared-Statements/execute.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "sql.other.explain.explain",
+              "title": "EXPLAIN",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Other/Explain/explain.md",
+              "compat": "partial",
+              "notes": [
+                "Output format is a single QUERY PLAN column with tree-structured text (PostgreSQL-style); MySQL uses a multi-column tabular format with id, select_type, table, partitions, type, possible_keys, key, key_len, ref, rows, filtered, Extra",
+                "JSON output (FORMAT=JSON) not supported; MO returns syntax error",
+                "FORMAT=TREE and FORMAT=TRADITIONAL not supported; FORMAT=TEXT bare keyword also errors; only bare keyword forms (EXPLAIN, EXPLAIN ANALYZE, EXPLAIN VERBOSE) work",
+                "EXPLAIN FOR CONNECTION not supported (returns internal error)",
+                "EXPLAIN (ANALYZE TRUE/FALSE) and EXPLAIN (VERBOSE TRUE/FALSE) parenthesized boolean syntax WORKS in MO 3.0.12, contrary to doc claims; only parenthesized FORMAT syntax is unsupported"
+              ]
+            },
+            {
+              "id": "sql.other.explain.explain_workflow",
+              "title": "EXPLAIN Output Format",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Other/Explain/explain-workflow.md",
+              "compat": "partial",
+              "notes": [
+                "Output is a single QUERY PLAN column with tree-structured text; MySQL uses multi-column tabular EXPLAIN format",
+                "JSON output not supported",
+                "Node types (Sink, Sink Scan, PreInsert, Fuzzy Filter, etc.) are MO-specific and have no MySQL equivalent"
+              ]
+            },
+            {
+              "id": "sql.other.explain.explain_prepared",
+              "title": "EXPLAIN PREPARED",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Other/Explain/explain-prepared.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] EXPLAIN FORCE EXECUTE stmt_name [USING @var] is a MatrixOne extension; MySQL explains prepared statements through EXPLAIN FOR CONNECTION."
+              ]
+            },
+            {
+              "id": "sql.other.explain.explain_analyze",
+              "title": "Get information with EXPLAIN ANALYZE",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Other/Explain/explain-analyze.md",
+              "compat": "partial",
+              "notes": [
+                "Output format mirrors PostgreSQL (QUERY PLAN tree with Analyze sub-lines showing timeConsumed, waitTime, inputRows, outputRows, InputSize, OutputSize, MemorySize); MySQL 8.0 EXPLAIN ANALYZE uses TREE format with cost estimation and actual time in a different structure",
+                "JSON output not supported",
+                "MO EXPLAIN ANALYZE produces one output row per plan tree line; MySQL produces a single row with the full plan"
+              ]
+            },
+            {
+              "id": "sql.other.kill",
+              "title": "KILL",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Other/kill.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "sql.other.prepared_statements.prepare",
+              "title": "PREPARE",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Other/Prepared-Statements/prepare.md",
+              "compat": "partial",
+              "notes": [
+                "MatrixOne cannot PREPARE SET, DO, or other TCL/DCL statements",
+                "Repreparation on parameter type change may throw a cast error instead of silently converting the value (e.g., passing a string to an integer parameter)."
+              ]
+            },
+            {
+              "id": "sql.other.set.set_role",
+              "title": "SET ROLE",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Other/Set/set-role.md",
+              "compat": "partial",
+              "notes": [
+                "Accepts a single role name only; MySQL 8.0 also supports NONE, DEFAULT, ALL, ALL EXCEPT role_list, and role lists.",
+                "[MO-only] SET SECONDARY ROLE {NONE | ALL} — MatrixOne-only primary/secondary role model."
+              ]
+            },
+            {
+              "id": "sql.other.show_statements.show_account",
+              "title": "SHOW ACCOUNTS",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Other/SHOW-Statements/show-account.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] SHOW ACCOUNTS"
+              ]
+            },
+            {
+              "id": "sql.other.show_statements.show_collation",
+              "title": "SHOW COLLATION",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Other/SHOW-Statements/show-collation.md",
+              "compat": "partial",
+              "notes": [
+                "Only utf8mb4_bin is effective; other collations appear but are inert",
+                "MO 3.0.12 returns 11 collations (with `Default` and `Pad_attribute` columns); older doc examples show only 1 row with 5 columns",
+                "Output columns (Collation, Charset, Id, Default, Compiled, Sortlen, Pad_attribute) differ slightly from MySQL which also includes Pad_attribute"
+              ]
+            },
+            {
+              "id": "sql.other.show_statements.show_columns",
+              "title": "SHOW COLUMNS",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Other/SHOW-Statements/show-columns.md",
+              "compat": "partial",
+              "notes": [
+                "MO SHOW COLUMNS (without FULL) already includes the `Comment` column; MySQL only shows Comment with FULL",
+                "MO SHOW FULL COLUMNS returns Collation and Privileges columns but Collation is always NULL",
+                "MO accepts EXTENDED keyword (SHOW EXTENDED COLUMNS) and FIELDS synonym (SHOW FIELDS), both returning same columns as SHOW COLUMNS",
+                "MO Type column includes display width (e.g. INT(32)) while MySQL shows just int"
+              ]
+            },
+            {
+              "id": "sql.other.show_statements.show_create_database",
+              "title": "SHOW CREATE DATABASE",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Other/SHOW-Statements/show-create-database.md",
+              "compat": "partial",
+              "notes": [
+                "Output omits CHARACTER SET, COLLATE, and ENCRYPTION clauses present in MySQL 8.0 SHOW CREATE DATABASE output"
+              ]
+            },
+            {
+              "id": "sql.other.show_statements.show_create_publication",
+              "title": "SHOW CREATE PUBLICATION",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Other/SHOW-Statements/show-create-publication.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] SHOW CREATE PUBLICATION"
+              ]
+            },
+            {
+              "id": "sql.other.show_statements.show_create_table",
+              "title": "SHOW CREATE TABLE",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Other/SHOW-Statements/show-create-table.md",
+              "compat": "partial",
+              "notes": [
+                "Output reflects MatrixOne-specific extensions (CLUSTER BY, USING IVFFLAT/HNSW, etc.)",
+                "MO output omits ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci appended by MySQL"
+              ]
+            },
+            {
+              "id": "sql.other.show_statements.show_create_view",
+              "title": "SHOW CREATE VIEW",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Other/SHOW-Statements/show-create-view.md",
+              "compat": "partial",
+              "notes": [
+                "DEFINER = user clause absent from output; SQL SECURITY {DEFINER|INVOKER} is emitted",
+                "MO output lacks ALGORITHM=UNDEFINED clause that MySQL always includes",
+                "MO does not fully qualify column references (MySQL outputs db.table.col AS alias)",
+                "MO uses unquoted identifiers; MySQL backtick-quotes database, table, and column names",
+                "The rendered Create View output shows `CREATE SQL SECURITY DEFINER VIEW` (not `CREATE ALGORITHM=UNDEFINED DEFINER=user SQL SECURITY DEFINER VIEW` as MySQL does)"
+              ]
+            },
+            {
+              "id": "sql.other.show_statements.show_databases",
+              "title": "SHOW DATABASES",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Other/SHOW-Statements/show-databases.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "sql.other.show_statements.show_function_status",
+              "title": "SHOW FUNCTION STATUS",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Other/SHOW-Statements/show-function-status.md",
+              "compat": "partial",
+              "notes": [
+                "Lists MatrixOne SQL/Python functions; MySQL shows stored routines AND built-in sys schema functions (e.g. extract_schema_from_file_name, format_bytes)",
+                "MO only shows user-defined functions; MySQL shows all functions including built-in ones"
+              ]
+            },
+            {
+              "id": "sql.other.show_statements.show_grants",
+              "title": "SHOW GRANTS",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Other/SHOW-Statements/show-grants.md",
+              "compat": "partial",
+              "notes": [
+                "Grant syntax output is completely different: MO uses MO-specific format (GRANT create account ON account, GRANT table all ON table) instead of MySQL standard format (GRANT SELECT, INSERT, UPDATE, DELETE ON *.*)",
+                "MO output includes backtick-quoted user@host inside grant statements; MySQL uses quoted user@host format with TO clause",
+                "USING role_list clause not supported",
+                "MO does not support SHOW GRANTS FOR CURRENT_USER (or CURRENT_USER()) as a shorthand for the current user"
+              ]
+            },
+            {
+              "id": "sql.other.show_statements.show_index",
+              "title": "SHOW INDEX",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Other/SHOW-Statements/show-index.md",
+              "compat": "partial",
+              "notes": [
+                "Reflects MatrixOne index model — secondary index rows appear but may not accelerate queries",
+                "Index_type may be empty (MySQL typically shows BTREE)",
+                "Index_comment column is present (MySQL 8.0 also has Index_comment; difference is minor)",
+                "Index_params column is present (MySQL does not have this column)",
+                "Expression column shows the column name for non-functional key parts; MySQL shows NULL for non-functional key parts",
+                "MO SHOW INDEX returns 16 columns vs MySQL 15 columns (MO adds Index_params, lacks the extra Collation behavior)"
+              ]
+            },
+            {
+              "id": "sql.other.show_statements.show_pitrs",
+              "title": "SHOW PITR",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Other/SHOW-Statements/show-pitrs.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] SHOW PITR"
+              ]
+            },
+            {
+              "id": "sql.other.show_statements.show_processlist",
+              "title": "SHOW PROCESSLIST",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Other/SHOW-Statements/show-processlist.md",
+              "compat": "partial",
+              "notes": [
+                "MO returns 19 columns (node_id, conn_id, session_id, account, user, host, db, session_start, command, info, txn_id, statement_id, statement_type, query_type, sql_source_type, query_start, client_host, role, proxy_host) vs MySQL 8 columns (Id, User, Host, db, Command, Time, State, Info)",
+                "MO column names differ completely: conn_id vs Id, session_start vs Time, no State column, MO adds txn_id/statement_id/statement_type/query_type/sql_source_type/query_start/client_host/role/proxy_host",
+                "SHOW FULL PROCESSLIST is accepted by MO but returns same columns as SHOW PROCESSLIST (no behavioral difference)"
+              ]
+            },
+            {
+              "id": "sql.other.show_statements.show_publications",
+              "title": "SHOW PUBLICATIONS",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Other/SHOW-Statements/show-publications.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] SHOW PUBLICATIONS"
+              ]
+            },
+            {
+              "id": "sql.other.show_statements.show_roles",
+              "title": "SHOW ROLES",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Other/SHOW-Statements/show-roles.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] SHOW ROLES"
+              ]
+            },
+            {
+              "id": "sql.other.show_statements.show_sequences",
+              "title": "SHOW SEQUENCES",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Other/SHOW-Statements/show-sequences.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] SHOW SEQUENCES"
+              ]
+            },
+            {
+              "id": "sql.other.show_statements.show_stage",
+              "title": "SHOW STAGES",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Other/SHOW-Statements/show-stage.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] SHOW STAGES"
+              ]
+            },
+            {
+              "id": "sql.other.show_statements.show_subscriptions",
+              "title": "SHOW SUBSCRIPTIONS",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Other/SHOW-Statements/show-subscriptions.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] SHOW SUBSCRIPTIONS"
+              ]
+            },
+            {
+              "id": "sql.other.show_statements.show_table_status",
+              "title": "SHOW TABLE STATUS",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Other/SHOW-Statements/show-table-status.md",
+              "compat": "partial",
+              "notes": [
+                "Result columns differ from MySQL: MO has 19 cols (adds Role_id, Role_name; omits Version); MySQL has 18 cols (includes Version; no Role_id/Role_name)",
+                "Engine column always shows Tae instead of InnoDB",
+                "MO's Auto_increment defaults to 0 (MySQL shows NULL for tables without auto-increment)",
+                "MO shows views in SHOW TABLE STATUS with Engine=NULL and Comment=VIEW (same as MySQL behavior)"
+              ]
+            },
+            {
+              "id": "sql.other.show_statements.show_tables",
+              "title": "SHOW TABLES",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Other/SHOW-Statements/show-tables.md",
+              "compat": "partial",
+              "notes": [
+                "Output column header uses lowercase database name (Tables_in_<db> vs MySQL's Tables_in_<DB>)",
+                "MO does not display a parenthesized LIKE pattern in the column header unlike MySQL"
+              ]
+            },
+            {
+              "id": "sql.other.show_statements.show_variables",
+              "title": "SHOW VARIABLES",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Other/SHOW-Statements/show-variables.md",
+              "compat": "partial",
+              "notes": [
+                "System variables are mostly syntactic stubs; actual behaviour differs from MySQL",
+                "GLOBAL and SESSION scope modifiers are syntactically accepted for both SET and SHOW; SHOW GLOBAL vs SHOW SESSION return different values when SESSION has been overridden, same as MySQL",
+                "MO has a completely different set of variable names (e.g. testbotchvar_nodyn, testbothvar_dyn) alongside MySQL-compatible ones (autocommit, sql_mode)",
+                "Variable values use lowercase ('on'/'off') while MySQL uses uppercase ('ON'/'OFF')"
+              ]
+            },
+            {
+              "id": "sql.other.use_database",
+              "title": "USE",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Other/use-database.md",
+              "compat": "full",
+              "notes": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "functions-and-operators",
+      "label": "Functions",
+      "summary": {
+        "full": 103,
+        "partial": 26,
+        "none": 0,
+        "mo_only": 35,
+        "unknown": 0
+      },
+      "categories": [
+        {
+          "id": "_root",
+          "label": "Functions",
+          "entries": [
+            {
+              "id": "func.matrixone_function_list",
+              "title": "Summary table of functions",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/matrixone-function-list.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] Listing page (includes MatrixOne-only functions)."
+              ]
+            }
+          ]
+        },
+        {
+          "id": "aggregate_functions",
+          "label": "Aggregate Functions",
+          "entries": [
+            {
+              "id": "func.aggregate_functions.any_value",
+              "title": "ANY_VALUE",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Aggregate-Functions/any-value.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.aggregate_functions.avg",
+              "title": "AVG",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Aggregate-Functions/avg.md",
+              "compat": "partial",
+              "notes": [
+                "AVG() returns DOUBLE for all input types (MySQL returns DECIMAL for exact-value types)"
+              ]
+            },
+            {
+              "id": "func.aggregate_functions.bit_and",
+              "title": "BIT_AND",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Aggregate-Functions/bit_and.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.aggregate_functions.bit_or",
+              "title": "BIT_OR",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Aggregate-Functions/bit_or.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.aggregate_functions.bit_xor",
+              "title": "BIT_XOR",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Aggregate-Functions/bit_xor.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.aggregate_functions.bitmap",
+              "title": "BITMAP function",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Aggregate-Functions/bitmap.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] BITMAP aggregates are MatrixOne extensions."
+              ]
+            },
+            {
+              "id": "func.aggregate_functions.count",
+              "title": "COUNT",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Aggregate-Functions/count.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.aggregate_functions.group_concat",
+              "title": "GROUP_CONCAT",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Aggregate-Functions/group-concat.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.aggregate_functions.max",
+              "title": "MAX",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Aggregate-Functions/max.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.aggregate_functions.median",
+              "title": "MEDIAN()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Aggregate-Functions/median.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] MEDIAN aggregate is a MatrixOne-specific aggregate (no native MySQL equivalent)."
+              ]
+            },
+            {
+              "id": "func.aggregate_functions.min",
+              "title": "MIN",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Aggregate-Functions/min.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.aggregate_functions.stddev_pop",
+              "title": "STDDEV_POP",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Aggregate-Functions/stddev_pop.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.aggregate_functions.sum",
+              "title": "SUM",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Aggregate-Functions/sum.md",
+              "compat": "partial",
+              "notes": [
+                "SUM() returns the input integer type rather than DECIMAL for exact-value arguments (MySQL returns DECIMAL)"
+              ]
+            },
+            {
+              "id": "func.aggregate_functions.var_pop",
+              "title": "VAR_POP",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Aggregate-Functions/var_pop.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.aggregate_functions.variance",
+              "title": "VARIANCE",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Aggregate-Functions/variance.md",
+              "compat": "full",
+              "notes": []
+            }
+          ]
+        },
+        {
+          "id": "datetime",
+          "label": "Datetime",
+          "entries": [
+            {
+              "id": "func.datetime.addtime",
+              "title": "ADDTIME()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Datetime/addtime.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.datetime.convert_tz",
+              "title": "CONVERT_TZ()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Datetime/convert-tz.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.datetime.curdate",
+              "title": "CURDATE()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Datetime/curdate.md",
+              "compat": "partial",
+              "notes": [
+                "curdate()+int returns days since 1970-01-01 rather than coercing both sides to integer and adding like MySQL."
+              ]
+            },
+            {
+              "id": "func.datetime.current_timestamp",
+              "title": "CURRENT_TIMESTAMP()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Datetime/current-timestamp.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.datetime.curtime",
+              "title": "CURTIME()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Datetime/curtime.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.datetime.date_add",
+              "title": "DATE_ADD()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Datetime/date-add.md",
+              "compat": "partial",
+              "notes": [
+                "Date literals accept only 'yyyy-mm-dd' and 'yyyymmdd' formats; MySQL accepts wider variants."
+              ]
+            },
+            {
+              "id": "func.datetime.date_format",
+              "title": "DATE_FORMAT()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Datetime/date-format.md",
+              "compat": "partial",
+              "notes": [
+                "Date literals accept only 'yyyy-mm-dd' and 'yyyymmdd' formats; MySQL accepts wider variants."
+              ]
+            },
+            {
+              "id": "func.datetime.date_sub",
+              "title": "DATE_SUB()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Datetime/date-sub.md",
+              "compat": "partial",
+              "notes": [
+                "Date literals accept only 'yyyy-mm-dd' and 'yyyymmdd' formats; MySQL accepts wider variants."
+              ]
+            },
+            {
+              "id": "func.datetime.date",
+              "title": "DATE()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Datetime/date.md",
+              "compat": "partial",
+              "notes": [
+                "Date literals accept only 'yyyy-mm-dd' and 'yyyymmdd' formats; MySQL accepts wider variants (yy-mm-dd, yy/mm/dd, yymmdd, etc.)."
+              ]
+            },
+            {
+              "id": "func.datetime.datediff",
+              "title": "DATEDIFF()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Datetime/datediff.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.datetime.day",
+              "title": "DAY()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Datetime/day.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.datetime.dayofyear",
+              "title": "DAYOFYEAR()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Datetime/dayofyear.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.datetime.extract",
+              "title": "EXTRACT()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Datetime/extract.md",
+              "compat": "partial",
+              "notes": [
+                "Date literals accept only 'yyyy-mm-dd' and 'yyyymmdd' formats; MySQL accepts wider variants."
+              ]
+            },
+            {
+              "id": "func.datetime.from_unixtime",
+              "title": "FROM_UNIXTIME()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Datetime/from-unixtime.md",
+              "compat": "partial",
+              "notes": [
+                "Date literals accept only 'yyyy-mm-dd' and 'yyyymmdd' formats; MySQL accepts wider variants."
+              ]
+            },
+            {
+              "id": "func.datetime.get_format",
+              "title": "GET_FORMAT()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Datetime/get-format.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.datetime.hour",
+              "title": "HOUR()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Datetime/hour.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.datetime.minute",
+              "title": "MINUTE()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Datetime/minute.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.datetime.month",
+              "title": "MONTH()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Datetime/month.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.datetime.now",
+              "title": "NOW()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Datetime/now.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.datetime.second",
+              "title": "SECOND()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Datetime/second.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.datetime.str_to_date",
+              "title": "STR_TO_DATE()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Datetime/str-to-date.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.datetime.subtime",
+              "title": "SUBTIME()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Datetime/subtime.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.datetime.sysdate",
+              "title": "SYSDATE()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Datetime/sysdate.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.datetime.time",
+              "title": "TIME()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Datetime/time.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.datetime.timediff",
+              "title": "TIMEDIFF()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Datetime/timediff.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.datetime.timestamp",
+              "title": "TIMESTAMP()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Datetime/timestamp.md",
+              "compat": "partial",
+              "notes": [
+                "MatrixOne TIMESTAMP range is '0001-01-01'–'9999-12-31' vs MySQL '1970-01-01'–'2038-01-19' (compat doc: Data Types).",
+                "Two-argument form TIMESTAMP(expr1, expr2) is not supported; MO only supports single-argument TIMESTAMP(expr)"
+              ]
+            },
+            {
+              "id": "func.datetime.timestampadd",
+              "title": "TIMESTAMPADD()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Datetime/timestampadd.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.datetime.timestampdiff",
+              "title": "TIMESTAMPDIFF()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Datetime/timestampdiff.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.datetime.to_date",
+              "title": "TO_DATE()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Datetime/to-date.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] TO_DATE is a MatrixOne alias for MySQL STR_TO_DATE (compat doc: Date and Time Functions). MySQL's own TO_DATE does not exist."
+              ]
+            },
+            {
+              "id": "func.datetime.to_days",
+              "title": "TO_DAYS()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Datetime/to-days.md",
+              "compat": "partial",
+              "notes": [
+                "Two-digit year handling differs: MatrixOne completes '08-10-07' to year 0008; MySQL interprets it as 2008.",
+                "Dates '0000-00-00' and '0000-01-01' raise an error in MatrixOne rather than being accepted as MySQL does."
+              ]
+            },
+            {
+              "id": "func.datetime.to_seconds",
+              "title": "TO_SECONDS()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Datetime/to-seconds.md",
+              "compat": "partial",
+              "notes": [
+                "Two-digit year handling differs: MatrixOne completes '08-10-07' to year 0008; MySQL interprets it as 2008.",
+                "Dates '0000-00-00' and '0000-01-01' raise an error in MatrixOne rather than being accepted as MySQL does."
+              ]
+            },
+            {
+              "id": "func.datetime.unix_timestamp",
+              "title": "UNIX_TIMESTAMP()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Datetime/unix-timestamp.md",
+              "compat": "partial",
+              "notes": [
+                "Date literals accept only 'yyyy-mm-dd' and 'yyyymmdd' formats; MySQL accepts wider variants."
+              ]
+            },
+            {
+              "id": "func.datetime.utc_timestamp",
+              "title": "UTC_TIMESTAMP()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Datetime/utc-timestamp.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.datetime.week",
+              "title": "WEEK()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Datetime/week.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.datetime.weekday",
+              "title": "WEEKDAY()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Datetime/weekday.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.datetime.year",
+              "title": "YEAR()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Datetime/year.md",
+              "compat": "partial",
+              "notes": [
+                "Date literals accept only 'yyyy-mm-dd' and 'yyyymmdd' formats; MySQL accepts wider variants.",
+                "[MO-only] TOYEAR() is a MatrixOne alias for YEAR() with no MySQL counterpart."
+              ]
+            },
+            {
+              "id": "func.datetime.yearweek",
+              "title": "YEARWEEK()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Datetime/yearweek.md",
+              "compat": "full",
+              "notes": []
+            }
+          ]
+        },
+        {
+          "id": "json",
+          "label": "Json",
+          "entries": [
+            {
+              "id": "func.json.jq",
+              "title": "JQ()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Json/jq.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] MatrixOne integration of the jq JSON query language; no MySQL equivalent."
+              ]
+            },
+            {
+              "id": "func.json.json_arrow",
+              "title": "JSON Arrow Operators -> and ->>",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Json/json-arrow.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.json.json_extract_float64",
+              "title": "JSON_EXTRACT_FLOAT64()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Json/json_extract_float64.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] MatrixOne convenience wrapper returning FLOAT64 directly."
+              ]
+            },
+            {
+              "id": "func.json.json_extract_string",
+              "title": "JSON_EXTRACT_STRING()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Json/json_extract_string.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] MatrixOne convenience wrapper returning a string result directly."
+              ]
+            },
+            {
+              "id": "func.json.json_extract",
+              "title": "JSON_EXTRACT()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Json/json_extract.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.json.json_quote",
+              "title": "JSON_QUOTE()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Json/json_quote.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.json.json_row",
+              "title": "JSON_ROW()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Json/json_row.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] MatrixOne-only; no MySQL equivalent."
+              ]
+            },
+            {
+              "id": "func.json.json_set",
+              "title": "JSON_SET()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Json/json_set.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.json.json_unquote",
+              "title": "JSON_UNQUOTE()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Json/json_unquote.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.json.try_jq",
+              "title": "TRY_JQ()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Json/try_jq.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] MatrixOne integration of the jq JSON query language; no MySQL equivalent."
+              ]
+            }
+          ]
+        },
+        {
+          "id": "mathematical",
+          "label": "Mathematical",
+          "entries": [
+            {
+              "id": "func.mathematical.abs",
+              "title": "ABS()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Mathematical/abs.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.mathematical.acos",
+              "title": "ACOS()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Mathematical/acos.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.mathematical.atan",
+              "title": "ATAN()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Mathematical/atan.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.mathematical.ceil",
+              "title": "CEIL()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Mathematical/ceil.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.mathematical.ceiling",
+              "title": "CEILING()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Mathematical/ceiling.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.mathematical.cos",
+              "title": "COS()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Mathematical/cos.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.mathematical.cot",
+              "title": "COT()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Mathematical/cot.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.mathematical.crc32",
+              "title": "CRC32()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Mathematical/crc32.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.mathematical.exp",
+              "title": "EXP()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Mathematical/exp.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.mathematical.floor",
+              "title": "FLOOR()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Mathematical/floor.md",
+              "compat": "partial",
+              "notes": [
+                "MatrixOne supports an optional second decimals argument (FLOOR(number, decimals)) to specify decimal places; MySQL 8.0 only supports the single-argument form FLOOR(X)",
+                "[MO-only] Two-argument form FLOOR(number, decimals) to specify decimal places"
+              ]
+            },
+            {
+              "id": "func.mathematical.ln",
+              "title": "LN()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Mathematical/ln.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.mathematical.log",
+              "title": "LOG()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Mathematical/log.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.mathematical.log10",
+              "title": "LOG10()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Mathematical/log10.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.mathematical.log2",
+              "title": "LOG2()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Mathematical/log2.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.mathematical.pi",
+              "title": "PI()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Mathematical/pi.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.mathematical.power",
+              "title": "POWER()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Mathematical/power.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.mathematical.rand",
+              "title": "RAND()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Mathematical/rand.md",
+              "compat": "partial",
+              "notes": [
+                "RAND(seed) is not supported; calling RAND(N) with an integer argument produces ERROR 20203"
+              ]
+            },
+            {
+              "id": "func.mathematical.round",
+              "title": "ROUND()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Mathematical/round.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.mathematical.sin",
+              "title": "SIN()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Mathematical/sin.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.mathematical.sinh",
+              "title": "SINH()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Mathematical/sinh.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] MySQL 8.0 has no hyperbolic trigonometric functions; SINH() is a MatrixOne extension."
+              ]
+            },
+            {
+              "id": "func.mathematical.tan",
+              "title": "TAN()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Mathematical/tan.md",
+              "compat": "full",
+              "notes": []
+            }
+          ]
+        },
+        {
+          "id": "other",
+          "label": "Other",
+          "entries": [
+            {
+              "id": "func.other.load_file",
+              "title": "LOAD_FILE()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Other/load_file.md",
+              "compat": "partial",
+              "notes": [
+                "LOAD_FILE() takes a DATALINK value (file:// or stage:// URL) rather than MySQL's plain filesystem path argument"
+              ]
+            },
+            {
+              "id": "func.other.sample",
+              "title": "SAMPLE Sampling Function",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Other/sample.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] SAMPLE() is a MatrixOne sampling operator; no MySQL equivalent."
+              ]
+            },
+            {
+              "id": "func.other.save_file",
+              "title": "SAVE_FILE()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Other/save_file.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] SAVE_FILE() writes to a MatrixOne stage; no MySQL equivalent."
+              ]
+            },
+            {
+              "id": "func.other.serial_extract",
+              "title": "SERIAL_EXTRACT function",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Other/serial_extract.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] SERIAL_EXTRACT() is a MatrixOne internal serial-column extractor."
+              ]
+            },
+            {
+              "id": "func.other.sleep",
+              "title": "SLEEP()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Other/sleep.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.other.stage_list",
+              "title": "STAGE_LIST()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Other/stage_list.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] STAGE_LIST() — MO-specific stage management function (currently unimplemented, returns ERROR 20105)"
+              ]
+            },
+            {
+              "id": "func.other.uuid",
+              "title": "UUID()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Other/uuid.md",
+              "compat": "full",
+              "notes": []
+            }
+          ]
+        },
+        {
+          "id": "string",
+          "label": "String",
+          "entries": [
+            {
+              "id": "func.string.aes_decrypt",
+              "title": "AES_DECRYPT()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/String/aes_decrypt.md",
+              "compat": "partial",
+              "notes": [
+                "MatrixOne supports only aes-128-ecb and aes-256-cbc block modes; MySQL 8.0 also supports the full set of ECB/CBC/CFB/OFB variants at multiple key sizes.",
+                "MatrixOne AES_DECRYPT does not accept the optional kdf_name / salt / info KDF arguments present in MySQL 8.0."
+              ]
+            },
+            {
+              "id": "func.string.aes_encrypt",
+              "title": "AES_ENCRYPT()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/String/aes_encrypt.md",
+              "compat": "partial",
+              "notes": [
+                "MatrixOne supports only aes-128-ecb and aes-256-cbc block modes; MySQL 8.0 also supports the full set of ECB/CBC/CFB/OFB variants at multiple key sizes.",
+                "MatrixOne AES_ENCRYPT does not accept the optional kdf_name / salt / info KDF arguments present in MySQL 8.0."
+              ]
+            },
+            {
+              "id": "func.string.bin",
+              "title": "BIN()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/String/bin.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.string.bit_length",
+              "title": "BIT_LENGTH()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/String/bit-length.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.string.char_length",
+              "title": "CHAR_LENGTH()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/String/char-length.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.string.concat_ws",
+              "title": "CONCAT_WS()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/String/concat-ws.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.string.concat",
+              "title": "CONCAT()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/String/concat.md",
+              "compat": "partial",
+              "notes": []
+            },
+            {
+              "id": "func.string.elt",
+              "title": "ELT()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/String/elt.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.string.empty",
+              "title": "EMPTY()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/String/empty.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] EMPTY() is a MatrixOne helper returning whether a string is empty."
+              ]
+            },
+            {
+              "id": "func.string.endswith",
+              "title": "ENDSWITH()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/String/endswith.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] ENDSWITH() is a MatrixOne helper; MySQL has no direct equivalent."
+              ]
+            },
+            {
+              "id": "func.string.field",
+              "title": "FIELD()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/String/field.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.string.find_in_set",
+              "title": "FIND_IN_SET()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/String/find-in-set.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.string.format",
+              "title": "FORMAT()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/String/format.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.string.from_base64",
+              "title": "FROM_BASE64()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/String/from_base64.md",
+              "compat": "partial",
+              "notes": [
+                "FROM_BASE64() may include trailing null bytes in decoded output; MySQL strips them (e.g., FROM_BASE64('YQ==') returns 'a\\\\0\\\\0' instead of 'a')"
+              ]
+            },
+            {
+              "id": "func.string.hex",
+              "title": "HEX()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/String/hex.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.string.instr",
+              "title": "INSTR()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/String/instr.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.string.lcase",
+              "title": "LCASE()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/String/lcase.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.string.left",
+              "title": "LEFT()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/String/left.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.string.length",
+              "title": "LENGTH()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/String/length.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.string.locate",
+              "title": "LOCATE()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/String/locate.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.string.lower",
+              "title": "LOWER()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/String/lower.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.string.lpad",
+              "title": "LPAD()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/String/lpad.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.string.ltrim",
+              "title": "LTRIM()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/String/ltrim.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.string.md5",
+              "title": "MD5()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/String/md5.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.string.regular_expressions.not_regexp",
+              "title": "NOT REGEXP",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/String/Regular-Expressions/not-regexp.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.string.oct",
+              "title": "OCT(N)",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/String/oct.md",
+              "compat": "partial",
+              "notes": [
+                "OCT(N) returns a numeric value rather than MySQL's plain string representation"
+              ]
+            },
+            {
+              "id": "func.string.regular_expressions.regexp_instr",
+              "title": "REGEXP_INSTR()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/String/Regular-Expressions/regexp-instr.md",
+              "compat": "partial",
+              "notes": [
+                "match_type parameter not yet supported; passing it causes ERROR 20203"
+              ]
+            },
+            {
+              "id": "func.string.regular_expressions.regexp_like",
+              "title": "REGEXP_LIKE()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/String/Regular-Expressions/regexp-like.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.string.regular_expressions.regexp_replace",
+              "title": "REGEXP_REPLACE()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/String/Regular-Expressions/regexp-replace.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.string.regular_expressions.regexp_substr",
+              "title": "REGEXP_SUBSTR()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/String/Regular-Expressions/regexp-substr.md",
+              "compat": "partial",
+              "notes": [
+                "match_type parameter not yet supported; passing it causes ERROR 20203"
+              ]
+            },
+            {
+              "id": "func.string.regular_expressions.regular_expression_functions_overview",
+              "title": "Regular Expressions Overview",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/String/Regular-Expressions/Regular-Expression-Functions-Overview.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.string.repeat",
+              "title": "REPEAT()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/String/repeat.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.string.reverse",
+              "title": "REVERSE()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/String/reverse.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.string.rpad",
+              "title": "RPAD()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/String/rpad.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.string.rtrim",
+              "title": "RTRIM()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/String/rtrim.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.string.sha1",
+              "title": "SHA1()/SHA()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/String/sha1.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.string.sha2",
+              "title": "SHA2()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/String/sha2.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.string.space",
+              "title": "SPACE()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/String/space.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.string.split_part",
+              "title": "SPLIT_PART()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/String/split_part.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] SPLIT_PART() is inherited from PostgreSQL; no MySQL equivalent."
+              ]
+            },
+            {
+              "id": "func.string.startswith",
+              "title": "STARTSWITH()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/String/startswith.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] STARTSWITH() is a MatrixOne helper; MySQL has no direct equivalent."
+              ]
+            },
+            {
+              "id": "func.string.strcmp",
+              "title": "STRCMP()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/String/strcmp.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.string.substring_index",
+              "title": "SUBSTRING_INDEX()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/String/substring-index.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.string.substring",
+              "title": "SUBSTRING()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/String/substring.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.string.to_base64",
+              "title": "TO_BASE64()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/String/to_base64.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.string.trim",
+              "title": "TRIM()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/String/trim.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.string.ucase",
+              "title": "UCASE()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/String/ucase.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.string.unhex",
+              "title": "UNHEX()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/String/unhex.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.string.upper",
+              "title": "UPPER()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/String/upper.md",
+              "compat": "full",
+              "notes": []
+            }
+          ]
+        },
+        {
+          "id": "system_ops",
+          "label": "System Operations",
+          "entries": [
+            {
+              "id": "func.system_ops.current_role_name",
+              "title": "CURRENT_ROLE_NAME()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/system-ops/current_role_name.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] MatrixOne multi-account/role system management function (compat doc: System Management Functions)."
+              ]
+            },
+            {
+              "id": "func.system_ops.current_role",
+              "title": "CURRENT_ROLE()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/system-ops/current_role.md",
+              "compat": "partial",
+              "notes": [
+                "Returns a single active role name; MySQL 8.0 can return multiple comma-separated active roles or 'NONE'."
+              ]
+            },
+            {
+              "id": "func.system_ops.current_user_name",
+              "title": "CURRENT_USER_NAME()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/system-ops/current_user_name.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] MatrixOne multi-account/role system management function (compat doc: System Management Functions)."
+              ]
+            },
+            {
+              "id": "func.system_ops.current_user",
+              "title": "CURRENT_USER, CURRENT_USER()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/system-ops/current_user.md",
+              "compat": "partial",
+              "notes": [
+                "The host part may be returned as 'localhost' or the resolved client host rather than MySQL's explicit 'username@host' format."
+              ]
+            },
+            {
+              "id": "func.system_ops.purge_log",
+              "title": "PURGE_LOG()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/system-ops/purge_log.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] MatrixOne multi-account/role system management function (compat doc: System Management Functions)."
+              ]
+            },
+            {
+              "id": "func.system_ops.version",
+              "title": "VERSION",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/system-ops/version.md",
+              "compat": "full",
+              "notes": []
+            }
+          ]
+        },
+        {
+          "id": "table",
+          "label": "Table",
+          "entries": [
+            {
+              "id": "func.table.generate_series",
+              "title": "GENERATE_SERIES()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Table/generate_series.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] Table-valued function; no direct MySQL equivalent."
+              ]
+            },
+            {
+              "id": "func.table.unnest",
+              "title": "UNNEST()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Table/unnest.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] Table-valued function; no direct MySQL equivalent."
+              ]
+            }
+          ]
+        },
+        {
+          "id": "vector",
+          "label": "Vector",
+          "entries": [
+            {
+              "id": "func.vector.arithmetic",
+              "title": "Arithmetic operators",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Vector/arithmetic.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] Vector type and related distance/norm/clustering functions are MatrixOne extensions (compat doc: Data Types — \\\"MatrixOne supports vector types\\\")."
+              ]
+            },
+            {
+              "id": "func.vector.cluster_centers",
+              "title": "CLUSTER_CENTERS",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Vector/cluster_centers.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] CLUSTER_CENTERS() — MO-specific vector clustering function (currently unimplemented, returns ERROR 20102)"
+              ]
+            },
+            {
+              "id": "func.vector.cosine_distance",
+              "title": "COSINE_DISTANCE()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Vector/cosine_distance.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] Vector type and related distance/norm/clustering functions are MatrixOne extensions (compat doc: Data Types — \\\"MatrixOne supports vector types\\\")."
+              ]
+            },
+            {
+              "id": "func.vector.cosine_similarity",
+              "title": "cosine_similarity()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Vector/cosine_similarity.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] Vector type and related distance/norm/clustering functions are MatrixOne extensions (compat doc: Data Types — \\\"MatrixOne supports vector types\\\")."
+              ]
+            },
+            {
+              "id": "func.vector.inner_product",
+              "title": "inner_product()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Vector/inner_product.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] Vector type and related distance/norm/clustering functions are MatrixOne extensions (compat doc: Data Types — \\\"MatrixOne supports vector types\\\")."
+              ]
+            },
+            {
+              "id": "func.vector.l1_norm",
+              "title": "l1_norm()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Vector/l1_norm.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] Vector type and related distance/norm/clustering functions are MatrixOne extensions (compat doc: Data Types — \\\"MatrixOne supports vector types\\\")."
+              ]
+            },
+            {
+              "id": "func.vector.l2_distance",
+              "title": "L2_DISTANCE()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Vector/l2_distance.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] Vector type and related distance/norm/clustering functions are MatrixOne extensions (compat doc: Data Types — \\\"MatrixOne supports vector types\\\")."
+              ]
+            },
+            {
+              "id": "func.vector.l2_norm",
+              "title": "l2_norm()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Vector/l2_norm.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] Vector type and related distance/norm/clustering functions are MatrixOne extensions (compat doc: Data Types — \\\"MatrixOne supports vector types\\\")."
+              ]
+            },
+            {
+              "id": "func.vector.misc",
+              "title": "Mathematical class functions",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Vector/misc.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] Vector type and related distance/norm/clustering functions are MatrixOne extensions (compat doc: Data Types — \\\"MatrixOne supports vector types\\\")."
+              ]
+            },
+            {
+              "id": "func.vector.normalize_l2",
+              "title": "NORMALIZE_L2()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Vector/normalize_l2.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] Vector type and related distance/norm/clustering functions are MatrixOne extensions (compat doc: Data Types — \\\"MatrixOne supports vector types\\\")."
+              ]
+            },
+            {
+              "id": "func.vector.subvector",
+              "title": "SUBVECTOR()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Vector/subvector.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] Vector type and related distance/norm/clustering functions are MatrixOne extensions (compat doc: Data Types — \\\"MatrixOne supports vector types\\\")."
+              ]
+            },
+            {
+              "id": "func.vector.vector_dims",
+              "title": "vector_dims()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Vector/vector_dims.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] Vector type and related distance/norm/clustering functions are MatrixOne extensions (compat doc: Data Types — \\\"MatrixOne supports vector types\\\")."
+              ]
+            }
+          ]
+        },
+        {
+          "id": "window_functions",
+          "label": "Window Functions",
+          "entries": [
+            {
+              "id": "func.window_functions.cume_dist",
+              "title": "CUME_DIST()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Window-Functions/cume_dist.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.window_functions.dense_rank",
+              "title": "DENSE_RANK()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Window-Functions/dense_rank.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.window_functions.percent_rank",
+              "title": "PERCENT_RANK()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Window-Functions/percent_rank.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.window_functions.rank",
+              "title": "RANK()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Window-Functions/rank.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "func.window_functions.row_number",
+              "title": "ROW_NUMBER()",
+              "path": "docs/MatrixOne/Reference/Functions-and-Operators/Window-Functions/row_number.md",
+              "compat": "full",
+              "notes": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "operators",
+      "label": "Operators",
+      "summary": {
+        "full": 6,
+        "partial": 4,
+        "none": 0,
+        "mo_only": 5,
+        "unknown": 47
+      },
+      "categories": [
+        {
+          "id": "_root",
+          "label": "Operators",
+          "entries": [
+            {
+              "id": "op.interval",
+              "title": "INTERVAL",
+              "path": "docs/MatrixOne/Reference/Operators/interval.md",
+              "compat": "partial",
+              "notes": [
+                "INTERVAL is internally implemented as a two-argument function rather than as a true SQL keyword; documented syntax INTERVAL(expr,unit) differs from MySQL's INTERVAL expr unit keyword-style notation",
+                "Malformed dates in DATE_ADD/DATE_SUB raise errors rather than returning NULL (MySQL 8.0 returns NULL)"
+              ]
+            },
+            {
+              "id": "op.operator_precedence",
+              "title": "operator-precedence",
+              "path": "docs/MatrixOne/Reference/Operators/operator-precedence.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators",
+              "title": "operators",
+              "path": "docs/MatrixOne/Reference/Operators/operators.md",
+              "compat": "unknown",
+              "notes": []
+            }
+          ]
+        },
+        {
+          "id": "arithmetic_operators",
+          "label": "Arithmetic Operators",
+          "entries": [
+            {
+              "id": "op.arithmetic_operators.addition",
+              "title": "addition",
+              "path": "docs/MatrixOne/Reference/Operators/arithmetic-operators/addition.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.arithmetic_operators.arithmetic_operators_overview",
+              "title": "arithmetic-operators-overview",
+              "path": "docs/MatrixOne/Reference/Operators/arithmetic-operators/arithmetic-operators-overview.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.arithmetic_operators.div",
+              "title": "div",
+              "path": "docs/MatrixOne/Reference/Operators/arithmetic-operators/div.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.arithmetic_operators.division",
+              "title": "division",
+              "path": "docs/MatrixOne/Reference/Operators/arithmetic-operators/division.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.arithmetic_operators.minus",
+              "title": "minus",
+              "path": "docs/MatrixOne/Reference/Operators/arithmetic-operators/minus.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.arithmetic_operators.mod",
+              "title": "mod",
+              "path": "docs/MatrixOne/Reference/Operators/arithmetic-operators/mod.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.arithmetic_operators.multiplication",
+              "title": "multiplication",
+              "path": "docs/MatrixOne/Reference/Operators/arithmetic-operators/multiplication.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.arithmetic_operators.unary_minus",
+              "title": "unary-minus",
+              "path": "docs/MatrixOne/Reference/Operators/arithmetic-operators/unary-minus.md",
+              "compat": "unknown",
+              "notes": []
+            }
+          ]
+        },
+        {
+          "id": "assignment_operators",
+          "label": "Assignment Operators",
+          "entries": [
+            {
+              "id": "op.assignment_operators.assignment_operators_overview",
+              "title": "assignment-operators-overview",
+              "path": "docs/MatrixOne/Reference/Operators/assignment-operators/assignment-operators-overview.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.assignment_operators.equal",
+              "title": "equal",
+              "path": "docs/MatrixOne/Reference/Operators/assignment-operators/equal.md",
+              "compat": "unknown",
+              "notes": []
+            }
+          ]
+        },
+        {
+          "id": "bit_functions_and_operators",
+          "label": "Bit Functions and Operators",
+          "entries": [
+            {
+              "id": "op.bit_functions_and_operators.bit_functions_and_operators_overview",
+              "title": "bit-functions-and-operators-overview",
+              "path": "docs/MatrixOne/Reference/Operators/bit-functions-and-operators/bit-functions-and-operators-overview.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.bit_functions_and_operators.bitwise_and",
+              "title": "bitwise-and",
+              "path": "docs/MatrixOne/Reference/Operators/bit-functions-and-operators/bitwise-and.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.bit_functions_and_operators.bitwise_inversion",
+              "title": "bitwise-inversion",
+              "path": "docs/MatrixOne/Reference/Operators/bit-functions-and-operators/bitwise-inversion.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.bit_functions_and_operators.bitwise_or",
+              "title": "bitwise-or",
+              "path": "docs/MatrixOne/Reference/Operators/bit-functions-and-operators/bitwise-or.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.bit_functions_and_operators.bitwise_xor",
+              "title": "bitwise-xor",
+              "path": "docs/MatrixOne/Reference/Operators/bit-functions-and-operators/bitwise-xor.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.bit_functions_and_operators.left_shift",
+              "title": "left-shift",
+              "path": "docs/MatrixOne/Reference/Operators/bit-functions-and-operators/left-shift.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.bit_functions_and_operators.right_shift",
+              "title": "right-shift",
+              "path": "docs/MatrixOne/Reference/Operators/bit-functions-and-operators/right-shift.md",
+              "compat": "unknown",
+              "notes": []
+            }
+          ]
+        },
+        {
+          "id": "cast_functions_and_operators",
+          "label": "Cast Functions and Operators",
+          "entries": [
+            {
+              "id": "op.cast_functions_and_operators.binary",
+              "title": "binary",
+              "path": "docs/MatrixOne/Reference/Operators/cast-functions-and-operators/binary.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.cast_functions_and_operators.cast",
+              "title": "CAST",
+              "path": "docs/MatrixOne/Reference/Operators/cast-functions-and-operators/cast.md",
+              "compat": "partial",
+              "notes": [
+                "CAST('non-numeric' AS SIGNED) raises an error instead of returning 0 or NULL (MySQL 8.0 returns 0 with a warning)",
+                "CAST(datetime_typed_value AS CHAR) may fail in some cases (MySQL 8.0 supports it universally)"
+              ]
+            },
+            {
+              "id": "op.cast_functions_and_operators.cast_functions_and_operators_overview",
+              "title": "cast-functions-and-operators-overview",
+              "path": "docs/MatrixOne/Reference/Operators/cast-functions-and-operators/cast-functions-and-operators-overview.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.cast_functions_and_operators.convert",
+              "title": "CONVERT",
+              "path": "docs/MatrixOne/Reference/Operators/cast-functions-and-operators/convert.md",
+              "compat": "partial",
+              "notes": [
+                "CONVERT('non-numeric', SIGNED) raises an error instead of returning 0 or NULL",
+                "CONVERT(datetime_typed_value, CHAR) may fail in some cases (MySQL 8.0 supports it universally)"
+              ]
+            },
+            {
+              "id": "op.cast_functions_and_operators.decode",
+              "title": "DECODE()",
+              "path": "docs/MatrixOne/Reference/Operators/cast-functions-and-operators/decode.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] DECODE() was deprecated in MySQL 5.7 and removed in MySQL 8.0; MatrixOne continues to support it"
+              ]
+            },
+            {
+              "id": "op.cast_functions_and_operators.encode",
+              "title": "ENCODE()",
+              "path": "docs/MatrixOne/Reference/Operators/cast-functions-and-operators/encode.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] ENCODE() was deprecated in MySQL 5.7 and removed in MySQL 8.0; MatrixOne continues to support it"
+              ]
+            },
+            {
+              "id": "op.cast_functions_and_operators.serial_full",
+              "title": "SERIAL_FULL()",
+              "path": "docs/MatrixOne/Reference/Operators/cast-functions-and-operators/serial_full.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] SERIAL_FULL() is a MO-specific serialization function variant with NULL preservation, no MySQL 8.0 counterpart"
+              ]
+            },
+            {
+              "id": "op.cast_functions_and_operators.serial",
+              "title": "SERIAL()",
+              "path": "docs/MatrixOne/Reference/Operators/cast-functions-and-operators/serial.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] SERIAL() is a MO-specific serialization function with no MySQL 8.0 counterpart"
+              ]
+            }
+          ]
+        },
+        {
+          "id": "comparison_functions_and_operators",
+          "label": "Comparison Functions and Operators",
+          "entries": [
+            {
+              "id": "op.comparison_functions_and_operators.null_safe_equal",
+              "title": "<=>",
+              "path": "docs/MatrixOne/Reference/Operators/comparison-functions-and-operators/null-safe-equal.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "op.comparison_functions_and_operators.assign_equal",
+              "title": "assign-equal",
+              "path": "docs/MatrixOne/Reference/Operators/comparison-functions-and-operators/assign-equal.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.comparison_functions_and_operators.between",
+              "title": "between",
+              "path": "docs/MatrixOne/Reference/Operators/comparison-functions-and-operators/between.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.comparison_functions_and_operators.coalesce",
+              "title": "coalesce",
+              "path": "docs/MatrixOne/Reference/Operators/comparison-functions-and-operators/coalesce.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.comparison_functions_and_operators.comparison_functions_and_operators_overview",
+              "title": "comparison-functions-and-operators-overview",
+              "path": "docs/MatrixOne/Reference/Operators/comparison-functions-and-operators/comparison-functions-and-operators-overview.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.comparison_functions_and_operators.function_interval",
+              "title": "function_interval",
+              "path": "docs/MatrixOne/Reference/Operators/comparison-functions-and-operators/function_interval.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.comparison_functions_and_operators.function_isnull",
+              "title": "function_isnull",
+              "path": "docs/MatrixOne/Reference/Operators/comparison-functions-and-operators/function_isnull.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.comparison_functions_and_operators.function_least",
+              "title": "function_least",
+              "path": "docs/MatrixOne/Reference/Operators/comparison-functions-and-operators/function_least.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.comparison_functions_and_operators.function_strcmp",
+              "title": "function_strcmp",
+              "path": "docs/MatrixOne/Reference/Operators/comparison-functions-and-operators/function_strcmp.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.comparison_functions_and_operators.greater_than",
+              "title": "greater-than",
+              "path": "docs/MatrixOne/Reference/Operators/comparison-functions-and-operators/greater-than.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.comparison_functions_and_operators.greater_than_or_equal",
+              "title": "greater-than-or-equal",
+              "path": "docs/MatrixOne/Reference/Operators/comparison-functions-and-operators/greater-than-or-equal.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.comparison_functions_and_operators.ilike",
+              "title": "ILIKE",
+              "path": "docs/MatrixOne/Reference/Operators/comparison-functions-and-operators/ilike.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] ILIKE operator for case-insensitive LIKE matching (PostgreSQL extension)"
+              ]
+            },
+            {
+              "id": "op.comparison_functions_and_operators.in",
+              "title": "IN",
+              "path": "docs/MatrixOne/Reference/Operators/comparison-functions-and-operators/in.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "op.comparison_functions_and_operators.is",
+              "title": "is",
+              "path": "docs/MatrixOne/Reference/Operators/comparison-functions-and-operators/is.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.comparison_functions_and_operators.is_null",
+              "title": "IS NULL",
+              "path": "docs/MatrixOne/Reference/Operators/comparison-functions-and-operators/is-null.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "op.comparison_functions_and_operators.is_not",
+              "title": "is-not",
+              "path": "docs/MatrixOne/Reference/Operators/comparison-functions-and-operators/is-not.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.comparison_functions_and_operators.is_not_null",
+              "title": "is-not-null",
+              "path": "docs/MatrixOne/Reference/Operators/comparison-functions-and-operators/is-not-null.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.comparison_functions_and_operators.less_than",
+              "title": "less-than",
+              "path": "docs/MatrixOne/Reference/Operators/comparison-functions-and-operators/less-than.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.comparison_functions_and_operators.less_than_or_equal",
+              "title": "less-than-or-equal",
+              "path": "docs/MatrixOne/Reference/Operators/comparison-functions-and-operators/less-than-or-equal.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.comparison_functions_and_operators.like",
+              "title": "like",
+              "path": "docs/MatrixOne/Reference/Operators/comparison-functions-and-operators/like.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.comparison_functions_and_operators.not_in",
+              "title": "NOT IN",
+              "path": "docs/MatrixOne/Reference/Operators/comparison-functions-and-operators/not-in.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "op.comparison_functions_and_operators.not_between",
+              "title": "not-between",
+              "path": "docs/MatrixOne/Reference/Operators/comparison-functions-and-operators/not-between.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.comparison_functions_and_operators.not_equal",
+              "title": "not-equal",
+              "path": "docs/MatrixOne/Reference/Operators/comparison-functions-and-operators/not-equal.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.comparison_functions_and_operators.not_like",
+              "title": "not-like",
+              "path": "docs/MatrixOne/Reference/Operators/comparison-functions-and-operators/not-like.md",
+              "compat": "unknown",
+              "notes": []
+            }
+          ]
+        },
+        {
+          "id": "flow_control_functions",
+          "label": "Flow Control Functions",
+          "entries": [
+            {
+              "id": "op.flow_control_functions.case_when",
+              "title": "CASE WHEN",
+              "path": "docs/MatrixOne/Reference/Operators/flow-control-functions/case-when.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "op.flow_control_functions.flow_control_functions_overview",
+              "title": "flow-control-functions-overview",
+              "path": "docs/MatrixOne/Reference/Operators/flow-control-functions/flow-control-functions-overview.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.flow_control_functions.function_ifnull",
+              "title": "function_ifnull",
+              "path": "docs/MatrixOne/Reference/Operators/flow-control-functions/function_ifnull.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.flow_control_functions.function_nullif",
+              "title": "function_nullif",
+              "path": "docs/MatrixOne/Reference/Operators/flow-control-functions/function_nullif.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.flow_control_functions.function_if",
+              "title": "IF()",
+              "path": "docs/MatrixOne/Reference/Operators/flow-control-functions/function_if.md",
+              "compat": "partial",
+              "notes": [
+                "IF(NULL, expr2, expr3) raises an error instead of returning expr3 (MySQL 8.0 returns expr3)"
+              ]
+            }
+          ]
+        },
+        {
+          "id": "logical_operators",
+          "label": "Logical Operators",
+          "entries": [
+            {
+              "id": "op.logical_operators.and",
+              "title": "and",
+              "path": "docs/MatrixOne/Reference/Operators/logical-operators/and.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.logical_operators.logical_operators_overview",
+              "title": "logical-operators-overview",
+              "path": "docs/MatrixOne/Reference/Operators/logical-operators/logical-operators-overview.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.logical_operators.not",
+              "title": "NOT / !",
+              "path": "docs/MatrixOne/Reference/Operators/logical-operators/not.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "op.logical_operators.or",
+              "title": "or",
+              "path": "docs/MatrixOne/Reference/Operators/logical-operators/or.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.logical_operators.xor",
+              "title": "xor",
+              "path": "docs/MatrixOne/Reference/Operators/logical-operators/xor.md",
+              "compat": "unknown",
+              "notes": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "data-types",
+      "label": "Data Types",
+      "summary": {
+        "full": 1,
+        "partial": 7,
+        "none": 0,
+        "mo_only": 3,
+        "unknown": 1
+      },
+      "categories": [
+        {
+          "id": "_root",
+          "label": "Data Types",
+          "entries": [
+            {
+              "id": "dtype.blob_text_type",
+              "title": "blob-text-type",
+              "path": "docs/MatrixOne/Reference/Data-Types/blob-text-type.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "dtype.data_type_conversion",
+              "title": "Data Type Conversion",
+              "path": "docs/MatrixOne/Reference/Data-Types/data-type-conversion.md",
+              "compat": "partial",
+              "notes": [
+                "BOOLEAN → DECIMAL cast is not supported; other common conversions are supported"
+              ]
+            },
+            {
+              "id": "dtype.data_types",
+              "title": "Data Types Overview",
+              "path": "docs/MatrixOne/Reference/Data-Types/data-types.md",
+              "compat": "partial",
+              "notes": [
+                "TIMESTAMP range is 0001-01-01 to 9999-12-31 (MySQL: 1970-01-01 to 2038-01-19)",
+                "DATETIME lower bound is 0001-01-01 (MySQL: 1000-01-01)",
+                "Non-standard type names FLOAT32/FLOAT64 in addition to MySQL's FLOAT/DOUBLE"
+              ]
+            },
+            {
+              "id": "dtype.datalink_type",
+              "title": "DATALINK Type",
+              "path": "docs/MatrixOne/Reference/Data-Types/datalink-type.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] DATALINK data type with STAGE integration, file:// and stage:// URL schemes",
+                "[MO-only] load_file() integration for reading DATALINK values"
+              ]
+            },
+            {
+              "id": "dtype.enum_type",
+              "title": "ENUM Type",
+              "path": "docs/MatrixOne/Reference/Data-Types/enum-type.md",
+              "compat": "partial",
+              "notes": []
+            },
+            {
+              "id": "dtype.fixed_point_types",
+              "title": "Fixed-Point Types (Exact Value) - DECIMAL",
+              "path": "docs/MatrixOne/Reference/Data-Types/fixed-point-types.md",
+              "compat": "partial",
+              "notes": [
+                "DECIMAL precision supports up to 65 digits via DECIMAL256"
+              ]
+            },
+            {
+              "id": "dtype.json_type",
+              "title": "JSON Type",
+              "path": "docs/MatrixOne/Reference/Data-Types/json-type.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "dtype.set_type",
+              "title": "SET Type",
+              "path": "docs/MatrixOne/Reference/Data-Types/set-type.md",
+              "compat": "partial",
+              "notes": []
+            },
+            {
+              "id": "dtype.uuid_type",
+              "title": "UUID Type",
+              "path": "docs/MatrixOne/Reference/Data-Types/uuid-type.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] UUID as a native column type (MySQL 8.0 has UUID() function only, no UUID column type)",
+                "[MO-only] DEFAULT uuid() on UUID columns"
+              ]
+            },
+            {
+              "id": "dtype.vector_type",
+              "title": "Vector Type",
+              "path": "docs/MatrixOne/Reference/Data-Types/vector-type.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] vecf32 and vecf64 vector data types for embedding storage and similarity search",
+                "[MO-only] Binary vector insert via hex encoding",
+                "[MO-only] Dimension specification syntax in column definition"
+              ]
+            }
+          ]
+        },
+        {
+          "id": "date_time_data_types",
+          "label": "Date/Time Data Types",
+          "entries": [
+            {
+              "id": "dtype.date_time_data_types.timestamp_initialization",
+              "title": "TIMESTAMP Initialization",
+              "path": "docs/MatrixOne/Reference/Data-Types/date-time-data-types/timestamp-initialization.md",
+              "compat": "partial",
+              "notes": [
+                "TIMESTAMP range is 0001-9999 (MySQL 8.0: 1970-2038); auto-initialization behavior near range boundaries may differ",
+                "DATETIME DEFAULT 0 is not supported (MySQL 8.0 supports it)",
+                "TIMESTAMP ON UPDATE CURRENT_TIMESTAMP without explicit DEFAULT defaults to NULL (MySQL 8.0 defaults to 0)",
+                "DATETIME NOT NULL ON UPDATE CURRENT_TIMESTAMP without explicit DEFAULT rejects NULL insert (MySQL 8.0 defaults to 0)"
+              ]
+            },
+            {
+              "id": "dtype.date_time_data_types.year_type",
+              "title": "YEAR Type",
+              "path": "docs/MatrixOne/Reference/Data-Types/date-time-data-types/year-type.md",
+              "compat": "partial",
+              "notes": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "language-structure",
+      "label": "Language Structure",
+      "summary": {
+        "full": 0,
+        "partial": 2,
+        "none": 0,
+        "mo_only": 0,
+        "unknown": 0
+      },
+      "categories": [
+        {
+          "id": "_root",
+          "label": "Language Structure",
+          "entries": [
+            {
+              "id": "lang.comment",
+              "title": "Comments",
+              "path": "docs/MatrixOne/Reference/Language-Structure/comment.md",
+              "compat": "partial",
+              "notes": [
+                "Supports // single-line comments (C++ style); MySQL 8.0 does not support // comments",
+                "Does not support /*!...*/ conditional/executable comments (MySQL 8.0 does)"
+              ]
+            },
+            {
+              "id": "lang.keywords",
+              "title": "Keywords",
+              "path": "docs/MatrixOne/Reference/Language-Structure/keywords.md",
+              "compat": "partial",
+              "notes": [
+                "MatrixOne-specific keywords marked with (M) in the keyword list"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/docs/MatrixOne/Reference/mysql-compatibility-matrix.md
+++ b/docs/MatrixOne/Reference/mysql-compatibility-matrix.md
@@ -6,11 +6,22 @@ mysql_compat: full
 # MySQL Compatibility Matrix
 
 > Auto-generated from `mysql_compat` frontmatter across
-> `docs/MatrixOne/Reference/SQL-Reference/**`. Do not edit by hand —
-> re-run `node scripts/generate-compat-matrix.js` after updating any
-> source page.
+> `docs/MatrixOne/Reference/SQL-Reference/**`, `docs/MatrixOne/Reference/Functions-and-Operators/**`, `docs/MatrixOne/Reference/Operators/**`, `docs/MatrixOne/Reference/Data-Types/**`, `docs/MatrixOne/Reference/Language-Structure/**`.
+> Do not edit by hand — re-run `node scripts/generate-compat-matrix.js`
+> after updating any source page.
 
 ## Summary
+
+| Status | Count |
+|---|---|
+| ✅ Full | 131 |
+| ⚠️ Partial | 97 |
+| ❌ None | 1 |
+| 🟣 MatrixOne-only | 96 |
+| ❓ Unknown | 48 |
+| **Total** | **373** |
+
+## SQL Statements
 
 | Status | Count |
 |---|---|
@@ -18,168 +29,553 @@ mysql_compat: full
 | ⚠️ Partial | 58 |
 | ❌ None | 1 |
 | 🟣 MatrixOne-only | 53 |
-| ❓ Unknown | 0 |
 | **Total** | **133** |
 
-## Data Definition Language (DDL)
+### SQL Statements
 
-| Statement | MySQL Compat | Differences from MySQL | MatrixOne-only |
-|---|---|---|---|
-| [ALTER PITR](./SQL-Reference/Data-Definition-Language/alter-pitr.md) | 🟣 MatrixOne-only | — | ALTER PITR |
-| [ALTER PUBLICATION](./SQL-Reference/Data-Definition-Language/alter-publication.md) | 🟣 MatrixOne-only | — | ALTER PUBLICATION |
-| [ALTER REINDEX](./SQL-Reference/Data-Definition-Language/alter-reindex.md) | 🟣 MatrixOne-only | — | ALTER … REINDEX (rebuild vector index) |
-| [ALTER SEQUENCE](./SQL-Reference/Data-Definition-Language/alter-sequence.md) | 🟣 MatrixOne-only | — | ALTER SEQUENCE |
-| [ALTER STAGE](./SQL-Reference/Data-Definition-Language/alter-stage.md) | 🟣 MatrixOne-only | — | ALTER STAGE |
-| [ALTER TABLE](./SQL-Reference/Data-Definition-Language/alter-table.md) | ⚠️ Partial | Multiple ALTER TABLE operations can be combined in one statement, with limitation: DROP PRIMARY KEY cannot be combined with RENAME COLUMN, CHANGE COLUMN, or DROP COLUMN (causes server panic); DROP PK + ADD COLUMN and DROP PK + MODIFY COLUMN work correctly<br/>Temporary tables cannot be altered<br/>ALTER TABLE does not support PARTITION operations | — |
-| [ALTER VIEW](./SQL-Reference/Data-Definition-Language/alter-view.md) | ⚠️ Partial | WITH CHECK OPTION is accepted in CREATE VIEW (syntax only, views are read-only) but rejected as a syntax error in ALTER VIEW | — |
-| [Branch Protect Snapshots](./SQL-Reference/Data-Definition-Language/branch-protect-snapshots.md) | 🟣 MatrixOne-only | — | — |
-| [CREATE CLONE](./SQL-Reference/Data-Definition-Language/create-clone.md) | 🟣 MatrixOne-only | — | CREATE TABLE … CLONE db.table [TO ACCOUNT …] |
-| [CREATE CLUSTER TABLE](./SQL-Reference/Data-Definition-Language/create-cluster-table.md) | 🟣 MatrixOne-only | — | CREATE CLUSTER TABLE |
-| [CREATE DATABASE](./SQL-Reference/Data-Definition-Language/create-database.md) | ⚠️ Partial | Only utf8mb4 / utf8mb4_bin are functional; other charsets/collations are syntactically accepted but have no effect<br/>ENCRYPTION clause accepted but inert | — |
-| [CREATE DYNAMIC TABLE](./SQL-Reference/Data-Definition-Language/create-dynamic-table.md) | 🟣 MatrixOne-only | — | CREATE DYNAMIC TABLE |
-| [CREATE EXTERNAL TABLE](./SQL-Reference/Data-Definition-Language/create-external-table.md) | 🟣 MatrixOne-only | — | CREATE EXTERNAL TABLE |
-| [Create Fulltext Index](./SQL-Reference/Data-Definition-Language/create-fulltext-index.md) | ⚠️ Partial | MatrixOne full-text index is implemented on TAE storage with CJK/English optimizations; MySQL implements it on InnoDB/MyISAM with different stopword and parser semantics. | — |
-| [CREATE FUNCTION...LANGUAGE PYTHON AS](./SQL-Reference/Data-Definition-Language/create-function-python.md) | 🟣 MatrixOne-only | — | CREATE FUNCTION … LANGUAGE PYTHON AS … |
-| [CREATE FUNCTION...LANGUAGE SQL AS](./SQL-Reference/Data-Definition-Language/create-function-sql.md) | ⚠️ Partial | Only LANGUAGE SQL and LANGUAGE PYTHON are supported; usage differs significantly from MySQL stored functions<br/>CREATE OR REPLACE FUNCTION is supported; MySQL 8.0 does not support OR REPLACE for functions (only IF NOT EXISTS since 8.0.29) | — |
-| [CREATE INDEX](./SQL-Reference/Data-Definition-Language/create-index.md) | ⚠️ Partial | Secondary indexes are supported and participate in query optimization (as of MO 3.0.12, EXPLAIN shows Index Table Scan for secondary index queries). Does not support index hints (USE INDEX, FORCE INDEX, IGNORE INDEX), function-based indexes, or FULLTEXT index via CREATE INDEX syntax (use CREATE FULLTEXT INDEX instead). | USING IVFFLAT — vector index for approximate nearest neighbour<br/>USING HNSW — vector index for approximate nearest neighbour<br/>USING MASTER — composite master index |
-| [CREATE INDEX USING HNSW](./SQL-Reference/Data-Definition-Language/create-index-hnsw.md) | 🟣 MatrixOne-only | — | CREATE INDEX … USING HNSW |
-| [CREATE INDEX USING IVFFLAT](./SQL-Reference/Data-Definition-Language/create-index-ivfflat.md) | 🟣 MatrixOne-only | — | CREATE INDEX … USING IVFFLAT |
-| [CREATE PITR](./SQL-Reference/Data-Definition-Language/create-pitr.md) | 🟣 MatrixOne-only | — | CREATE PITR … RANGE N {h\|d\|mo\|y} |
-| [CREATE PUBLICATION](./SQL-Reference/Data-Definition-Language/create-publication.md) | 🟣 MatrixOne-only | — | CREATE PUBLICATION |
-| [CREATE SEQUENCE](./SQL-Reference/Data-Definition-Language/create-sequence.md) | 🟣 MatrixOne-only | — | CREATE SEQUENCE (PostgreSQL-style) |
-| [CREATE SNAPSHOT](./SQL-Reference/Data-Definition-Language/create-snapshot.md) | 🟣 MatrixOne-only | — | CREATE SNAPSHOT FOR {ACCOUNT\|DATABASE\|TABLE\|CLUSTER} |
-| [CREATE SOURCE](./SQL-Reference/Data-Definition-Language/create-source.md) | 🟣 MatrixOne-only | — | CREATE SOURCE (stream/Kafka connector) |
-| [CREATE STAGE](./SQL-Reference/Data-Definition-Language/create-stage.md) | 🟣 MatrixOne-only | — | CREATE STAGE (external file-system binding) |
-| [CREATE TABLE](./SQL-Reference/Data-Definition-Language/create-table.md) | ⚠️ Partial | ENGINE= clause is syntactically accepted but ignored; MatrixOne uses TAE exclusively<br/>Spatial type names (GEOMETRY, POINT, etc.) are syntactically accepted but non-functional; MEDIUMINT is syntactically accepted but treated as INT<br/>BOOL is a native boolean type, not an INT alias as in MySQL<br/>AUTO_INCREMENT step is always 1; @@auto_increment_increment is syntactically accepted but inert<br/>Partitioning accepts syntax but only HASH and KEY participate in partition pruning (RANGE/LIST/RANGE COLUMNS/LIST COLUMNS are syntax-only); subpartitioning causes an internal error; ADD/DROP/TRUNCATE PARTITION not supported<br/>CHECK constraints are syntactically accepted but not enforced; MySQL 8.0.16+ enforces them | CLUSTER BY (col, …) — pre-sort columns to accelerate queries<br/>START TRANSACTION table option — non-standard table option with no MySQL 8.0 equivalent |
-| [CREATE TABLE ... LIKE](./SQL-Reference/Data-Definition-Language/create-table-like.md) | ✅ Full | — | — |
-| [CREATE TABLE AS SELECT](./SQL-Reference/Data-Definition-Language/create-table-as-select.md) | ✅ Full | — | — |
-| [CREATE TASK (SQL Task)](./SQL-Reference/Data-Definition-Language/sql-task.md) | 🟣 MatrixOne-only | — | CREATE TASK / ALTER TASK / DROP TASK / EXECUTE TASK / SHOW TASKS (MO-specific scheduled SQL tasks; MySQL uses CREATE EVENT instead) |
-| [CREATE VIEW](./SQL-Reference/Data-Definition-Language/create-view.md) | ⚠️ Partial | WITH CHECK OPTION is syntactically accepted but not enforced<br/>Views are read-only; MySQL 8.0 supports INSERT/UPDATE/DELETE through views that meet updatability criteria | — |
-| [CREATE...FROM...PUBLICATION...](./SQL-Reference/Data-Definition-Language/create-subscription.md) | 🟣 MatrixOne-only | — | CREATE DATABASE … FROM … PUBLICATION … |
-| [DATA BRANCH CREATE](./SQL-Reference/Data-Definition-Language/data-branch-create-en.md) | 🟣 MatrixOne-only | — | DATA BRANCH CREATE (Git-for-Data) |
-| [DATA BRANCH DELETE](./SQL-Reference/Data-Definition-Language/data-branch-delete-en.md) | 🟣 MatrixOne-only | — | DATA BRANCH DELETE |
-| [DATA BRANCH DIFF](./SQL-Reference/Data-Definition-Language/data-branch-diff-en.md) | 🟣 MatrixOne-only | — | DATA BRANCH DIFF |
-| [DATA BRANCH MERGE](./SQL-Reference/Data-Definition-Language/data-branch-merge-en.md) | 🟣 MatrixOne-only | — | DATA BRANCH MERGE |
-| [DATA BRANCH PICK](./SQL-Reference/Data-Definition-Language/data-branch-pick.md) | 🟣 MatrixOne-only | — | DATA BRANCH PICK (cherry-pick specific rows between branch tables, Git-for-Data feature) |
-| [DROP DATABASE](./SQL-Reference/Data-Definition-Language/drop-database.md) | ✅ Full | — | — |
-| [DROP FUNCTION](./SQL-Reference/Data-Definition-Language/drop-function.md) | ⚠️ Partial | Drops MatrixOne-style SQL / Python functions, not MySQL stored procedures/functions<br/>Requires argument type list on DROP (e.g. DROP FUNCTION py_add(int, int)); MySQL 8.0 accepts only the function name | — |
-| [DROP INDEX](./SQL-Reference/Data-Definition-Language/drop-index.md) | ⚠️ Partial | MO accepts DROP INDEX IF EXISTS syntax (MySQL 8.0 does not), but IF EXISTS does not suppress errors for missing indexes; it returns internal error 20101 instead of a silent skip | — |
-| [DROP PITR](./SQL-Reference/Data-Definition-Language/drop-pitr.md) | 🟣 MatrixOne-only | — | DROP PITR |
-| [DROP PUBLICATION](./SQL-Reference/Data-Definition-Language/drop-publication.md) | 🟣 MatrixOne-only | — | DROP PUBLICATION |
-| [DROP SEQUENCE](./SQL-Reference/Data-Definition-Language/drop-sequence.md) | 🟣 MatrixOne-only | — | DROP SEQUENCE |
-| [DROP SNAPSHOT](./SQL-Reference/Data-Definition-Language/drop-snapshot.md) | 🟣 MatrixOne-only | — | DROP SNAPSHOT |
-| [DROP STAGE](./SQL-Reference/Data-Definition-Language/drop-stage.md) | 🟣 MatrixOne-only | — | DROP STAGE |
-| [DROP TABLE](./SQL-Reference/Data-Definition-Language/drop-table.md) | ✅ Full | — | — |
-| [DROP VIEW](./SQL-Reference/Data-Definition-Language/drop-view.md) | ⚠️ Partial | MO does not support dropping multiple views in a single statement; only a single view per DROP VIEW. MySQL 8.0 supports dropping multiple views (e.g., DROP VIEW v1, v2). | — |
-| [Rename Table](./SQL-Reference/Data-Definition-Language/rename-table.md) | ⚠️ Partial | MO does not support RENAME TABLE across databases; when given cross-database syntax, MO renames the table within its current database instead of raising an error. MySQL 8.0 supports cross-database RENAME TABLE. | — |
-| [RESTORE ... FROM PITR](./SQL-Reference/Data-Definition-Language/restore-pitr.md) | 🟣 MatrixOne-only | — | RESTORE … FROM PITR |
-| [RESTORE ... SNAPSHOT](./SQL-Reference/Data-Definition-Language/restore-snapshot.md) | 🟣 MatrixOne-only | — | RESTORE … FROM SNAPSHOT |
-| [TRUNCATE TABLE](./SQL-Reference/Data-Definition-Language/truncate-table.md) | ✅ Full | — | — |
+| Statement | MySQL Compat | Notes |
+|---|---|---|
+| [Type of SQL Statements](./SQL-Reference/SQL-Type.md) | 🟣 MatrixOne-only | [MO-only] Index page describing MatrixOne's own SQL statement taxonomy; not a MySQL-equivalent concept. |
 
-## Data Manipulation Language (DML)
+### Data Control Language (DCL)
 
-| Statement | MySQL Compat | Differences from MySQL | MatrixOne-only |
-|---|---|---|---|
-| [CASE](./SQL-Reference/Data-Manipulation-Language/case.md) | ✅ Full | This page describes the CASE operator (expression), not the stored-program CASE statement. MatrixOne does not support stored programs, so the stored-program CASE STATEMENT is unavailable; the CASE OPERATOR behaves compatibly. | — |
-| [CURRENT_ROLE()](./SQL-Reference/Data-Manipulation-Language/information-functions/current_role.md) | ⚠️ Partial | Returns a single active role name; MySQL 8.0 can return multiple comma-separated active roles or 'NONE'. | — |
-| [DELETE](./SQL-Reference/Data-Manipulation-Language/delete.md) | ⚠️ Partial | LOW_PRIORITY, QUICK, IGNORE modifiers are syntactically accepted but have no effect<br/>PARTITION clause not supported | — |
-| [INSERT](./SQL-Reference/Data-Manipulation-Language/insert.md) | ⚠️ Partial | Modifiers LOW_PRIORITY / DELAYED / HIGH_PRIORITY not supported<br/>PARTITION clause not supported | — |
-| [INSERT ... ON DUPLICATE KEY UPDATE](./SQL-Reference/Data-Manipulation-Language/upsert/insert-on-duplicate.md) | ⚠️ Partial | ON DUPLICATE KEY UPDATE only triggers on PRIMARY KEY conflicts; UNIQUE index conflicts are detected but result in errors (ERROR 1062 or ERROR 20102) rather than triggering ON DUPLICATE KEY UPDATE | — |
-| [INSERT IGNORE](./SQL-Reference/Data-Manipulation-Language/upsert/insert-ignore.md) | ⚠️ Partial | LOW_PRIORITY / DELAYED / HIGH_PRIORITY modifiers not supported<br/>Duplicates are silently ignored; MySQL emits a warning for each skipped row.<br/>Does not ignore NULL-into-NOT-NULL, type-conversion, or partition-mismatch errors as MySQL does.<br/>PARTITION clause not supported | — |
-| [INSERT INTO SELECT](./SQL-Reference/Data-Manipulation-Language/insert-into-select.md) | ✅ Full | — | — |
-| [LAST_INSERT_ID()](./SQL-Reference/Data-Manipulation-Language/information-functions/last-insert-id.md) | ⚠️ Partial | Multi-row INSERT returns the last inserted auto-increment value; MySQL returns the first inserted value. | — |
-| [LAST_QUERY_ID](./SQL-Reference/Data-Manipulation-Language/information-functions/last-query-id.md) | 🟣 MatrixOne-only | — | LAST_QUERY_ID() |
-| [LOAD DATA](./SQL-Reference/Data-Manipulation-Language/load-data-infile.md) | ⚠️ Partial | SET clause only accepts columns_name = nullif(expr1, expr2)<br/>JSONLines import uses MatrixOne-specific syntax<br/>Object-storage import (S3/URL) uses MatrixOne-specific syntax<br/>LOW_PRIORITY and CONCURRENT modifiers not supported<br/>REPLACE and IGNORE modifiers not supported | PARALLEL clause (controls parallel file loading)<br/>STRICT clause (controls parallel splitting mode) |
-| [LOAD DATA INLINE](./SQL-Reference/Data-Manipulation-Language/load-data-inline.md) | 🟣 MatrixOne-only | — | LOAD DATA INLINE (stage-sourced import) |
-| [REPLACE](./SQL-Reference/Data-Manipulation-Language/replace.md) | ⚠️ Partial | node-sql-parser rejects REPLACE … WHERE (parser bug, not MatrixOne)<br/>PARTITION clause not supported<br/>LOW_PRIORITY and DELAYED modifiers not supported<br/>REPLACE only detects conflicts on PRIMARY KEY; secondary UNIQUE index conflicts throw ERROR 1062 (MySQL 8.0 handles both). Constraints section incorrectly states UNIQUE index can also trigger REPLACE; this is wrong per actual MO behavior. | — |
-| [REPLACE](./SQL-Reference/Data-Manipulation-Language/upsert/replace.md) | ⚠️ Partial | node-sql-parser rejects REPLACE … WHERE (parser bug, not MatrixOne)<br/>PARTITION clause not supported<br/>LOW_PRIORITY and DELAYED modifiers not supported<br/>REPLACE only detects conflicts on PRIMARY KEY; secondary UNIQUE index conflicts throw ERROR 1062 (MySQL 8.0 handles both). Constraints section incorrectly states UNIQUE index can also trigger REPLACE; this is wrong per actual MO behavior. | — |
-| [UPDATE](./SQL-Reference/Data-Manipulation-Language/update.md) | ⚠️ Partial | LOW_PRIORITY and IGNORE modifiers are syntactically accepted but have no effect<br/>PARTITION clause not supported | — |
-| [UPSERT](./SQL-Reference/Data-Manipulation-Language/upsert/upsert.md) | ⚠️ Partial | INSERT IGNORE does not suppress NOT NULL or type-conversion errors (MySQL 8.0 does)<br/>INSERT ON DUPLICATE KEY UPDATE only triggers on PRIMARY KEY conflicts; UNIQUE index conflicts are detected but result in errors (ERROR 1062 or ERROR 20102) rather than triggering ON DUPLICATE KEY UPDATE<br/>REPLACE does not support REPLACE ... WHERE (parser bug) | — |
+| Statement | MySQL Compat | Notes |
+|---|---|---|
+| [ALTER ACCOUNT](./SQL-Reference/Data-Control-Language/alter-account.md) | 🟣 MatrixOne-only | [MO-only] ALTER ACCOUNT |
+| [ALTER USER](./SQL-Reference/Data-Control-Language/alter-user.md) | ⚠️ Partial | Only ALTER USER can change passwords; account-limit clauses not honoured<br/>Password management options (PASSWORD EXPIRE, PASSWORD HISTORY, PASSWORD REUSE INTERVAL, PASSWORD REQUIRE CURRENT, FAILED_LOGIN_ATTEMPTS, PASSWORD_LOCK_TIME) not supported<br/>Account locking (ACCOUNT LOCK/UNLOCK) not supported<br/>REQUIRE clause (TLS/SSL enforcement) not supported<br/>COMMENT and ATTRIBUTE modification not supported<br/>Multiple users per statement not supported (MySQL 8.0 allows user [, user] ...) |
+| [CREATE ACCOUNT](./SQL-Reference/Data-Control-Language/create-account.md) | 🟣 MatrixOne-only | [MO-only] CREATE ACCOUNT … ADMIN_NAME … |
+| [CREATE ROLE](./SQL-Reference/Data-Control-Language/create-role.md) | ⚠️ Partial | Role exists inside MatrixOne's multi-account model; roles are account-scoped, not server-global as in MySQL. |
+| [CREATE USER](./SQL-Reference/Data-Control-Language/create-user.md) | ⚠️ Partial | IDENTIFIED BY is the only supported password form; IDENTIFIED WITH plugins not supported<br/>Connection-IP whitelists and connection-limit clauses not supported<br/>COMMENT and ATTRIBUTE clauses not supported<br/>'user'@'host' syntax is accepted and host is stored in mo_catalog.mo_user.user_host but may not restrict connections; users are scoped to the current account, not server-global as in MySQL<br/>Password management options (PASSWORD EXPIRE, PASSWORD HISTORY, PASSWORD REUSE INTERVAL, PASSWORD REQUIRE CURRENT) not supported<br/>Account locking (ACCOUNT LOCK/UNLOCK) not supported<br/>REQUIRE clause (TLS/SSL enforcement) not supported |
+| [DROP ACCOUNT](./SQL-Reference/Data-Control-Language/drop-account.md) | 🟣 MatrixOne-only | [MO-only] DROP ACCOUNT |
+| [DROP ROLE](./SQL-Reference/Data-Control-Language/drop-role.md) | ⚠️ Partial | Role exists inside MatrixOne's multi-account model; roles are account-scoped, not server-global as in MySQL. |
+| [DROP USER](./SQL-Reference/Data-Control-Language/drop-user.md) | ⚠️ Partial | User identifier is a bare username scoped to the current account; MySQL uses 'user'@'host' tuples. |
+| [GRANT](./SQL-Reference/Data-Control-Language/grant.md) | ⚠️ Partial | Authorization logic differs from MySQL — MatrixOne evaluates via its role/account model<br/>User identifier is a bare username scoped to the current account; MySQL uses 'user'@'host' tuples<br/>AS user [WITH ROLE ...] clause (MySQL 8.0 privilege restriction) not supported<br/>GRANT privilege ... TO only accepts roles; users receive privileges indirectly through role membership (GRANT role TO user)<br/>WITH ADMIN OPTION for role grants is not supported<br/>[MO-only] `GRANT ... ON ACCOUNT *` — account-level privileges have no MySQL counterpart<br/>[MO-only] `GRANT ... ON DATABASE *` — MatrixOne-specific database-level grant target<br/>[MO-only] GRANT ... ON VIEW db_name.view_name (separate VIEW object_type; MySQL 8.0 only supports TABLE, FUNCTION, PROCEDURE) |
+| [REVOKE](./SQL-Reference/Data-Control-Language/revoke.md) | ⚠️ Partial | Recovery logic differs from MySQL — privileges return to the role/account graph<br/>User identifier is a bare username scoped to the current account; MySQL uses 'user'@'host' tuples<br/>IGNORE UNKNOWN USER clause (MySQL 8.0.30+) not supported<br/>[MO-only] `REVOKE ... ON ACCOUNT *` — account-level privileges have no MySQL counterpart<br/>[MO-only] `REVOKE ... ON DATABASE *` — MatrixOne-specific database-level revoke target<br/>[MO-only] REVOKE ... ON VIEW db_name.view_name (separate VIEW object_type) |
+| [Role Rewrite Rules (ALTER ROLE ... RULE / SHOW RULES)](./SQL-Reference/Data-Control-Language/role-rule.md) | 🟣 MatrixOne-only | — |
 
-## Data Query Language (DQL)
+### Data Definition Language (DDL)
 
-| Statement | MySQL Compat | Differences from MySQL | MatrixOne-only |
-|---|---|---|---|
-| [BY RANK WITH OPTION](./SQL-Reference/Data-Query-Language/by-rank-with-option.md) | 🟣 MatrixOne-only | — | BY RANK WITH OPTION (IVF vector ranking) |
-| [Combining Queries (UNION, INTERSECT, MINUS)](./SQL-Reference/Data-Query-Language/union-intersect-minus-overview.md) | ⚠️ Partial | MINUS keyword is MO-specific; MySQL 8.0.31+ uses EXCEPT for the same set-difference semantics. MINUS ALL is not yet implemented in MO while MySQL 8.0.31+ supports EXCEPT ALL.<br/>INTERSECT was added in MySQL 8.0.31; both MO and MySQL support INTERSECT and INTERSECT ALL with matching semantics.<br/>UNION is standard across both, but MO's type coercion in UNION columns is stricter (errors on incompatible types where MySQL silently coerces). | MINUS keyword (MO-specific syntax; MySQL 8.0.31+ offers equivalent EXCEPT) |
-| [Comparisons Using Subqueries](./SQL-Reference/Data-Query-Language/subqueries/comparisons-using-subqueries.md) | ✅ Full | — | — |
-| [CROSS APPLY](./SQL-Reference/Data-Query-Language/apply/cross-apply.md) | 🟣 MatrixOne-only | — | CROSS APPLY (SQL Server-style, not in MySQL) |
-| [CROSS JOIN](./SQL-Reference/Data-Query-Language/join/cross-join.md) | ✅ Full | — | — |
-| [Derived Tables](./SQL-Reference/Data-Query-Language/subqueries/derived-tables.md) | ⚠️ Partial | LATERAL derived tables are not supported in MO (MySQL 8.0.14+ supports LATERAL for correlated subqueries in FROM clause) | — |
-| [FULL JOIN](./SQL-Reference/Data-Query-Language/join/full-join.md) | ❌ None | FULL JOIN with ON clause produces different errors on MO (missing FROM-clause entry) vs MySQL 8.0 (Unknown column in ON clause). FULL JOIN with USING returns INNER JOIN results on both (neither returns unmatched rows). FULL OUTER JOIN produces a syntax error on both. MySQL 8.0 does not natively support either FULL JOIN or FULL OUTER JOIN. | — |
-| [INNER JOIN](./SQL-Reference/Data-Query-Language/join/inner-join.md) | ✅ Full | — | — |
-| [INTERSECT](./SQL-Reference/Data-Query-Language/intersect.md) | ⚠️ Partial | INTERSECT was added in MySQL 8.0.31; MO INTERSECT and INTERSECT ALL semantics match MySQL 8.0 (both return identical results for common test cases including duplicate handling) | — |
-| [JOIN](./SQL-Reference/Data-Query-Language/join/join.md) | ⚠️ Partial | FULL JOIN and FULL OUTER JOIN are not fully supported (FULL JOIN with ON produces errors, FULL JOIN with USING returns INNER JOIN results, FULL OUTER JOIN is a syntax error); MySQL 8.0 also does not support FULL JOIN/OUTER JOIN natively | — |
-| [LEFT JOIN](./SQL-Reference/Data-Query-Language/join/left-join.md) | ✅ Full | — | — |
-| [MINUS](./SQL-Reference/Data-Query-Language/minus.md) | 🟣 MatrixOne-only | MINUS keyword is MO-specific; MySQL 8.0.31+ uses EXCEPT for the same set-difference semantics (MINUS is not a recognized keyword in MySQL)<br/>MINUS ALL is not yet implemented in MO; MySQL 8.0.31+ supports EXCEPT ALL with full duplicate-preserving semantics | MINUS keyword (MO's set-difference operator; MySQL 8.0.31+ offers equivalent functionality via EXCEPT) |
-| [NATURAL JOIN](./SQL-Reference/Data-Query-Language/join/natural-join.md) | ✅ Full | — | — |
-| [OUTER APPLY](./SQL-Reference/Data-Query-Language/apply/outer-apply.md) | 🟣 MatrixOne-only | — | OUTER APPLY (SQL Server-style, not in MySQL) |
-| [OUTER JOIN](./SQL-Reference/Data-Query-Language/join/outer-join.md) | ⚠️ Partial | Overview page that includes FULL OUTER JOIN; neither MO nor MySQL 8.0 natively support FULL OUTER JOIN (MO produces syntax error, same as MySQL) | — |
-| [RIGHT JOIN](./SQL-Reference/Data-Query-Language/join/right-join.md) | ✅ Full | — | — |
-| [SELECT](./SQL-Reference/Data-Query-Language/select.md) | ⚠️ Partial | SELECT … FOR UPDATE only supports single-table queries<br/>SELECT INTO OUTFILE is only partially supported<br/>AS OF TIMESTAMP time-travel queries require PITR/snapshot to be enabled on the database; without PITR the syntax produces an error<br/>SELECT ... FOR SHARE is not supported<br/>FOR UPDATE NOWAIT and SKIP LOCKED modifiers are not supported<br/>GROUP BY ... WITH ROLLUP row ordering differs: MO places rollup summary rows at the top of the result set, while MySQL 8.0 places them at the bottom (standard MySQL grouping order) | { AS OF TIMESTAMP 'YYYY-MM-DD HH:MM:SS' } — time-travel query against enabled snapshot/PITR<br/>ORDER BY ... NULLS { FIRST \| LAST } — PostgreSQL-style NULL ordering not available in MySQL |
-| [Subqueries with ALL](./SQL-Reference/Data-Query-Language/subqueries/subquery-with-all.md) | ✅ Full | — | — |
-| [Subqueries with ANY or SOME](./SQL-Reference/Data-Query-Language/subqueries/subquery-with-any-some.md) | ✅ Full | — | — |
-| [Subqueries with EXISTS or NOT EXISTS](./SQL-Reference/Data-Query-Language/subqueries/subquery-with-exists.md) | ✅ Full | — | — |
-| [Subqueries with IN](./SQL-Reference/Data-Query-Language/subqueries/subquery-with-in.md) | ✅ Full | — | — |
-| [SUBQUERY](./SQL-Reference/Data-Query-Language/subqueries/subquery.md) | ⚠️ Partial | Multi-column scalar subquery comparisons (e.g., WHERE (a,b) = (SELECT ...)) are not supported; use multi-column IN instead | — |
-| [UNION](./SQL-Reference/Data-Query-Language/union.md) | ⚠️ Partial | UNION type coercion is strict: MO errors on incompatible types in UNION columns (e.g., INT vs VARCHAR), while MySQL 8.0 silently coerces (e.g., varchar to int converts to 0)<br/>UNION ALL type coercion is similarly strict compared to MySQL 8.0's lenient coercion | — |
-| [WITH (Common Table Expressions)](./SQL-Reference/Data-Query-Language/with-cte.md) | ⚠️ Partial | Outer joins (LEFT JOIN, RIGHT JOIN, OUTER JOIN) are not allowed in recursive CTE members; MySQL 8.0 permits them except when the recursive CTE is on the right side of a LEFT JOIN (MySQL allows LEFT JOIN with CTE on the left side; MO rejects all outer joins in recursive CTEs regardless of position) | — |
+| Statement | MySQL Compat | Notes |
+|---|---|---|
+| [ALTER PITR](./SQL-Reference/Data-Definition-Language/alter-pitr.md) | 🟣 MatrixOne-only | [MO-only] ALTER PITR |
+| [ALTER PUBLICATION](./SQL-Reference/Data-Definition-Language/alter-publication.md) | 🟣 MatrixOne-only | [MO-only] ALTER PUBLICATION |
+| [ALTER REINDEX](./SQL-Reference/Data-Definition-Language/alter-reindex.md) | 🟣 MatrixOne-only | [MO-only] ALTER … REINDEX (rebuild vector index) |
+| [ALTER SEQUENCE](./SQL-Reference/Data-Definition-Language/alter-sequence.md) | 🟣 MatrixOne-only | [MO-only] ALTER SEQUENCE |
+| [ALTER STAGE](./SQL-Reference/Data-Definition-Language/alter-stage.md) | 🟣 MatrixOne-only | [MO-only] ALTER STAGE |
+| [ALTER TABLE](./SQL-Reference/Data-Definition-Language/alter-table.md) | ⚠️ Partial | Multiple ALTER TABLE operations can be combined in one statement, with limitation: DROP PRIMARY KEY cannot be combined with RENAME COLUMN, CHANGE COLUMN, or DROP COLUMN (causes server panic); DROP PK + ADD COLUMN and DROP PK + MODIFY COLUMN work correctly<br/>Temporary tables cannot be altered<br/>ALTER TABLE does not support PARTITION operations |
+| [ALTER VIEW](./SQL-Reference/Data-Definition-Language/alter-view.md) | ⚠️ Partial | WITH CHECK OPTION is accepted in CREATE VIEW (syntax only, views are read-only) but rejected as a syntax error in ALTER VIEW |
+| [Branch Protect Snapshots](./SQL-Reference/Data-Definition-Language/branch-protect-snapshots.md) | 🟣 MatrixOne-only | — |
+| [CREATE CLONE](./SQL-Reference/Data-Definition-Language/create-clone.md) | 🟣 MatrixOne-only | [MO-only] CREATE TABLE … CLONE db.table [TO ACCOUNT …] |
+| [CREATE CLUSTER TABLE](./SQL-Reference/Data-Definition-Language/create-cluster-table.md) | 🟣 MatrixOne-only | [MO-only] CREATE CLUSTER TABLE |
+| [CREATE DATABASE](./SQL-Reference/Data-Definition-Language/create-database.md) | ⚠️ Partial | Only utf8mb4 / utf8mb4_bin are functional; other charsets/collations are syntactically accepted but have no effect<br/>ENCRYPTION clause accepted but inert |
+| [CREATE DYNAMIC TABLE](./SQL-Reference/Data-Definition-Language/create-dynamic-table.md) | 🟣 MatrixOne-only | [MO-only] CREATE DYNAMIC TABLE |
+| [CREATE EXTERNAL TABLE](./SQL-Reference/Data-Definition-Language/create-external-table.md) | 🟣 MatrixOne-only | [MO-only] CREATE EXTERNAL TABLE |
+| [Create Fulltext Index](./SQL-Reference/Data-Definition-Language/create-fulltext-index.md) | ⚠️ Partial | MatrixOne full-text index is implemented on TAE storage with CJK/English optimizations; MySQL implements it on InnoDB/MyISAM with different stopword and parser semantics. |
+| [CREATE FUNCTION...LANGUAGE PYTHON AS](./SQL-Reference/Data-Definition-Language/create-function-python.md) | 🟣 MatrixOne-only | [MO-only] CREATE FUNCTION … LANGUAGE PYTHON AS … |
+| [CREATE FUNCTION...LANGUAGE SQL AS](./SQL-Reference/Data-Definition-Language/create-function-sql.md) | ⚠️ Partial | Only LANGUAGE SQL and LANGUAGE PYTHON are supported; usage differs significantly from MySQL stored functions<br/>CREATE OR REPLACE FUNCTION is supported; MySQL 8.0 does not support OR REPLACE for functions (only IF NOT EXISTS since 8.0.29) |
+| [CREATE INDEX](./SQL-Reference/Data-Definition-Language/create-index.md) | ⚠️ Partial | Secondary indexes are supported and participate in query optimization (as of MO 3.0.12, EXPLAIN shows Index Table Scan for secondary index queries). Does not support index hints (USE INDEX, FORCE INDEX, IGNORE INDEX), function-based indexes, or FULLTEXT index via CREATE INDEX syntax (use CREATE FULLTEXT INDEX instead).<br/>[MO-only] USING IVFFLAT — vector index for approximate nearest neighbour<br/>[MO-only] USING HNSW — vector index for approximate nearest neighbour<br/>[MO-only] USING MASTER — composite master index |
+| [CREATE INDEX USING HNSW](./SQL-Reference/Data-Definition-Language/create-index-hnsw.md) | 🟣 MatrixOne-only | [MO-only] CREATE INDEX … USING HNSW |
+| [CREATE INDEX USING IVFFLAT](./SQL-Reference/Data-Definition-Language/create-index-ivfflat.md) | 🟣 MatrixOne-only | [MO-only] CREATE INDEX … USING IVFFLAT |
+| [CREATE PITR](./SQL-Reference/Data-Definition-Language/create-pitr.md) | 🟣 MatrixOne-only | [MO-only] CREATE PITR … RANGE N {h\|d\|mo\|y} |
+| [CREATE PUBLICATION](./SQL-Reference/Data-Definition-Language/create-publication.md) | 🟣 MatrixOne-only | [MO-only] CREATE PUBLICATION |
+| [CREATE SEQUENCE](./SQL-Reference/Data-Definition-Language/create-sequence.md) | 🟣 MatrixOne-only | [MO-only] CREATE SEQUENCE (PostgreSQL-style) |
+| [CREATE SNAPSHOT](./SQL-Reference/Data-Definition-Language/create-snapshot.md) | 🟣 MatrixOne-only | [MO-only] CREATE SNAPSHOT FOR {ACCOUNT\|DATABASE\|TABLE\|CLUSTER} |
+| [CREATE SOURCE](./SQL-Reference/Data-Definition-Language/create-source.md) | 🟣 MatrixOne-only | [MO-only] CREATE SOURCE (stream/Kafka connector) |
+| [CREATE STAGE](./SQL-Reference/Data-Definition-Language/create-stage.md) | 🟣 MatrixOne-only | [MO-only] CREATE STAGE (external file-system binding) |
+| [CREATE TABLE](./SQL-Reference/Data-Definition-Language/create-table.md) | ⚠️ Partial | ENGINE= clause is syntactically accepted but ignored; MatrixOne uses TAE exclusively<br/>Spatial type names (GEOMETRY, POINT, etc.) are syntactically accepted but non-functional; MEDIUMINT is syntactically accepted but treated as INT<br/>BOOL is a native boolean type, not an INT alias as in MySQL<br/>AUTO_INCREMENT step is always 1; @@auto_increment_increment is syntactically accepted but inert<br/>Partitioning accepts syntax but only HASH and KEY participate in partition pruning (RANGE/LIST/RANGE COLUMNS/LIST COLUMNS are syntax-only); subpartitioning causes an internal error; ADD/DROP/TRUNCATE PARTITION not supported<br/>CHECK constraints are syntactically accepted but not enforced; MySQL 8.0.16+ enforces them<br/>[MO-only] CLUSTER BY (col, …) — pre-sort columns to accelerate queries<br/>[MO-only] START TRANSACTION table option — non-standard table option with no MySQL 8.0 equivalent |
+| [CREATE TABLE ... LIKE](./SQL-Reference/Data-Definition-Language/create-table-like.md) | ✅ Full | — |
+| [CREATE TABLE AS SELECT](./SQL-Reference/Data-Definition-Language/create-table-as-select.md) | ✅ Full | — |
+| [CREATE TASK (SQL Task)](./SQL-Reference/Data-Definition-Language/sql-task.md) | 🟣 MatrixOne-only | [MO-only] CREATE TASK / ALTER TASK / DROP TASK / EXECUTE TASK / SHOW TASKS (MO-specific scheduled SQL tasks; MySQL uses CREATE EVENT instead) |
+| [CREATE VIEW](./SQL-Reference/Data-Definition-Language/create-view.md) | ⚠️ Partial | WITH CHECK OPTION is syntactically accepted but not enforced<br/>Views are read-only; MySQL 8.0 supports INSERT/UPDATE/DELETE through views that meet updatability criteria |
+| [CREATE...FROM...PUBLICATION...](./SQL-Reference/Data-Definition-Language/create-subscription.md) | 🟣 MatrixOne-only | [MO-only] CREATE DATABASE … FROM … PUBLICATION … |
+| [DATA BRANCH CREATE](./SQL-Reference/Data-Definition-Language/data-branch-create-en.md) | 🟣 MatrixOne-only | [MO-only] DATA BRANCH CREATE (Git-for-Data) |
+| [DATA BRANCH DELETE](./SQL-Reference/Data-Definition-Language/data-branch-delete-en.md) | 🟣 MatrixOne-only | [MO-only] DATA BRANCH DELETE |
+| [DATA BRANCH DIFF](./SQL-Reference/Data-Definition-Language/data-branch-diff-en.md) | 🟣 MatrixOne-only | [MO-only] DATA BRANCH DIFF |
+| [DATA BRANCH MERGE](./SQL-Reference/Data-Definition-Language/data-branch-merge-en.md) | 🟣 MatrixOne-only | [MO-only] DATA BRANCH MERGE |
+| [DATA BRANCH PICK](./SQL-Reference/Data-Definition-Language/data-branch-pick.md) | 🟣 MatrixOne-only | [MO-only] DATA BRANCH PICK (cherry-pick specific rows between branch tables, Git-for-Data feature) |
+| [DROP DATABASE](./SQL-Reference/Data-Definition-Language/drop-database.md) | ✅ Full | — |
+| [DROP FUNCTION](./SQL-Reference/Data-Definition-Language/drop-function.md) | ⚠️ Partial | Drops MatrixOne-style SQL / Python functions, not MySQL stored procedures/functions<br/>Requires argument type list on DROP (e.g. DROP FUNCTION py_add(int, int)); MySQL 8.0 accepts only the function name |
+| [DROP INDEX](./SQL-Reference/Data-Definition-Language/drop-index.md) | ⚠️ Partial | MO accepts DROP INDEX IF EXISTS syntax (MySQL 8.0 does not), but IF EXISTS does not suppress errors for missing indexes; it returns internal error 20101 instead of a silent skip |
+| [DROP PITR](./SQL-Reference/Data-Definition-Language/drop-pitr.md) | 🟣 MatrixOne-only | [MO-only] DROP PITR |
+| [DROP PUBLICATION](./SQL-Reference/Data-Definition-Language/drop-publication.md) | 🟣 MatrixOne-only | [MO-only] DROP PUBLICATION |
+| [DROP SEQUENCE](./SQL-Reference/Data-Definition-Language/drop-sequence.md) | 🟣 MatrixOne-only | [MO-only] DROP SEQUENCE |
+| [DROP SNAPSHOT](./SQL-Reference/Data-Definition-Language/drop-snapshot.md) | 🟣 MatrixOne-only | [MO-only] DROP SNAPSHOT |
+| [DROP STAGE](./SQL-Reference/Data-Definition-Language/drop-stage.md) | 🟣 MatrixOne-only | [MO-only] DROP STAGE |
+| [DROP TABLE](./SQL-Reference/Data-Definition-Language/drop-table.md) | ✅ Full | — |
+| [DROP VIEW](./SQL-Reference/Data-Definition-Language/drop-view.md) | ⚠️ Partial | MO does not support dropping multiple views in a single statement; only a single view per DROP VIEW. MySQL 8.0 supports dropping multiple views (e.g., DROP VIEW v1, v2). |
+| [Rename Table](./SQL-Reference/Data-Definition-Language/rename-table.md) | ⚠️ Partial | MO does not support RENAME TABLE across databases; when given cross-database syntax, MO renames the table within its current database instead of raising an error. MySQL 8.0 supports cross-database RENAME TABLE. |
+| [RESTORE ... FROM PITR](./SQL-Reference/Data-Definition-Language/restore-pitr.md) | 🟣 MatrixOne-only | [MO-only] RESTORE … FROM PITR |
+| [RESTORE ... SNAPSHOT](./SQL-Reference/Data-Definition-Language/restore-snapshot.md) | 🟣 MatrixOne-only | [MO-only] RESTORE … FROM SNAPSHOT |
+| [TRUNCATE TABLE](./SQL-Reference/Data-Definition-Language/truncate-table.md) | ✅ Full | — |
 
-## Data Control Language (DCL)
+### Data Manipulation Language (DML)
 
-| Statement | MySQL Compat | Differences from MySQL | MatrixOne-only |
-|---|---|---|---|
-| [ALTER ACCOUNT](./SQL-Reference/Data-Control-Language/alter-account.md) | 🟣 MatrixOne-only | — | ALTER ACCOUNT |
-| [ALTER USER](./SQL-Reference/Data-Control-Language/alter-user.md) | ⚠️ Partial | Only ALTER USER can change passwords; account-limit clauses not honoured<br/>Password management options (PASSWORD EXPIRE, PASSWORD HISTORY, PASSWORD REUSE INTERVAL, PASSWORD REQUIRE CURRENT, FAILED_LOGIN_ATTEMPTS, PASSWORD_LOCK_TIME) not supported<br/>Account locking (ACCOUNT LOCK/UNLOCK) not supported<br/>REQUIRE clause (TLS/SSL enforcement) not supported<br/>COMMENT and ATTRIBUTE modification not supported<br/>Multiple users per statement not supported (MySQL 8.0 allows user [, user] ...) | — |
-| [CREATE ACCOUNT](./SQL-Reference/Data-Control-Language/create-account.md) | 🟣 MatrixOne-only | — | CREATE ACCOUNT … ADMIN_NAME … |
-| [CREATE ROLE](./SQL-Reference/Data-Control-Language/create-role.md) | ⚠️ Partial | Role exists inside MatrixOne's multi-account model; roles are account-scoped, not server-global as in MySQL. | — |
-| [CREATE USER](./SQL-Reference/Data-Control-Language/create-user.md) | ⚠️ Partial | IDENTIFIED BY is the only supported password form; IDENTIFIED WITH plugins not supported<br/>Connection-IP whitelists and connection-limit clauses not supported<br/>COMMENT and ATTRIBUTE clauses not supported<br/>'user'@'host' syntax is accepted and host is stored in mo_catalog.mo_user.user_host but may not restrict connections; users are scoped to the current account, not server-global as in MySQL<br/>Password management options (PASSWORD EXPIRE, PASSWORD HISTORY, PASSWORD REUSE INTERVAL, PASSWORD REQUIRE CURRENT) not supported<br/>Account locking (ACCOUNT LOCK/UNLOCK) not supported<br/>REQUIRE clause (TLS/SSL enforcement) not supported | — |
-| [DROP ACCOUNT](./SQL-Reference/Data-Control-Language/drop-account.md) | 🟣 MatrixOne-only | — | DROP ACCOUNT |
-| [DROP ROLE](./SQL-Reference/Data-Control-Language/drop-role.md) | ⚠️ Partial | Role exists inside MatrixOne's multi-account model; roles are account-scoped, not server-global as in MySQL. | — |
-| [DROP USER](./SQL-Reference/Data-Control-Language/drop-user.md) | ⚠️ Partial | User identifier is a bare username scoped to the current account; MySQL uses 'user'@'host' tuples. | — |
-| [GRANT](./SQL-Reference/Data-Control-Language/grant.md) | ⚠️ Partial | Authorization logic differs from MySQL — MatrixOne evaluates via its role/account model<br/>User identifier is a bare username scoped to the current account; MySQL uses 'user'@'host' tuples<br/>AS user [WITH ROLE ...] clause (MySQL 8.0 privilege restriction) not supported<br/>GRANT privilege ... TO only accepts roles; users receive privileges indirectly through role membership (GRANT role TO user)<br/>WITH ADMIN OPTION for role grants is not supported | `GRANT ... ON ACCOUNT *` — account-level privileges have no MySQL counterpart<br/>`GRANT ... ON DATABASE *` — MatrixOne-specific database-level grant target<br/>GRANT ... ON VIEW db_name.view_name (separate VIEW object_type; MySQL 8.0 only supports TABLE, FUNCTION, PROCEDURE) |
-| [REVOKE](./SQL-Reference/Data-Control-Language/revoke.md) | ⚠️ Partial | Recovery logic differs from MySQL — privileges return to the role/account graph<br/>User identifier is a bare username scoped to the current account; MySQL uses 'user'@'host' tuples<br/>IGNORE UNKNOWN USER clause (MySQL 8.0.30+) not supported | `REVOKE ... ON ACCOUNT *` — account-level privileges have no MySQL counterpart<br/>`REVOKE ... ON DATABASE *` — MatrixOne-specific database-level revoke target<br/>REVOKE ... ON VIEW db_name.view_name (separate VIEW object_type) |
-| [Role Rewrite Rules (ALTER ROLE ... RULE / SHOW RULES)](./SQL-Reference/Data-Control-Language/role-rule.md) | 🟣 MatrixOne-only | — | — |
+| Statement | MySQL Compat | Notes |
+|---|---|---|
+| [CASE](./SQL-Reference/Data-Manipulation-Language/case.md) | ✅ Full | This page describes the CASE operator (expression), not the stored-program CASE statement. MatrixOne does not support stored programs, so the stored-program CASE STATEMENT is unavailable; the CASE OPERATOR behaves compatibly. |
+| [CURRENT_ROLE()](./SQL-Reference/Data-Manipulation-Language/information-functions/current_role.md) | ⚠️ Partial | Returns a single active role name; MySQL 8.0 can return multiple comma-separated active roles or 'NONE'. |
+| [DELETE](./SQL-Reference/Data-Manipulation-Language/delete.md) | ⚠️ Partial | LOW_PRIORITY, QUICK, IGNORE modifiers are syntactically accepted but have no effect<br/>PARTITION clause not supported |
+| [INSERT](./SQL-Reference/Data-Manipulation-Language/insert.md) | ⚠️ Partial | Modifiers LOW_PRIORITY / DELAYED / HIGH_PRIORITY not supported<br/>PARTITION clause not supported |
+| [INSERT ... ON DUPLICATE KEY UPDATE](./SQL-Reference/Data-Manipulation-Language/upsert/insert-on-duplicate.md) | ⚠️ Partial | ON DUPLICATE KEY UPDATE only triggers on PRIMARY KEY conflicts; UNIQUE index conflicts are detected but result in errors (ERROR 1062 or ERROR 20102) rather than triggering ON DUPLICATE KEY UPDATE |
+| [INSERT IGNORE](./SQL-Reference/Data-Manipulation-Language/upsert/insert-ignore.md) | ⚠️ Partial | LOW_PRIORITY / DELAYED / HIGH_PRIORITY modifiers not supported<br/>Duplicates are silently ignored; MySQL emits a warning for each skipped row.<br/>Does not ignore NULL-into-NOT-NULL, type-conversion, or partition-mismatch errors as MySQL does.<br/>PARTITION clause not supported |
+| [INSERT INTO SELECT](./SQL-Reference/Data-Manipulation-Language/insert-into-select.md) | ✅ Full | — |
+| [LAST_INSERT_ID()](./SQL-Reference/Data-Manipulation-Language/information-functions/last-insert-id.md) | ⚠️ Partial | Multi-row INSERT returns the last inserted auto-increment value; MySQL returns the first inserted value. |
+| [LAST_QUERY_ID](./SQL-Reference/Data-Manipulation-Language/information-functions/last-query-id.md) | 🟣 MatrixOne-only | [MO-only] LAST_QUERY_ID() |
+| [LOAD DATA](./SQL-Reference/Data-Manipulation-Language/load-data-infile.md) | ⚠️ Partial | SET clause only accepts columns_name = nullif(expr1, expr2)<br/>JSONLines import uses MatrixOne-specific syntax<br/>Object-storage import (S3/URL) uses MatrixOne-specific syntax<br/>LOW_PRIORITY and CONCURRENT modifiers not supported<br/>REPLACE and IGNORE modifiers not supported<br/>[MO-only] PARALLEL clause (controls parallel file loading)<br/>[MO-only] STRICT clause (controls parallel splitting mode) |
+| [LOAD DATA INLINE](./SQL-Reference/Data-Manipulation-Language/load-data-inline.md) | 🟣 MatrixOne-only | [MO-only] LOAD DATA INLINE (stage-sourced import) |
+| [REPLACE](./SQL-Reference/Data-Manipulation-Language/replace.md) | ⚠️ Partial | node-sql-parser rejects REPLACE … WHERE (parser bug, not MatrixOne)<br/>PARTITION clause not supported<br/>LOW_PRIORITY and DELAYED modifiers not supported<br/>REPLACE only detects conflicts on PRIMARY KEY; secondary UNIQUE index conflicts throw ERROR 1062 (MySQL 8.0 handles both). Constraints section incorrectly states UNIQUE index can also trigger REPLACE; this is wrong per actual MO behavior. |
+| [REPLACE](./SQL-Reference/Data-Manipulation-Language/upsert/replace.md) | ⚠️ Partial | node-sql-parser rejects REPLACE … WHERE (parser bug, not MatrixOne)<br/>PARTITION clause not supported<br/>LOW_PRIORITY and DELAYED modifiers not supported<br/>REPLACE only detects conflicts on PRIMARY KEY; secondary UNIQUE index conflicts throw ERROR 1062 (MySQL 8.0 handles both). Constraints section incorrectly states UNIQUE index can also trigger REPLACE; this is wrong per actual MO behavior. |
+| [UPDATE](./SQL-Reference/Data-Manipulation-Language/update.md) | ⚠️ Partial | LOW_PRIORITY and IGNORE modifiers are syntactically accepted but have no effect<br/>PARTITION clause not supported |
+| [UPSERT](./SQL-Reference/Data-Manipulation-Language/upsert/upsert.md) | ⚠️ Partial | INSERT IGNORE does not suppress NOT NULL or type-conversion errors (MySQL 8.0 does)<br/>INSERT ON DUPLICATE KEY UPDATE only triggers on PRIMARY KEY conflicts; UNIQUE index conflicts are detected but result in errors (ERROR 1062 or ERROR 20102) rather than triggering ON DUPLICATE KEY UPDATE<br/>REPLACE does not support REPLACE ... WHERE (parser bug) |
 
-## Other
+### Data Query Language (DQL)
 
-| Statement | MySQL Compat | Differences from MySQL | MatrixOne-only |
-|---|---|---|---|
-| [DEALLOCATE PREPARE](./SQL-Reference/Other/Prepared-Statements/deallocate.md) | ⚠️ Partial | DEALLOCATE PREPARE on a non-existent statement silently succeeds; MySQL returns ERROR 1243 (Unknown prepared statement handler). | — |
-| [DESCRIBE / DESC](./SQL-Reference/Other/describe.md) | ⚠️ Partial | DESCRIBE/DESC output includes an extra `Comment` column (7 columns total vs MySQL's 6).<br/>Type names are displayed in uppercase with display widths (e.g., `INT(32)`, `FLOAT(0)`, `TIMESTAMP(0)`) instead of MySQL's lowercase without widths (e.g., `int`, `float`, `timestamp`).<br/>Column name filter (`DESC tbl_name col_name`) is non-functional; all columns are returned.<br/>Wild pattern (`DESC tbl_name 'pattern'`) not supported; produces syntax error.<br/>For TIMESTAMP columns with DEFAULT CURRENT_TIMESTAMP, MO does not show `DEFAULT_GENERATED` in the Extra column as MySQL does. | — |
-| [EXECUTE](./SQL-Reference/Other/Prepared-Statements/execute.md) | ✅ Full | — | — |
-| [EXPLAIN](./SQL-Reference/Other/Explain/explain.md) | ⚠️ Partial | Output format is a single QUERY PLAN column with tree-structured text (PostgreSQL-style); MySQL uses a multi-column tabular format with id, select_type, table, partitions, type, possible_keys, key, key_len, ref, rows, filtered, Extra<br/>JSON output (FORMAT=JSON) not supported; MO returns syntax error<br/>FORMAT=TREE and FORMAT=TRADITIONAL not supported; FORMAT=TEXT bare keyword also errors; only bare keyword forms (EXPLAIN, EXPLAIN ANALYZE, EXPLAIN VERBOSE) work<br/>EXPLAIN FOR CONNECTION not supported (returns internal error)<br/>EXPLAIN (ANALYZE TRUE/FALSE) and EXPLAIN (VERBOSE TRUE/FALSE) parenthesized boolean syntax WORKS in MO 3.0.12, contrary to doc claims; only parenthesized FORMAT syntax is unsupported | — |
-| [EXPLAIN Output Format](./SQL-Reference/Other/Explain/explain-workflow.md) | ⚠️ Partial | Output is a single QUERY PLAN column with tree-structured text; MySQL uses multi-column tabular EXPLAIN format<br/>JSON output not supported<br/>Node types (Sink, Sink Scan, PreInsert, Fuzzy Filter, etc.) are MO-specific and have no MySQL equivalent | — |
-| [EXPLAIN PREPARED](./SQL-Reference/Other/Explain/explain-prepared.md) | 🟣 MatrixOne-only | — | EXPLAIN FORCE EXECUTE stmt_name [USING @var] is a MatrixOne extension; MySQL explains prepared statements through EXPLAIN FOR CONNECTION. |
-| [Get information with EXPLAIN ANALYZE](./SQL-Reference/Other/Explain/explain-analyze.md) | ⚠️ Partial | Output format mirrors PostgreSQL (QUERY PLAN tree with Analyze sub-lines showing timeConsumed, waitTime, inputRows, outputRows, InputSize, OutputSize, MemorySize); MySQL 8.0 EXPLAIN ANALYZE uses TREE format with cost estimation and actual time in a different structure<br/>JSON output not supported<br/>MO EXPLAIN ANALYZE produces one output row per plan tree line; MySQL produces a single row with the full plan | — |
-| [KILL](./SQL-Reference/Other/kill.md) | ✅ Full | — | — |
-| [PREPARE](./SQL-Reference/Other/Prepared-Statements/prepare.md) | ⚠️ Partial | MatrixOne cannot PREPARE SET, DO, or other TCL/DCL statements<br/>Repreparation on parameter type change may throw a cast error instead of silently converting the value (e.g., passing a string to an integer parameter). | — |
-| [SET ROLE](./SQL-Reference/Other/Set/set-role.md) | ⚠️ Partial | Accepts a single role name only; MySQL 8.0 also supports NONE, DEFAULT, ALL, ALL EXCEPT role_list, and role lists. | SET SECONDARY ROLE {NONE \| ALL} — MatrixOne-only primary/secondary role model. |
-| [SHOW ACCOUNTS](./SQL-Reference/Other/SHOW-Statements/show-account.md) | 🟣 MatrixOne-only | — | SHOW ACCOUNTS |
-| [SHOW COLLATION](./SQL-Reference/Other/SHOW-Statements/show-collation.md) | ⚠️ Partial | Only utf8mb4_bin is effective; other collations appear but are inert<br/>MO 3.0.12 returns 11 collations (with `Default` and `Pad_attribute` columns); older doc examples show only 1 row with 5 columns<br/>Output columns (Collation, Charset, Id, Default, Compiled, Sortlen, Pad_attribute) differ slightly from MySQL which also includes Pad_attribute | — |
-| [SHOW COLUMNS](./SQL-Reference/Other/SHOW-Statements/show-columns.md) | ⚠️ Partial | MO SHOW COLUMNS (without FULL) already includes the `Comment` column; MySQL only shows Comment with FULL<br/>MO SHOW FULL COLUMNS returns Collation and Privileges columns but Collation is always NULL<br/>MO accepts EXTENDED keyword (SHOW EXTENDED COLUMNS) and FIELDS synonym (SHOW FIELDS), both returning same columns as SHOW COLUMNS<br/>MO Type column includes display width (e.g. INT(32)) while MySQL shows just int | — |
-| [SHOW CREATE DATABASE](./SQL-Reference/Other/SHOW-Statements/show-create-database.md) | ⚠️ Partial | Output omits CHARACTER SET, COLLATE, and ENCRYPTION clauses present in MySQL 8.0 SHOW CREATE DATABASE output | — |
-| [SHOW CREATE PUBLICATION](./SQL-Reference/Other/SHOW-Statements/show-create-publication.md) | 🟣 MatrixOne-only | — | SHOW CREATE PUBLICATION |
-| [SHOW CREATE TABLE](./SQL-Reference/Other/SHOW-Statements/show-create-table.md) | ⚠️ Partial | Output reflects MatrixOne-specific extensions (CLUSTER BY, USING IVFFLAT/HNSW, etc.)<br/>MO output omits ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci appended by MySQL | — |
-| [SHOW CREATE VIEW](./SQL-Reference/Other/SHOW-Statements/show-create-view.md) | ⚠️ Partial | DEFINER = user clause absent from output; SQL SECURITY {DEFINER\|INVOKER} is emitted<br/>MO output lacks ALGORITHM=UNDEFINED clause that MySQL always includes<br/>MO does not fully qualify column references (MySQL outputs db.table.col AS alias)<br/>MO uses unquoted identifiers; MySQL backtick-quotes database, table, and column names<br/>The rendered Create View output shows `CREATE SQL SECURITY DEFINER VIEW` (not `CREATE ALGORITHM=UNDEFINED DEFINER=user SQL SECURITY DEFINER VIEW` as MySQL does) | — |
-| [SHOW DATABASES](./SQL-Reference/Other/SHOW-Statements/show-databases.md) | ✅ Full | — | — |
-| [SHOW FUNCTION STATUS](./SQL-Reference/Other/SHOW-Statements/show-function-status.md) | ⚠️ Partial | Lists MatrixOne SQL/Python functions; MySQL shows stored routines AND built-in sys schema functions (e.g. extract_schema_from_file_name, format_bytes)<br/>MO only shows user-defined functions; MySQL shows all functions including built-in ones | — |
-| [SHOW GRANTS](./SQL-Reference/Other/SHOW-Statements/show-grants.md) | ⚠️ Partial | Grant syntax output is completely different: MO uses MO-specific format (GRANT create account ON account, GRANT table all ON table) instead of MySQL standard format (GRANT SELECT, INSERT, UPDATE, DELETE ON *.*)<br/>MO output includes backtick-quoted user@host inside grant statements; MySQL uses quoted user@host format with TO clause<br/>USING role_list clause not supported<br/>MO does not support SHOW GRANTS FOR CURRENT_USER (or CURRENT_USER()) as a shorthand for the current user | — |
-| [SHOW INDEX](./SQL-Reference/Other/SHOW-Statements/show-index.md) | ⚠️ Partial | Reflects MatrixOne index model — secondary index rows appear but may not accelerate queries<br/>Index_type may be empty (MySQL typically shows BTREE)<br/>Index_comment column is present (MySQL 8.0 also has Index_comment; difference is minor)<br/>Index_params column is present (MySQL does not have this column)<br/>Expression column shows the column name for non-functional key parts; MySQL shows NULL for non-functional key parts<br/>MO SHOW INDEX returns 16 columns vs MySQL 15 columns (MO adds Index_params, lacks the extra Collation behavior) | — |
-| [SHOW PITR](./SQL-Reference/Other/SHOW-Statements/show-pitrs.md) | 🟣 MatrixOne-only | — | SHOW PITR |
-| [SHOW PROCESSLIST](./SQL-Reference/Other/SHOW-Statements/show-processlist.md) | ⚠️ Partial | MO returns 19 columns (node_id, conn_id, session_id, account, user, host, db, session_start, command, info, txn_id, statement_id, statement_type, query_type, sql_source_type, query_start, client_host, role, proxy_host) vs MySQL 8 columns (Id, User, Host, db, Command, Time, State, Info)<br/>MO column names differ completely: conn_id vs Id, session_start vs Time, no State column, MO adds txn_id/statement_id/statement_type/query_type/sql_source_type/query_start/client_host/role/proxy_host<br/>SHOW FULL PROCESSLIST is accepted by MO but returns same columns as SHOW PROCESSLIST (no behavioral difference) | — |
-| [SHOW PUBLICATIONS](./SQL-Reference/Other/SHOW-Statements/show-publications.md) | 🟣 MatrixOne-only | — | SHOW PUBLICATIONS |
-| [SHOW ROLES](./SQL-Reference/Other/SHOW-Statements/show-roles.md) | 🟣 MatrixOne-only | — | SHOW ROLES |
-| [SHOW SEQUENCES](./SQL-Reference/Other/SHOW-Statements/show-sequences.md) | 🟣 MatrixOne-only | — | SHOW SEQUENCES |
-| [SHOW STAGES](./SQL-Reference/Other/SHOW-Statements/show-stage.md) | 🟣 MatrixOne-only | — | SHOW STAGES |
-| [SHOW SUBSCRIPTIONS](./SQL-Reference/Other/SHOW-Statements/show-subscriptions.md) | 🟣 MatrixOne-only | — | SHOW SUBSCRIPTIONS |
-| [SHOW TABLE STATUS](./SQL-Reference/Other/SHOW-Statements/show-table-status.md) | ⚠️ Partial | Result columns differ from MySQL: MO has 19 cols (adds Role_id, Role_name; omits Version); MySQL has 18 cols (includes Version; no Role_id/Role_name)<br/>Engine column always shows Tae instead of InnoDB<br/>MO's Auto_increment defaults to 0 (MySQL shows NULL for tables without auto-increment)<br/>MO shows views in SHOW TABLE STATUS with Engine=NULL and Comment=VIEW (same as MySQL behavior) | — |
-| [SHOW TABLES](./SQL-Reference/Other/SHOW-Statements/show-tables.md) | ⚠️ Partial | Output column header uses lowercase database name (Tables_in_<db> vs MySQL's Tables_in_<DB>)<br/>MO does not display a parenthesized LIKE pattern in the column header unlike MySQL | — |
-| [SHOW VARIABLES](./SQL-Reference/Other/SHOW-Statements/show-variables.md) | ⚠️ Partial | System variables are mostly syntactic stubs; actual behaviour differs from MySQL<br/>GLOBAL and SESSION scope modifiers are syntactically accepted for both SET and SHOW; SHOW GLOBAL vs SHOW SESSION return different values when SESSION has been overridden, same as MySQL<br/>MO has a completely different set of variable names (e.g. testbotchvar_nodyn, testbothvar_dyn) alongside MySQL-compatible ones (autocommit, sql_mode)<br/>Variable values use lowercase ('on'/'off') while MySQL uses uppercase ('ON'/'OFF') | — |
-| [USE](./SQL-Reference/Other/use-database.md) | ✅ Full | — | — |
+| Statement | MySQL Compat | Notes |
+|---|---|---|
+| [BY RANK WITH OPTION](./SQL-Reference/Data-Query-Language/by-rank-with-option.md) | 🟣 MatrixOne-only | [MO-only] BY RANK WITH OPTION (IVF vector ranking) |
+| [Combining Queries (UNION, INTERSECT, MINUS)](./SQL-Reference/Data-Query-Language/union-intersect-minus-overview.md) | ⚠️ Partial | MINUS keyword is MO-specific; MySQL 8.0.31+ uses EXCEPT for the same set-difference semantics. MINUS ALL is not yet implemented in MO while MySQL 8.0.31+ supports EXCEPT ALL.<br/>INTERSECT was added in MySQL 8.0.31; both MO and MySQL support INTERSECT and INTERSECT ALL with matching semantics.<br/>UNION is standard across both, but MO's type coercion in UNION columns is stricter (errors on incompatible types where MySQL silently coerces).<br/>[MO-only] MINUS keyword (MO-specific syntax; MySQL 8.0.31+ offers equivalent EXCEPT) |
+| [Comparisons Using Subqueries](./SQL-Reference/Data-Query-Language/subqueries/comparisons-using-subqueries.md) | ✅ Full | — |
+| [CROSS APPLY](./SQL-Reference/Data-Query-Language/apply/cross-apply.md) | 🟣 MatrixOne-only | [MO-only] CROSS APPLY (SQL Server-style, not in MySQL) |
+| [CROSS JOIN](./SQL-Reference/Data-Query-Language/join/cross-join.md) | ✅ Full | — |
+| [Derived Tables](./SQL-Reference/Data-Query-Language/subqueries/derived-tables.md) | ⚠️ Partial | LATERAL derived tables are not supported in MO (MySQL 8.0.14+ supports LATERAL for correlated subqueries in FROM clause) |
+| [FULL JOIN](./SQL-Reference/Data-Query-Language/join/full-join.md) | ❌ None | FULL JOIN with ON clause produces different errors on MO (missing FROM-clause entry) vs MySQL 8.0 (Unknown column in ON clause). FULL JOIN with USING returns INNER JOIN results on both (neither returns unmatched rows). FULL OUTER JOIN produces a syntax error on both. MySQL 8.0 does not natively support either FULL JOIN or FULL OUTER JOIN. |
+| [INNER JOIN](./SQL-Reference/Data-Query-Language/join/inner-join.md) | ✅ Full | — |
+| [INTERSECT](./SQL-Reference/Data-Query-Language/intersect.md) | ⚠️ Partial | INTERSECT was added in MySQL 8.0.31; MO INTERSECT and INTERSECT ALL semantics match MySQL 8.0 (both return identical results for common test cases including duplicate handling) |
+| [JOIN](./SQL-Reference/Data-Query-Language/join/join.md) | ⚠️ Partial | FULL JOIN and FULL OUTER JOIN are not fully supported (FULL JOIN with ON produces errors, FULL JOIN with USING returns INNER JOIN results, FULL OUTER JOIN is a syntax error); MySQL 8.0 also does not support FULL JOIN/OUTER JOIN natively |
+| [LEFT JOIN](./SQL-Reference/Data-Query-Language/join/left-join.md) | ✅ Full | — |
+| [MINUS](./SQL-Reference/Data-Query-Language/minus.md) | 🟣 MatrixOne-only | MINUS keyword is MO-specific; MySQL 8.0.31+ uses EXCEPT for the same set-difference semantics (MINUS is not a recognized keyword in MySQL)<br/>MINUS ALL is not yet implemented in MO; MySQL 8.0.31+ supports EXCEPT ALL with full duplicate-preserving semantics<br/>[MO-only] MINUS keyword (MO's set-difference operator; MySQL 8.0.31+ offers equivalent functionality via EXCEPT) |
+| [NATURAL JOIN](./SQL-Reference/Data-Query-Language/join/natural-join.md) | ✅ Full | — |
+| [OUTER APPLY](./SQL-Reference/Data-Query-Language/apply/outer-apply.md) | 🟣 MatrixOne-only | [MO-only] OUTER APPLY (SQL Server-style, not in MySQL) |
+| [OUTER JOIN](./SQL-Reference/Data-Query-Language/join/outer-join.md) | ⚠️ Partial | Overview page that includes FULL OUTER JOIN; neither MO nor MySQL 8.0 natively support FULL OUTER JOIN (MO produces syntax error, same as MySQL) |
+| [RIGHT JOIN](./SQL-Reference/Data-Query-Language/join/right-join.md) | ✅ Full | — |
+| [SELECT](./SQL-Reference/Data-Query-Language/select.md) | ⚠️ Partial | SELECT … FOR UPDATE only supports single-table queries<br/>SELECT INTO OUTFILE is only partially supported<br/>AS OF TIMESTAMP time-travel queries require PITR/snapshot to be enabled on the database; without PITR the syntax produces an error<br/>SELECT ... FOR SHARE is not supported<br/>FOR UPDATE NOWAIT and SKIP LOCKED modifiers are not supported<br/>GROUP BY ... WITH ROLLUP row ordering differs: MO places rollup summary rows at the top of the result set, while MySQL 8.0 places them at the bottom (standard MySQL grouping order)<br/>[MO-only] { AS OF TIMESTAMP 'YYYY-MM-DD HH:MM:SS' } — time-travel query against enabled snapshot/PITR<br/>[MO-only] ORDER BY ... NULLS { FIRST \| LAST } — PostgreSQL-style NULL ordering not available in MySQL |
+| [Subqueries with ALL](./SQL-Reference/Data-Query-Language/subqueries/subquery-with-all.md) | ✅ Full | — |
+| [Subqueries with ANY or SOME](./SQL-Reference/Data-Query-Language/subqueries/subquery-with-any-some.md) | ✅ Full | — |
+| [Subqueries with EXISTS or NOT EXISTS](./SQL-Reference/Data-Query-Language/subqueries/subquery-with-exists.md) | ✅ Full | — |
+| [Subqueries with IN](./SQL-Reference/Data-Query-Language/subqueries/subquery-with-in.md) | ✅ Full | — |
+| [SUBQUERY](./SQL-Reference/Data-Query-Language/subqueries/subquery.md) | ⚠️ Partial | Multi-column scalar subquery comparisons (e.g., WHERE (a,b) = (SELECT ...)) are not supported; use multi-column IN instead |
+| [UNION](./SQL-Reference/Data-Query-Language/union.md) | ⚠️ Partial | UNION type coercion is strict: MO errors on incompatible types in UNION columns (e.g., INT vs VARCHAR), while MySQL 8.0 silently coerces (e.g., varchar to int converts to 0)<br/>UNION ALL type coercion is similarly strict compared to MySQL 8.0's lenient coercion |
+| [WITH (Common Table Expressions)](./SQL-Reference/Data-Query-Language/with-cte.md) | ⚠️ Partial | Outer joins (LEFT JOIN, RIGHT JOIN, OUTER JOIN) are not allowed in recursive CTE members; MySQL 8.0 permits them except when the recursive CTE is on the right side of a LEFT JOIN (MySQL allows LEFT JOIN with CTE on the left side; MO rejects all outer joins in recursive CTEs regardless of position) |
 
-## Uncategorized
+### Other
 
-| Statement | MySQL Compat | Differences from MySQL | MatrixOne-only |
-|---|---|---|---|
-| [Type of SQL Statements](./SQL-Reference/SQL-Type.md) | 🟣 MatrixOne-only | — | Index page describing MatrixOne's own SQL statement taxonomy; not a MySQL-equivalent concept. |
+| Statement | MySQL Compat | Notes |
+|---|---|---|
+| [DEALLOCATE PREPARE](./SQL-Reference/Other/Prepared-Statements/deallocate.md) | ⚠️ Partial | DEALLOCATE PREPARE on a non-existent statement silently succeeds; MySQL returns ERROR 1243 (Unknown prepared statement handler). |
+| [DESCRIBE / DESC](./SQL-Reference/Other/describe.md) | ⚠️ Partial | DESCRIBE/DESC output includes an extra `Comment` column (7 columns total vs MySQL's 6).<br/>Type names are displayed in uppercase with display widths (e.g., `INT(32)`, `FLOAT(0)`, `TIMESTAMP(0)`) instead of MySQL's lowercase without widths (e.g., `int`, `float`, `timestamp`).<br/>Column name filter (`DESC tbl_name col_name`) is non-functional; all columns are returned.<br/>Wild pattern (`DESC tbl_name 'pattern'`) not supported; produces syntax error.<br/>For TIMESTAMP columns with DEFAULT CURRENT_TIMESTAMP, MO does not show `DEFAULT_GENERATED` in the Extra column as MySQL does. |
+| [EXECUTE](./SQL-Reference/Other/Prepared-Statements/execute.md) | ✅ Full | — |
+| [EXPLAIN](./SQL-Reference/Other/Explain/explain.md) | ⚠️ Partial | Output format is a single QUERY PLAN column with tree-structured text (PostgreSQL-style); MySQL uses a multi-column tabular format with id, select_type, table, partitions, type, possible_keys, key, key_len, ref, rows, filtered, Extra<br/>JSON output (FORMAT=JSON) not supported; MO returns syntax error<br/>FORMAT=TREE and FORMAT=TRADITIONAL not supported; FORMAT=TEXT bare keyword also errors; only bare keyword forms (EXPLAIN, EXPLAIN ANALYZE, EXPLAIN VERBOSE) work<br/>EXPLAIN FOR CONNECTION not supported (returns internal error)<br/>EXPLAIN (ANALYZE TRUE/FALSE) and EXPLAIN (VERBOSE TRUE/FALSE) parenthesized boolean syntax WORKS in MO 3.0.12, contrary to doc claims; only parenthesized FORMAT syntax is unsupported |
+| [EXPLAIN Output Format](./SQL-Reference/Other/Explain/explain-workflow.md) | ⚠️ Partial | Output is a single QUERY PLAN column with tree-structured text; MySQL uses multi-column tabular EXPLAIN format<br/>JSON output not supported<br/>Node types (Sink, Sink Scan, PreInsert, Fuzzy Filter, etc.) are MO-specific and have no MySQL equivalent |
+| [EXPLAIN PREPARED](./SQL-Reference/Other/Explain/explain-prepared.md) | 🟣 MatrixOne-only | [MO-only] EXPLAIN FORCE EXECUTE stmt_name [USING @var] is a MatrixOne extension; MySQL explains prepared statements through EXPLAIN FOR CONNECTION. |
+| [Get information with EXPLAIN ANALYZE](./SQL-Reference/Other/Explain/explain-analyze.md) | ⚠️ Partial | Output format mirrors PostgreSQL (QUERY PLAN tree with Analyze sub-lines showing timeConsumed, waitTime, inputRows, outputRows, InputSize, OutputSize, MemorySize); MySQL 8.0 EXPLAIN ANALYZE uses TREE format with cost estimation and actual time in a different structure<br/>JSON output not supported<br/>MO EXPLAIN ANALYZE produces one output row per plan tree line; MySQL produces a single row with the full plan |
+| [KILL](./SQL-Reference/Other/kill.md) | ✅ Full | — |
+| [PREPARE](./SQL-Reference/Other/Prepared-Statements/prepare.md) | ⚠️ Partial | MatrixOne cannot PREPARE SET, DO, or other TCL/DCL statements<br/>Repreparation on parameter type change may throw a cast error instead of silently converting the value (e.g., passing a string to an integer parameter). |
+| [SET ROLE](./SQL-Reference/Other/Set/set-role.md) | ⚠️ Partial | Accepts a single role name only; MySQL 8.0 also supports NONE, DEFAULT, ALL, ALL EXCEPT role_list, and role lists.<br/>[MO-only] SET SECONDARY ROLE {NONE \| ALL} — MatrixOne-only primary/secondary role model. |
+| [SHOW ACCOUNTS](./SQL-Reference/Other/SHOW-Statements/show-account.md) | 🟣 MatrixOne-only | [MO-only] SHOW ACCOUNTS |
+| [SHOW COLLATION](./SQL-Reference/Other/SHOW-Statements/show-collation.md) | ⚠️ Partial | Only utf8mb4_bin is effective; other collations appear but are inert<br/>MO 3.0.12 returns 11 collations (with `Default` and `Pad_attribute` columns); older doc examples show only 1 row with 5 columns<br/>Output columns (Collation, Charset, Id, Default, Compiled, Sortlen, Pad_attribute) differ slightly from MySQL which also includes Pad_attribute |
+| [SHOW COLUMNS](./SQL-Reference/Other/SHOW-Statements/show-columns.md) | ⚠️ Partial | MO SHOW COLUMNS (without FULL) already includes the `Comment` column; MySQL only shows Comment with FULL<br/>MO SHOW FULL COLUMNS returns Collation and Privileges columns but Collation is always NULL<br/>MO accepts EXTENDED keyword (SHOW EXTENDED COLUMNS) and FIELDS synonym (SHOW FIELDS), both returning same columns as SHOW COLUMNS<br/>MO Type column includes display width (e.g. INT(32)) while MySQL shows just int |
+| [SHOW CREATE DATABASE](./SQL-Reference/Other/SHOW-Statements/show-create-database.md) | ⚠️ Partial | Output omits CHARACTER SET, COLLATE, and ENCRYPTION clauses present in MySQL 8.0 SHOW CREATE DATABASE output |
+| [SHOW CREATE PUBLICATION](./SQL-Reference/Other/SHOW-Statements/show-create-publication.md) | 🟣 MatrixOne-only | [MO-only] SHOW CREATE PUBLICATION |
+| [SHOW CREATE TABLE](./SQL-Reference/Other/SHOW-Statements/show-create-table.md) | ⚠️ Partial | Output reflects MatrixOne-specific extensions (CLUSTER BY, USING IVFFLAT/HNSW, etc.)<br/>MO output omits ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci appended by MySQL |
+| [SHOW CREATE VIEW](./SQL-Reference/Other/SHOW-Statements/show-create-view.md) | ⚠️ Partial | DEFINER = user clause absent from output; SQL SECURITY {DEFINER\|INVOKER} is emitted<br/>MO output lacks ALGORITHM=UNDEFINED clause that MySQL always includes<br/>MO does not fully qualify column references (MySQL outputs db.table.col AS alias)<br/>MO uses unquoted identifiers; MySQL backtick-quotes database, table, and column names<br/>The rendered Create View output shows `CREATE SQL SECURITY DEFINER VIEW` (not `CREATE ALGORITHM=UNDEFINED DEFINER=user SQL SECURITY DEFINER VIEW` as MySQL does) |
+| [SHOW DATABASES](./SQL-Reference/Other/SHOW-Statements/show-databases.md) | ✅ Full | — |
+| [SHOW FUNCTION STATUS](./SQL-Reference/Other/SHOW-Statements/show-function-status.md) | ⚠️ Partial | Lists MatrixOne SQL/Python functions; MySQL shows stored routines AND built-in sys schema functions (e.g. extract_schema_from_file_name, format_bytes)<br/>MO only shows user-defined functions; MySQL shows all functions including built-in ones |
+| [SHOW GRANTS](./SQL-Reference/Other/SHOW-Statements/show-grants.md) | ⚠️ Partial | Grant syntax output is completely different: MO uses MO-specific format (GRANT create account ON account, GRANT table all ON table) instead of MySQL standard format (GRANT SELECT, INSERT, UPDATE, DELETE ON *.*)<br/>MO output includes backtick-quoted user@host inside grant statements; MySQL uses quoted user@host format with TO clause<br/>USING role_list clause not supported<br/>MO does not support SHOW GRANTS FOR CURRENT_USER (or CURRENT_USER()) as a shorthand for the current user |
+| [SHOW INDEX](./SQL-Reference/Other/SHOW-Statements/show-index.md) | ⚠️ Partial | Reflects MatrixOne index model — secondary index rows appear but may not accelerate queries<br/>Index_type may be empty (MySQL typically shows BTREE)<br/>Index_comment column is present (MySQL 8.0 also has Index_comment; difference is minor)<br/>Index_params column is present (MySQL does not have this column)<br/>Expression column shows the column name for non-functional key parts; MySQL shows NULL for non-functional key parts<br/>MO SHOW INDEX returns 16 columns vs MySQL 15 columns (MO adds Index_params, lacks the extra Collation behavior) |
+| [SHOW PITR](./SQL-Reference/Other/SHOW-Statements/show-pitrs.md) | 🟣 MatrixOne-only | [MO-only] SHOW PITR |
+| [SHOW PROCESSLIST](./SQL-Reference/Other/SHOW-Statements/show-processlist.md) | ⚠️ Partial | MO returns 19 columns (node_id, conn_id, session_id, account, user, host, db, session_start, command, info, txn_id, statement_id, statement_type, query_type, sql_source_type, query_start, client_host, role, proxy_host) vs MySQL 8 columns (Id, User, Host, db, Command, Time, State, Info)<br/>MO column names differ completely: conn_id vs Id, session_start vs Time, no State column, MO adds txn_id/statement_id/statement_type/query_type/sql_source_type/query_start/client_host/role/proxy_host<br/>SHOW FULL PROCESSLIST is accepted by MO but returns same columns as SHOW PROCESSLIST (no behavioral difference) |
+| [SHOW PUBLICATIONS](./SQL-Reference/Other/SHOW-Statements/show-publications.md) | 🟣 MatrixOne-only | [MO-only] SHOW PUBLICATIONS |
+| [SHOW ROLES](./SQL-Reference/Other/SHOW-Statements/show-roles.md) | 🟣 MatrixOne-only | [MO-only] SHOW ROLES |
+| [SHOW SEQUENCES](./SQL-Reference/Other/SHOW-Statements/show-sequences.md) | 🟣 MatrixOne-only | [MO-only] SHOW SEQUENCES |
+| [SHOW STAGES](./SQL-Reference/Other/SHOW-Statements/show-stage.md) | 🟣 MatrixOne-only | [MO-only] SHOW STAGES |
+| [SHOW SUBSCRIPTIONS](./SQL-Reference/Other/SHOW-Statements/show-subscriptions.md) | 🟣 MatrixOne-only | [MO-only] SHOW SUBSCRIPTIONS |
+| [SHOW TABLE STATUS](./SQL-Reference/Other/SHOW-Statements/show-table-status.md) | ⚠️ Partial | Result columns differ from MySQL: MO has 19 cols (adds Role_id, Role_name; omits Version); MySQL has 18 cols (includes Version; no Role_id/Role_name)<br/>Engine column always shows Tae instead of InnoDB<br/>MO's Auto_increment defaults to 0 (MySQL shows NULL for tables without auto-increment)<br/>MO shows views in SHOW TABLE STATUS with Engine=NULL and Comment=VIEW (same as MySQL behavior) |
+| [SHOW TABLES](./SQL-Reference/Other/SHOW-Statements/show-tables.md) | ⚠️ Partial | Output column header uses lowercase database name (Tables_in_<db> vs MySQL's Tables_in_<DB>)<br/>MO does not display a parenthesized LIKE pattern in the column header unlike MySQL |
+| [SHOW VARIABLES](./SQL-Reference/Other/SHOW-Statements/show-variables.md) | ⚠️ Partial | System variables are mostly syntactic stubs; actual behaviour differs from MySQL<br/>GLOBAL and SESSION scope modifiers are syntactically accepted for both SET and SHOW; SHOW GLOBAL vs SHOW SESSION return different values when SESSION has been overridden, same as MySQL<br/>MO has a completely different set of variable names (e.g. testbotchvar_nodyn, testbothvar_dyn) alongside MySQL-compatible ones (autocommit, sql_mode)<br/>Variable values use lowercase ('on'/'off') while MySQL uses uppercase ('ON'/'OFF') |
+| [USE](./SQL-Reference/Other/use-database.md) | ✅ Full | — |
+
+## Functions
+
+| Status | Count |
+|---|---|
+| ✅ Full | 103 |
+| ⚠️ Partial | 26 |
+| 🟣 MatrixOne-only | 35 |
+| **Total** | **164** |
+
+### Functions
+
+| Function | MySQL Compat | Notes |
+|---|---|---|
+| [Summary table of functions](./Functions-and-Operators/matrixone-function-list.md) | 🟣 MatrixOne-only | [MO-only] Listing page (includes MatrixOne-only functions). |
+
+### Aggregate Functions
+
+| Function | MySQL Compat | Notes |
+|---|---|---|
+| [ANY_VALUE](./Functions-and-Operators/Aggregate-Functions/any-value.md) | ✅ Full | — |
+| [AVG](./Functions-and-Operators/Aggregate-Functions/avg.md) | ⚠️ Partial | AVG() returns DOUBLE for all input types (MySQL returns DECIMAL for exact-value types) |
+| [BIT_AND](./Functions-and-Operators/Aggregate-Functions/bit_and.md) | ✅ Full | — |
+| [BIT_OR](./Functions-and-Operators/Aggregate-Functions/bit_or.md) | ✅ Full | — |
+| [BIT_XOR](./Functions-and-Operators/Aggregate-Functions/bit_xor.md) | ✅ Full | — |
+| [BITMAP function](./Functions-and-Operators/Aggregate-Functions/bitmap.md) | 🟣 MatrixOne-only | [MO-only] BITMAP aggregates are MatrixOne extensions. |
+| [COUNT](./Functions-and-Operators/Aggregate-Functions/count.md) | ✅ Full | — |
+| [GROUP_CONCAT](./Functions-and-Operators/Aggregate-Functions/group-concat.md) | ✅ Full | — |
+| [MAX](./Functions-and-Operators/Aggregate-Functions/max.md) | ✅ Full | — |
+| [MEDIAN()](./Functions-and-Operators/Aggregate-Functions/median.md) | 🟣 MatrixOne-only | [MO-only] MEDIAN aggregate is a MatrixOne-specific aggregate (no native MySQL equivalent). |
+| [MIN](./Functions-and-Operators/Aggregate-Functions/min.md) | ✅ Full | — |
+| [STDDEV_POP](./Functions-and-Operators/Aggregate-Functions/stddev_pop.md) | ✅ Full | — |
+| [SUM](./Functions-and-Operators/Aggregate-Functions/sum.md) | ⚠️ Partial | SUM() returns the input integer type rather than DECIMAL for exact-value arguments (MySQL returns DECIMAL) |
+| [VAR_POP](./Functions-and-Operators/Aggregate-Functions/var_pop.md) | ✅ Full | — |
+| [VARIANCE](./Functions-and-Operators/Aggregate-Functions/variance.md) | ✅ Full | — |
+
+### Datetime
+
+| Function | MySQL Compat | Notes |
+|---|---|---|
+| [ADDTIME()](./Functions-and-Operators/Datetime/addtime.md) | ✅ Full | — |
+| [CONVERT_TZ()](./Functions-and-Operators/Datetime/convert-tz.md) | ✅ Full | — |
+| [CURDATE()](./Functions-and-Operators/Datetime/curdate.md) | ⚠️ Partial | curdate()+int returns days since 1970-01-01 rather than coercing both sides to integer and adding like MySQL. |
+| [CURRENT_TIMESTAMP()](./Functions-and-Operators/Datetime/current-timestamp.md) | ✅ Full | — |
+| [CURTIME()](./Functions-and-Operators/Datetime/curtime.md) | ✅ Full | — |
+| [DATE_ADD()](./Functions-and-Operators/Datetime/date-add.md) | ⚠️ Partial | Date literals accept only 'yyyy-mm-dd' and 'yyyymmdd' formats; MySQL accepts wider variants. |
+| [DATE_FORMAT()](./Functions-and-Operators/Datetime/date-format.md) | ⚠️ Partial | Date literals accept only 'yyyy-mm-dd' and 'yyyymmdd' formats; MySQL accepts wider variants. |
+| [DATE_SUB()](./Functions-and-Operators/Datetime/date-sub.md) | ⚠️ Partial | Date literals accept only 'yyyy-mm-dd' and 'yyyymmdd' formats; MySQL accepts wider variants. |
+| [DATE()](./Functions-and-Operators/Datetime/date.md) | ⚠️ Partial | Date literals accept only 'yyyy-mm-dd' and 'yyyymmdd' formats; MySQL accepts wider variants (yy-mm-dd, yy/mm/dd, yymmdd, etc.). |
+| [DATEDIFF()](./Functions-and-Operators/Datetime/datediff.md) | ✅ Full | — |
+| [DAY()](./Functions-and-Operators/Datetime/day.md) | ✅ Full | — |
+| [DAYOFYEAR()](./Functions-and-Operators/Datetime/dayofyear.md) | ✅ Full | — |
+| [EXTRACT()](./Functions-and-Operators/Datetime/extract.md) | ⚠️ Partial | Date literals accept only 'yyyy-mm-dd' and 'yyyymmdd' formats; MySQL accepts wider variants. |
+| [FROM_UNIXTIME()](./Functions-and-Operators/Datetime/from-unixtime.md) | ⚠️ Partial | Date literals accept only 'yyyy-mm-dd' and 'yyyymmdd' formats; MySQL accepts wider variants. |
+| [GET_FORMAT()](./Functions-and-Operators/Datetime/get-format.md) | ✅ Full | — |
+| [HOUR()](./Functions-and-Operators/Datetime/hour.md) | ✅ Full | — |
+| [MINUTE()](./Functions-and-Operators/Datetime/minute.md) | ✅ Full | — |
+| [MONTH()](./Functions-and-Operators/Datetime/month.md) | ✅ Full | — |
+| [NOW()](./Functions-and-Operators/Datetime/now.md) | ✅ Full | — |
+| [SECOND()](./Functions-and-Operators/Datetime/second.md) | ✅ Full | — |
+| [STR_TO_DATE()](./Functions-and-Operators/Datetime/str-to-date.md) | ✅ Full | — |
+| [SUBTIME()](./Functions-and-Operators/Datetime/subtime.md) | ✅ Full | — |
+| [SYSDATE()](./Functions-and-Operators/Datetime/sysdate.md) | ✅ Full | — |
+| [TIME()](./Functions-and-Operators/Datetime/time.md) | ✅ Full | — |
+| [TIMEDIFF()](./Functions-and-Operators/Datetime/timediff.md) | ✅ Full | — |
+| [TIMESTAMP()](./Functions-and-Operators/Datetime/timestamp.md) | ⚠️ Partial | MatrixOne TIMESTAMP range is '0001-01-01'–'9999-12-31' vs MySQL '1970-01-01'–'2038-01-19' (compat doc: Data Types).<br/>Two-argument form TIMESTAMP(expr1, expr2) is not supported; MO only supports single-argument TIMESTAMP(expr) |
+| [TIMESTAMPADD()](./Functions-and-Operators/Datetime/timestampadd.md) | ✅ Full | — |
+| [TIMESTAMPDIFF()](./Functions-and-Operators/Datetime/timestampdiff.md) | ✅ Full | — |
+| [TO_DATE()](./Functions-and-Operators/Datetime/to-date.md) | 🟣 MatrixOne-only | [MO-only] TO_DATE is a MatrixOne alias for MySQL STR_TO_DATE (compat doc: Date and Time Functions). MySQL's own TO_DATE does not exist. |
+| [TO_DAYS()](./Functions-and-Operators/Datetime/to-days.md) | ⚠️ Partial | Two-digit year handling differs: MatrixOne completes '08-10-07' to year 0008; MySQL interprets it as 2008.<br/>Dates '0000-00-00' and '0000-01-01' raise an error in MatrixOne rather than being accepted as MySQL does. |
+| [TO_SECONDS()](./Functions-and-Operators/Datetime/to-seconds.md) | ⚠️ Partial | Two-digit year handling differs: MatrixOne completes '08-10-07' to year 0008; MySQL interprets it as 2008.<br/>Dates '0000-00-00' and '0000-01-01' raise an error in MatrixOne rather than being accepted as MySQL does. |
+| [UNIX_TIMESTAMP()](./Functions-and-Operators/Datetime/unix-timestamp.md) | ⚠️ Partial | Date literals accept only 'yyyy-mm-dd' and 'yyyymmdd' formats; MySQL accepts wider variants. |
+| [UTC_TIMESTAMP()](./Functions-and-Operators/Datetime/utc-timestamp.md) | ✅ Full | — |
+| [WEEK()](./Functions-and-Operators/Datetime/week.md) | ✅ Full | — |
+| [WEEKDAY()](./Functions-and-Operators/Datetime/weekday.md) | ✅ Full | — |
+| [YEAR()](./Functions-and-Operators/Datetime/year.md) | ⚠️ Partial | Date literals accept only 'yyyy-mm-dd' and 'yyyymmdd' formats; MySQL accepts wider variants.<br/>[MO-only] TOYEAR() is a MatrixOne alias for YEAR() with no MySQL counterpart. |
+| [YEARWEEK()](./Functions-and-Operators/Datetime/yearweek.md) | ✅ Full | — |
+
+### Json
+
+| Function | MySQL Compat | Notes |
+|---|---|---|
+| [JQ()](./Functions-and-Operators/Json/jq.md) | 🟣 MatrixOne-only | [MO-only] MatrixOne integration of the jq JSON query language; no MySQL equivalent. |
+| [JSON Arrow Operators -> and ->>](./Functions-and-Operators/Json/json-arrow.md) | ✅ Full | — |
+| [JSON_EXTRACT_FLOAT64()](./Functions-and-Operators/Json/json_extract_float64.md) | 🟣 MatrixOne-only | [MO-only] MatrixOne convenience wrapper returning FLOAT64 directly. |
+| [JSON_EXTRACT_STRING()](./Functions-and-Operators/Json/json_extract_string.md) | 🟣 MatrixOne-only | [MO-only] MatrixOne convenience wrapper returning a string result directly. |
+| [JSON_EXTRACT()](./Functions-and-Operators/Json/json_extract.md) | ✅ Full | — |
+| [JSON_QUOTE()](./Functions-and-Operators/Json/json_quote.md) | ✅ Full | — |
+| [JSON_ROW()](./Functions-and-Operators/Json/json_row.md) | 🟣 MatrixOne-only | [MO-only] MatrixOne-only; no MySQL equivalent. |
+| [JSON_SET()](./Functions-and-Operators/Json/json_set.md) | ✅ Full | — |
+| [JSON_UNQUOTE()](./Functions-and-Operators/Json/json_unquote.md) | ✅ Full | — |
+| [TRY_JQ()](./Functions-and-Operators/Json/try_jq.md) | 🟣 MatrixOne-only | [MO-only] MatrixOne integration of the jq JSON query language; no MySQL equivalent. |
+
+### Mathematical
+
+| Function | MySQL Compat | Notes |
+|---|---|---|
+| [ABS()](./Functions-and-Operators/Mathematical/abs.md) | ✅ Full | — |
+| [ACOS()](./Functions-and-Operators/Mathematical/acos.md) | ✅ Full | — |
+| [ATAN()](./Functions-and-Operators/Mathematical/atan.md) | ✅ Full | — |
+| [CEIL()](./Functions-and-Operators/Mathematical/ceil.md) | ✅ Full | — |
+| [CEILING()](./Functions-and-Operators/Mathematical/ceiling.md) | ✅ Full | — |
+| [COS()](./Functions-and-Operators/Mathematical/cos.md) | ✅ Full | — |
+| [COT()](./Functions-and-Operators/Mathematical/cot.md) | ✅ Full | — |
+| [CRC32()](./Functions-and-Operators/Mathematical/crc32.md) | ✅ Full | — |
+| [EXP()](./Functions-and-Operators/Mathematical/exp.md) | ✅ Full | — |
+| [FLOOR()](./Functions-and-Operators/Mathematical/floor.md) | ⚠️ Partial | MatrixOne supports an optional second decimals argument (FLOOR(number, decimals)) to specify decimal places; MySQL 8.0 only supports the single-argument form FLOOR(X)<br/>[MO-only] Two-argument form FLOOR(number, decimals) to specify decimal places |
+| [LN()](./Functions-and-Operators/Mathematical/ln.md) | ✅ Full | — |
+| [LOG()](./Functions-and-Operators/Mathematical/log.md) | ✅ Full | — |
+| [LOG10()](./Functions-and-Operators/Mathematical/log10.md) | ✅ Full | — |
+| [LOG2()](./Functions-and-Operators/Mathematical/log2.md) | ✅ Full | — |
+| [PI()](./Functions-and-Operators/Mathematical/pi.md) | ✅ Full | — |
+| [POWER()](./Functions-and-Operators/Mathematical/power.md) | ✅ Full | — |
+| [RAND()](./Functions-and-Operators/Mathematical/rand.md) | ⚠️ Partial | RAND(seed) is not supported; calling RAND(N) with an integer argument produces ERROR 20203 |
+| [ROUND()](./Functions-and-Operators/Mathematical/round.md) | ✅ Full | — |
+| [SIN()](./Functions-and-Operators/Mathematical/sin.md) | ✅ Full | — |
+| [SINH()](./Functions-and-Operators/Mathematical/sinh.md) | 🟣 MatrixOne-only | [MO-only] MySQL 8.0 has no hyperbolic trigonometric functions; SINH() is a MatrixOne extension. |
+| [TAN()](./Functions-and-Operators/Mathematical/tan.md) | ✅ Full | — |
+
+### Other
+
+| Function | MySQL Compat | Notes |
+|---|---|---|
+| [LOAD_FILE()](./Functions-and-Operators/Other/load_file.md) | ⚠️ Partial | LOAD_FILE() takes a DATALINK value (file:// or stage:// URL) rather than MySQL's plain filesystem path argument |
+| [SAMPLE Sampling Function](./Functions-and-Operators/Other/sample.md) | 🟣 MatrixOne-only | [MO-only] SAMPLE() is a MatrixOne sampling operator; no MySQL equivalent. |
+| [SAVE_FILE()](./Functions-and-Operators/Other/save_file.md) | 🟣 MatrixOne-only | [MO-only] SAVE_FILE() writes to a MatrixOne stage; no MySQL equivalent. |
+| [SERIAL_EXTRACT function](./Functions-and-Operators/Other/serial_extract.md) | 🟣 MatrixOne-only | [MO-only] SERIAL_EXTRACT() is a MatrixOne internal serial-column extractor. |
+| [SLEEP()](./Functions-and-Operators/Other/sleep.md) | ✅ Full | — |
+| [STAGE_LIST()](./Functions-and-Operators/Other/stage_list.md) | 🟣 MatrixOne-only | [MO-only] STAGE_LIST() — MO-specific stage management function (currently unimplemented, returns ERROR 20105) |
+| [UUID()](./Functions-and-Operators/Other/uuid.md) | ✅ Full | — |
+
+### String
+
+| Function | MySQL Compat | Notes |
+|---|---|---|
+| [AES_DECRYPT()](./Functions-and-Operators/String/aes_decrypt.md) | ⚠️ Partial | MatrixOne supports only aes-128-ecb and aes-256-cbc block modes; MySQL 8.0 also supports the full set of ECB/CBC/CFB/OFB variants at multiple key sizes.<br/>MatrixOne AES_DECRYPT does not accept the optional kdf_name / salt / info KDF arguments present in MySQL 8.0. |
+| [AES_ENCRYPT()](./Functions-and-Operators/String/aes_encrypt.md) | ⚠️ Partial | MatrixOne supports only aes-128-ecb and aes-256-cbc block modes; MySQL 8.0 also supports the full set of ECB/CBC/CFB/OFB variants at multiple key sizes.<br/>MatrixOne AES_ENCRYPT does not accept the optional kdf_name / salt / info KDF arguments present in MySQL 8.0. |
+| [BIN()](./Functions-and-Operators/String/bin.md) | ✅ Full | — |
+| [BIT_LENGTH()](./Functions-and-Operators/String/bit-length.md) | ✅ Full | — |
+| [CHAR_LENGTH()](./Functions-and-Operators/String/char-length.md) | ✅ Full | — |
+| [CONCAT_WS()](./Functions-and-Operators/String/concat-ws.md) | ✅ Full | — |
+| [CONCAT()](./Functions-and-Operators/String/concat.md) | ⚠️ Partial | — |
+| [ELT()](./Functions-and-Operators/String/elt.md) | ✅ Full | — |
+| [EMPTY()](./Functions-and-Operators/String/empty.md) | 🟣 MatrixOne-only | [MO-only] EMPTY() is a MatrixOne helper returning whether a string is empty. |
+| [ENDSWITH()](./Functions-and-Operators/String/endswith.md) | 🟣 MatrixOne-only | [MO-only] ENDSWITH() is a MatrixOne helper; MySQL has no direct equivalent. |
+| [FIELD()](./Functions-and-Operators/String/field.md) | ✅ Full | — |
+| [FIND_IN_SET()](./Functions-and-Operators/String/find-in-set.md) | ✅ Full | — |
+| [FORMAT()](./Functions-and-Operators/String/format.md) | ✅ Full | — |
+| [FROM_BASE64()](./Functions-and-Operators/String/from_base64.md) | ⚠️ Partial | FROM_BASE64() may include trailing null bytes in decoded output; MySQL strips them (e.g., FROM_BASE64('YQ==') returns 'a\\0\\0' instead of 'a') |
+| [HEX()](./Functions-and-Operators/String/hex.md) | ✅ Full | — |
+| [INSTR()](./Functions-and-Operators/String/instr.md) | ✅ Full | — |
+| [LCASE()](./Functions-and-Operators/String/lcase.md) | ✅ Full | — |
+| [LEFT()](./Functions-and-Operators/String/left.md) | ✅ Full | — |
+| [LENGTH()](./Functions-and-Operators/String/length.md) | ✅ Full | — |
+| [LOCATE()](./Functions-and-Operators/String/locate.md) | ✅ Full | — |
+| [LOWER()](./Functions-and-Operators/String/lower.md) | ✅ Full | — |
+| [LPAD()](./Functions-and-Operators/String/lpad.md) | ✅ Full | — |
+| [LTRIM()](./Functions-and-Operators/String/ltrim.md) | ✅ Full | — |
+| [MD5()](./Functions-and-Operators/String/md5.md) | ✅ Full | — |
+| [NOT REGEXP](./Functions-and-Operators/String/Regular-Expressions/not-regexp.md) | ✅ Full | — |
+| [OCT(N)](./Functions-and-Operators/String/oct.md) | ⚠️ Partial | OCT(N) returns a numeric value rather than MySQL's plain string representation |
+| [REGEXP_INSTR()](./Functions-and-Operators/String/Regular-Expressions/regexp-instr.md) | ⚠️ Partial | match_type parameter not yet supported; passing it causes ERROR 20203 |
+| [REGEXP_LIKE()](./Functions-and-Operators/String/Regular-Expressions/regexp-like.md) | ✅ Full | — |
+| [REGEXP_REPLACE()](./Functions-and-Operators/String/Regular-Expressions/regexp-replace.md) | ✅ Full | — |
+| [REGEXP_SUBSTR()](./Functions-and-Operators/String/Regular-Expressions/regexp-substr.md) | ⚠️ Partial | match_type parameter not yet supported; passing it causes ERROR 20203 |
+| [Regular Expressions Overview](./Functions-and-Operators/String/Regular-Expressions/Regular-Expression-Functions-Overview.md) | ✅ Full | — |
+| [REPEAT()](./Functions-and-Operators/String/repeat.md) | ✅ Full | — |
+| [REVERSE()](./Functions-and-Operators/String/reverse.md) | ✅ Full | — |
+| [RPAD()](./Functions-and-Operators/String/rpad.md) | ✅ Full | — |
+| [RTRIM()](./Functions-and-Operators/String/rtrim.md) | ✅ Full | — |
+| [SHA1()/SHA()](./Functions-and-Operators/String/sha1.md) | ✅ Full | — |
+| [SHA2()](./Functions-and-Operators/String/sha2.md) | ✅ Full | — |
+| [SPACE()](./Functions-and-Operators/String/space.md) | ✅ Full | — |
+| [SPLIT_PART()](./Functions-and-Operators/String/split_part.md) | 🟣 MatrixOne-only | [MO-only] SPLIT_PART() is inherited from PostgreSQL; no MySQL equivalent. |
+| [STARTSWITH()](./Functions-and-Operators/String/startswith.md) | 🟣 MatrixOne-only | [MO-only] STARTSWITH() is a MatrixOne helper; MySQL has no direct equivalent. |
+| [STRCMP()](./Functions-and-Operators/String/strcmp.md) | ✅ Full | — |
+| [SUBSTRING_INDEX()](./Functions-and-Operators/String/substring-index.md) | ✅ Full | — |
+| [SUBSTRING()](./Functions-and-Operators/String/substring.md) | ✅ Full | — |
+| [TO_BASE64()](./Functions-and-Operators/String/to_base64.md) | ✅ Full | — |
+| [TRIM()](./Functions-and-Operators/String/trim.md) | ✅ Full | — |
+| [UCASE()](./Functions-and-Operators/String/ucase.md) | ✅ Full | — |
+| [UNHEX()](./Functions-and-Operators/String/unhex.md) | ✅ Full | — |
+| [UPPER()](./Functions-and-Operators/String/upper.md) | ✅ Full | — |
+
+### System Operations
+
+| Function | MySQL Compat | Notes |
+|---|---|---|
+| [CURRENT_ROLE_NAME()](./Functions-and-Operators/system-ops/current_role_name.md) | 🟣 MatrixOne-only | [MO-only] MatrixOne multi-account/role system management function (compat doc: System Management Functions). |
+| [CURRENT_ROLE()](./Functions-and-Operators/system-ops/current_role.md) | ⚠️ Partial | Returns a single active role name; MySQL 8.0 can return multiple comma-separated active roles or 'NONE'. |
+| [CURRENT_USER_NAME()](./Functions-and-Operators/system-ops/current_user_name.md) | 🟣 MatrixOne-only | [MO-only] MatrixOne multi-account/role system management function (compat doc: System Management Functions). |
+| [CURRENT_USER, CURRENT_USER()](./Functions-and-Operators/system-ops/current_user.md) | ⚠️ Partial | The host part may be returned as 'localhost' or the resolved client host rather than MySQL's explicit 'username@host' format. |
+| [PURGE_LOG()](./Functions-and-Operators/system-ops/purge_log.md) | 🟣 MatrixOne-only | [MO-only] MatrixOne multi-account/role system management function (compat doc: System Management Functions). |
+| [VERSION](./Functions-and-Operators/system-ops/version.md) | ✅ Full | — |
+
+### Table
+
+| Function | MySQL Compat | Notes |
+|---|---|---|
+| [GENERATE_SERIES()](./Functions-and-Operators/Table/generate_series.md) | 🟣 MatrixOne-only | [MO-only] Table-valued function; no direct MySQL equivalent. |
+| [UNNEST()](./Functions-and-Operators/Table/unnest.md) | 🟣 MatrixOne-only | [MO-only] Table-valued function; no direct MySQL equivalent. |
+
+### Vector
+
+| Function | MySQL Compat | Notes |
+|---|---|---|
+| [Arithmetic operators](./Functions-and-Operators/Vector/arithmetic.md) | 🟣 MatrixOne-only | [MO-only] Vector type and related distance/norm/clustering functions are MatrixOne extensions (compat doc: Data Types — \"MatrixOne supports vector types\"). |
+| [CLUSTER_CENTERS](./Functions-and-Operators/Vector/cluster_centers.md) | 🟣 MatrixOne-only | [MO-only] CLUSTER_CENTERS() — MO-specific vector clustering function (currently unimplemented, returns ERROR 20102) |
+| [COSINE_DISTANCE()](./Functions-and-Operators/Vector/cosine_distance.md) | 🟣 MatrixOne-only | [MO-only] Vector type and related distance/norm/clustering functions are MatrixOne extensions (compat doc: Data Types — \"MatrixOne supports vector types\"). |
+| [cosine_similarity()](./Functions-and-Operators/Vector/cosine_similarity.md) | 🟣 MatrixOne-only | [MO-only] Vector type and related distance/norm/clustering functions are MatrixOne extensions (compat doc: Data Types — \"MatrixOne supports vector types\"). |
+| [inner_product()](./Functions-and-Operators/Vector/inner_product.md) | 🟣 MatrixOne-only | [MO-only] Vector type and related distance/norm/clustering functions are MatrixOne extensions (compat doc: Data Types — \"MatrixOne supports vector types\"). |
+| [l1_norm()](./Functions-and-Operators/Vector/l1_norm.md) | 🟣 MatrixOne-only | [MO-only] Vector type and related distance/norm/clustering functions are MatrixOne extensions (compat doc: Data Types — \"MatrixOne supports vector types\"). |
+| [L2_DISTANCE()](./Functions-and-Operators/Vector/l2_distance.md) | 🟣 MatrixOne-only | [MO-only] Vector type and related distance/norm/clustering functions are MatrixOne extensions (compat doc: Data Types — \"MatrixOne supports vector types\"). |
+| [l2_norm()](./Functions-and-Operators/Vector/l2_norm.md) | 🟣 MatrixOne-only | [MO-only] Vector type and related distance/norm/clustering functions are MatrixOne extensions (compat doc: Data Types — \"MatrixOne supports vector types\"). |
+| [Mathematical class functions](./Functions-and-Operators/Vector/misc.md) | 🟣 MatrixOne-only | [MO-only] Vector type and related distance/norm/clustering functions are MatrixOne extensions (compat doc: Data Types — \"MatrixOne supports vector types\"). |
+| [NORMALIZE_L2()](./Functions-and-Operators/Vector/normalize_l2.md) | 🟣 MatrixOne-only | [MO-only] Vector type and related distance/norm/clustering functions are MatrixOne extensions (compat doc: Data Types — \"MatrixOne supports vector types\"). |
+| [SUBVECTOR()](./Functions-and-Operators/Vector/subvector.md) | 🟣 MatrixOne-only | [MO-only] Vector type and related distance/norm/clustering functions are MatrixOne extensions (compat doc: Data Types — \"MatrixOne supports vector types\"). |
+| [vector_dims()](./Functions-and-Operators/Vector/vector_dims.md) | 🟣 MatrixOne-only | [MO-only] Vector type and related distance/norm/clustering functions are MatrixOne extensions (compat doc: Data Types — \"MatrixOne supports vector types\"). |
+
+### Window Functions
+
+| Function | MySQL Compat | Notes |
+|---|---|---|
+| [CUME_DIST()](./Functions-and-Operators/Window-Functions/cume_dist.md) | ✅ Full | — |
+| [DENSE_RANK()](./Functions-and-Operators/Window-Functions/dense_rank.md) | ✅ Full | — |
+| [PERCENT_RANK()](./Functions-and-Operators/Window-Functions/percent_rank.md) | ✅ Full | — |
+| [RANK()](./Functions-and-Operators/Window-Functions/rank.md) | ✅ Full | — |
+| [ROW_NUMBER()](./Functions-and-Operators/Window-Functions/row_number.md) | ✅ Full | — |
+
+## Operators
+
+| Status | Count |
+|---|---|
+| ✅ Full | 6 |
+| ⚠️ Partial | 4 |
+| 🟣 MatrixOne-only | 5 |
+| ❓ Unknown | 47 |
+| **Total** | **62** |
+
+### Operators
+
+| Operator | MySQL Compat | Notes |
+|---|---|---|
+| [INTERVAL](./Operators/interval.md) | ⚠️ Partial | INTERVAL is internally implemented as a two-argument function rather than as a true SQL keyword; documented syntax INTERVAL(expr,unit) differs from MySQL's INTERVAL expr unit keyword-style notation<br/>Malformed dates in DATE_ADD/DATE_SUB raise errors rather than returning NULL (MySQL 8.0 returns NULL) |
+| [operator-precedence](./Operators/operator-precedence.md) | ❓ Unknown | — |
+| [operators](./Operators/operators.md) | ❓ Unknown | — |
+
+### Arithmetic Operators
+
+| Operator | MySQL Compat | Notes |
+|---|---|---|
+| [addition](./Operators/arithmetic-operators/addition.md) | ❓ Unknown | — |
+| [arithmetic-operators-overview](./Operators/arithmetic-operators/arithmetic-operators-overview.md) | ❓ Unknown | — |
+| [div](./Operators/arithmetic-operators/div.md) | ❓ Unknown | — |
+| [division](./Operators/arithmetic-operators/division.md) | ❓ Unknown | — |
+| [minus](./Operators/arithmetic-operators/minus.md) | ❓ Unknown | — |
+| [mod](./Operators/arithmetic-operators/mod.md) | ❓ Unknown | — |
+| [multiplication](./Operators/arithmetic-operators/multiplication.md) | ❓ Unknown | — |
+| [unary-minus](./Operators/arithmetic-operators/unary-minus.md) | ❓ Unknown | — |
+
+### Assignment Operators
+
+| Operator | MySQL Compat | Notes |
+|---|---|---|
+| [assignment-operators-overview](./Operators/assignment-operators/assignment-operators-overview.md) | ❓ Unknown | — |
+| [equal](./Operators/assignment-operators/equal.md) | ❓ Unknown | — |
+
+### Bit Functions and Operators
+
+| Operator | MySQL Compat | Notes |
+|---|---|---|
+| [bit-functions-and-operators-overview](./Operators/bit-functions-and-operators/bit-functions-and-operators-overview.md) | ❓ Unknown | — |
+| [bitwise-and](./Operators/bit-functions-and-operators/bitwise-and.md) | ❓ Unknown | — |
+| [bitwise-inversion](./Operators/bit-functions-and-operators/bitwise-inversion.md) | ❓ Unknown | — |
+| [bitwise-or](./Operators/bit-functions-and-operators/bitwise-or.md) | ❓ Unknown | — |
+| [bitwise-xor](./Operators/bit-functions-and-operators/bitwise-xor.md) | ❓ Unknown | — |
+| [left-shift](./Operators/bit-functions-and-operators/left-shift.md) | ❓ Unknown | — |
+| [right-shift](./Operators/bit-functions-and-operators/right-shift.md) | ❓ Unknown | — |
+
+### Cast Functions and Operators
+
+| Operator | MySQL Compat | Notes |
+|---|---|---|
+| [binary](./Operators/cast-functions-and-operators/binary.md) | ❓ Unknown | — |
+| [CAST](./Operators/cast-functions-and-operators/cast.md) | ⚠️ Partial | CAST('non-numeric' AS SIGNED) raises an error instead of returning 0 or NULL (MySQL 8.0 returns 0 with a warning)<br/>CAST(datetime_typed_value AS CHAR) may fail in some cases (MySQL 8.0 supports it universally) |
+| [cast-functions-and-operators-overview](./Operators/cast-functions-and-operators/cast-functions-and-operators-overview.md) | ❓ Unknown | — |
+| [CONVERT](./Operators/cast-functions-and-operators/convert.md) | ⚠️ Partial | CONVERT('non-numeric', SIGNED) raises an error instead of returning 0 or NULL<br/>CONVERT(datetime_typed_value, CHAR) may fail in some cases (MySQL 8.0 supports it universally) |
+| [DECODE()](./Operators/cast-functions-and-operators/decode.md) | 🟣 MatrixOne-only | [MO-only] DECODE() was deprecated in MySQL 5.7 and removed in MySQL 8.0; MatrixOne continues to support it |
+| [ENCODE()](./Operators/cast-functions-and-operators/encode.md) | 🟣 MatrixOne-only | [MO-only] ENCODE() was deprecated in MySQL 5.7 and removed in MySQL 8.0; MatrixOne continues to support it |
+| [SERIAL_FULL()](./Operators/cast-functions-and-operators/serial_full.md) | 🟣 MatrixOne-only | [MO-only] SERIAL_FULL() is a MO-specific serialization function variant with NULL preservation, no MySQL 8.0 counterpart |
+| [SERIAL()](./Operators/cast-functions-and-operators/serial.md) | 🟣 MatrixOne-only | [MO-only] SERIAL() is a MO-specific serialization function with no MySQL 8.0 counterpart |
+
+### Comparison Functions and Operators
+
+| Operator | MySQL Compat | Notes |
+|---|---|---|
+| [<=>](./Operators/comparison-functions-and-operators/null-safe-equal.md) | ✅ Full | — |
+| [assign-equal](./Operators/comparison-functions-and-operators/assign-equal.md) | ❓ Unknown | — |
+| [between](./Operators/comparison-functions-and-operators/between.md) | ❓ Unknown | — |
+| [coalesce](./Operators/comparison-functions-and-operators/coalesce.md) | ❓ Unknown | — |
+| [comparison-functions-and-operators-overview](./Operators/comparison-functions-and-operators/comparison-functions-and-operators-overview.md) | ❓ Unknown | — |
+| [function_interval](./Operators/comparison-functions-and-operators/function_interval.md) | ❓ Unknown | — |
+| [function_isnull](./Operators/comparison-functions-and-operators/function_isnull.md) | ❓ Unknown | — |
+| [function_least](./Operators/comparison-functions-and-operators/function_least.md) | ❓ Unknown | — |
+| [function_strcmp](./Operators/comparison-functions-and-operators/function_strcmp.md) | ❓ Unknown | — |
+| [greater-than](./Operators/comparison-functions-and-operators/greater-than.md) | ❓ Unknown | — |
+| [greater-than-or-equal](./Operators/comparison-functions-and-operators/greater-than-or-equal.md) | ❓ Unknown | — |
+| [ILIKE](./Operators/comparison-functions-and-operators/ilike.md) | 🟣 MatrixOne-only | [MO-only] ILIKE operator for case-insensitive LIKE matching (PostgreSQL extension) |
+| [IN](./Operators/comparison-functions-and-operators/in.md) | ✅ Full | — |
+| [is](./Operators/comparison-functions-and-operators/is.md) | ❓ Unknown | — |
+| [IS NULL](./Operators/comparison-functions-and-operators/is-null.md) | ✅ Full | — |
+| [is-not](./Operators/comparison-functions-and-operators/is-not.md) | ❓ Unknown | — |
+| [is-not-null](./Operators/comparison-functions-and-operators/is-not-null.md) | ❓ Unknown | — |
+| [less-than](./Operators/comparison-functions-and-operators/less-than.md) | ❓ Unknown | — |
+| [less-than-or-equal](./Operators/comparison-functions-and-operators/less-than-or-equal.md) | ❓ Unknown | — |
+| [like](./Operators/comparison-functions-and-operators/like.md) | ❓ Unknown | — |
+| [NOT IN](./Operators/comparison-functions-and-operators/not-in.md) | ✅ Full | — |
+| [not-between](./Operators/comparison-functions-and-operators/not-between.md) | ❓ Unknown | — |
+| [not-equal](./Operators/comparison-functions-and-operators/not-equal.md) | ❓ Unknown | — |
+| [not-like](./Operators/comparison-functions-and-operators/not-like.md) | ❓ Unknown | — |
+
+### Flow Control Functions
+
+| Operator | MySQL Compat | Notes |
+|---|---|---|
+| [CASE WHEN](./Operators/flow-control-functions/case-when.md) | ✅ Full | — |
+| [flow-control-functions-overview](./Operators/flow-control-functions/flow-control-functions-overview.md) | ❓ Unknown | — |
+| [function_ifnull](./Operators/flow-control-functions/function_ifnull.md) | ❓ Unknown | — |
+| [function_nullif](./Operators/flow-control-functions/function_nullif.md) | ❓ Unknown | — |
+| [IF()](./Operators/flow-control-functions/function_if.md) | ⚠️ Partial | IF(NULL, expr2, expr3) raises an error instead of returning expr3 (MySQL 8.0 returns expr3) |
+
+### Logical Operators
+
+| Operator | MySQL Compat | Notes |
+|---|---|---|
+| [and](./Operators/logical-operators/and.md) | ❓ Unknown | — |
+| [logical-operators-overview](./Operators/logical-operators/logical-operators-overview.md) | ❓ Unknown | — |
+| [NOT / !](./Operators/logical-operators/not.md) | ✅ Full | — |
+| [or](./Operators/logical-operators/or.md) | ❓ Unknown | — |
+| [xor](./Operators/logical-operators/xor.md) | ❓ Unknown | — |
+
+## Data Types
+
+| Status | Count |
+|---|---|
+| ✅ Full | 1 |
+| ⚠️ Partial | 7 |
+| 🟣 MatrixOne-only | 3 |
+| ❓ Unknown | 1 |
+| **Total** | **12** |
+
+### Data Types
+
+| Data Type | MySQL Compat | Notes |
+|---|---|---|
+| [blob-text-type](./Data-Types/blob-text-type.md) | ❓ Unknown | — |
+| [Data Type Conversion](./Data-Types/data-type-conversion.md) | ⚠️ Partial | BOOLEAN → DECIMAL cast is not supported; other common conversions are supported |
+| [Data Types Overview](./Data-Types/data-types.md) | ⚠️ Partial | TIMESTAMP range is 0001-01-01 to 9999-12-31 (MySQL: 1970-01-01 to 2038-01-19)<br/>DATETIME lower bound is 0001-01-01 (MySQL: 1000-01-01)<br/>Non-standard type names FLOAT32/FLOAT64 in addition to MySQL's FLOAT/DOUBLE |
+| [DATALINK Type](./Data-Types/datalink-type.md) | 🟣 MatrixOne-only | [MO-only] DATALINK data type with STAGE integration, file:// and stage:// URL schemes<br/>[MO-only] load_file() integration for reading DATALINK values |
+| [ENUM Type](./Data-Types/enum-type.md) | ⚠️ Partial | — |
+| [Fixed-Point Types (Exact Value) - DECIMAL](./Data-Types/fixed-point-types.md) | ⚠️ Partial | DECIMAL precision supports up to 65 digits via DECIMAL256 |
+| [JSON Type](./Data-Types/json-type.md) | ✅ Full | — |
+| [SET Type](./Data-Types/set-type.md) | ⚠️ Partial | — |
+| [UUID Type](./Data-Types/uuid-type.md) | 🟣 MatrixOne-only | [MO-only] UUID as a native column type (MySQL 8.0 has UUID() function only, no UUID column type)<br/>[MO-only] DEFAULT uuid() on UUID columns |
+| [Vector Type](./Data-Types/vector-type.md) | 🟣 MatrixOne-only | [MO-only] vecf32 and vecf64 vector data types for embedding storage and similarity search<br/>[MO-only] Binary vector insert via hex encoding<br/>[MO-only] Dimension specification syntax in column definition |
+
+### Date/Time Data Types
+
+| Data Type | MySQL Compat | Notes |
+|---|---|---|
+| [TIMESTAMP Initialization](./Data-Types/date-time-data-types/timestamp-initialization.md) | ⚠️ Partial | TIMESTAMP range is 0001-9999 (MySQL 8.0: 1970-2038); auto-initialization behavior near range boundaries may differ<br/>DATETIME DEFAULT 0 is not supported (MySQL 8.0 supports it)<br/>TIMESTAMP ON UPDATE CURRENT_TIMESTAMP without explicit DEFAULT defaults to NULL (MySQL 8.0 defaults to 0)<br/>DATETIME NOT NULL ON UPDATE CURRENT_TIMESTAMP without explicit DEFAULT rejects NULL insert (MySQL 8.0 defaults to 0) |
+| [YEAR Type](./Data-Types/date-time-data-types/year-type.md) | ⚠️ Partial | — |
+
+## Language Structure
+
+| Status | Count |
+|---|---|
+| ⚠️ Partial | 2 |
+| **Total** | **2** |
+
+### Language Structure
+
+| Element | MySQL Compat | Notes |
+|---|---|---|
+| [Comments](./Language-Structure/comment.md) | ⚠️ Partial | Supports // single-line comments (C++ style); MySQL 8.0 does not support // comments<br/>Does not support /*!...*/ conditional/executable comments (MySQL 8.0 does) |
+| [Keywords](./Language-Structure/keywords.md) | ⚠️ Partial | MatrixOne-specific keywords marked with (M) in the keyword list |

--- a/docs/hooks/agent_delivery.py
+++ b/docs/hooks/agent_delivery.py
@@ -16,7 +16,11 @@ MCP servers, etc.) can consume the MatrixOne docs without parsing HTML:
 3. **`site/llms-sql.txt`**. A flat per-statement index of every SQL-Reference
    page with its MySQL compatibility tag, so agents can scan the full SQL
    surface area in one fetch without parsing the matrix table.
-4. **`site/llms-full.txt`**. The whole corpus concatenated into one file so
+4. **`site/llms-func.txt`**. A flat per-function index of every
+   Functions-and-Operators page with its MySQL compatibility tag.
+5. **`site/llms-op.txt`**. A flat per-operator index of every Operators page
+   with its MySQL compatibility tag.
+6. **`site/llms-full.txt`**. The whole corpus concatenated into one file so
    agents can stuff the full docs into a single context window when needed.
 
 Override the base URL via `MATRIXONE_DOCS_BASE_URL` env var. Defaults to
@@ -36,6 +40,8 @@ BASE_URL_DEFAULT = "https://docs.matrixorigin.io"
 DOC_ROOT_REL = Path("MatrixOne")
 COMPAT_MATRIX_REL = "MatrixOne/Reference/mysql-compatibility-matrix.md"
 SQL_REF_ROOT_REL = Path("MatrixOne/Reference/SQL-Reference")
+FUNC_REF_ROOT_REL = Path("MatrixOne/Reference/Functions-and-Operators")
+OP_REF_ROOT_REL = Path("MatrixOne/Reference/Operators")
 MAX_AUTO_DESC_CHARS = 160
 
 SQL_CATEGORY_ORDER = [
@@ -52,6 +58,29 @@ COMPAT_TAG = {
     "mo_only": "mo-only",
     "unknown": "unknown",
 }
+
+FUNC_CATEGORY_ORDER = [
+    ("Aggregate-Functions", "Aggregate Functions"),
+    ("Datetime", "Date/Time Functions"),
+    ("Json", "JSON Functions"),
+    ("Mathematical", "Math Functions"),
+    ("String", "String Functions"),
+    ("Table", "Table Functions"),
+    ("Vector", "Vector Functions"),
+    ("Window-Functions", "Window Functions"),
+    ("system-ops", "System Operations"),
+    ("Other", "Other Functions"),
+]
+
+OP_CATEGORY_ORDER = [
+    ("arithmetic-operators", "Arithmetic Operators"),
+    ("assignment-operators", "Assignment Operators"),
+    ("bit-functions-and-operators", "Bit Functions and Operators"),
+    ("cast-functions-and-operators", "Cast Functions and Operators"),
+    ("comparison-functions-and-operators", "Comparison Functions and Operators"),
+    ("flow-control-functions", "Flow Control Functions"),
+    ("logical-operators", "Logical Operators"),
+]
 
 # Curated list of top-tier pages to highlight in llms.txt. Paths are relative
 # to `docs/`. Second tuple element is an optional description override; leave
@@ -146,7 +175,8 @@ SYSTEM_PROMPT_BLOCK = (
 # artifact to pull for which kind of question.
 AGENT_ROUTING = (
     "Agent routing: writing or debugging SQL → pull `llms-sql.txt` for the "
-    "flat per-statement catalogue; broad conceptual questions → this file; "
+    "flat per-statement catalogue; function lookup → `llms-func.txt`; operator "
+    "reference → `llms-op.txt`; broad conceptual questions → this file; "
     "long-context offline reading → `llms-full.txt`; authoritative diffs "
     "from MySQL → the MySQL Compatibility Matrix linked above."
 )
@@ -204,6 +234,8 @@ def on_post_build(config, **_kwargs):
     llms.append(f"- **MySQL Compatibility Matrix**: {compat_url}")
     llms.append(f"- **Per-page markdown mirror**: append `.md` to any doc URL under {base}/")
     llms.append(f"- **Full SQL reference (flat index, all statements)**: {base}/llms-sql.txt")
+    llms.append(f"- **Functions reference (flat index)**: {base}/llms-func.txt")
+    llms.append(f"- **Operators reference (flat index)**: {base}/llms-op.txt")
     llms.append(f"- **Full corpus**: {base}/llms-full.txt")
     llms.append(f"- **Generated**: {built_at} (UTC)")
     llms.append("")
@@ -231,6 +263,14 @@ def on_post_build(config, **_kwargs):
     # 3. llms-sql.txt — flat index of every SQL-Reference page with compat tag.
     sql_lines = _build_sql_index(docs_dir, base, built_at)
     (site_dir / "llms-sql.txt").write_text("\n".join(sql_lines), encoding="utf-8")
+
+    # 3b. llms-func.txt — flat index of every Functions-and-Operators page.
+    func_lines = _build_func_index(docs_dir, base, built_at)
+    (site_dir / "llms-func.txt").write_text("\n".join(func_lines), encoding="utf-8")
+
+    # 3c. llms-op.txt — flat index of every Operators page.
+    op_lines = _build_op_index(docs_dir, base, built_at)
+    (site_dir / "llms-op.txt").write_text("\n".join(op_lines), encoding="utf-8")
 
     # 4. llms-full.txt
     sections_order = [
@@ -284,7 +324,7 @@ def on_post_build(config, **_kwargs):
         full_parts.append("")
         full_parts.append(src.read_text(encoding="utf-8"))
     (site_dir / "llms-full.txt").write_text("\n".join(full_parts), encoding="utf-8")
-    print(f"[agent-delivery] emitted llms.txt, llms-sql.txt and llms-full.txt ({len(seen)} pages)")
+    print(f"[agent-delivery] emitted llms.txt, llms-sql.txt, llms-func.txt, llms-op.txt and llms-full.txt ({len(seen)} pages)")
 
 
 def _build_sql_index(docs_dir: Path, base: str, built_at: str) -> list[str]:
@@ -332,6 +372,138 @@ def _build_sql_index(docs_dir: Path, base: str, built_at: str) -> list[str]:
             uncategorised.append(row)
 
     for key, label in SQL_CATEGORY_ORDER:
+        rows = buckets.get(key) or []
+        if not rows:
+            continue
+        lines.append(f"## {label}")
+        lines.append("")
+        for title, url, compat, desc in sorted(rows, key=lambda r: r[0].lower()):
+            suffix = f": {desc}" if desc else ""
+            lines.append(f"- [{title}]({url}) [{compat}]{suffix}")
+        lines.append("")
+
+    if uncategorised:
+        lines.append("## Uncategorised")
+        lines.append("")
+        for title, url, compat, desc in sorted(uncategorised, key=lambda r: r[0].lower()):
+            suffix = f": {desc}" if desc else ""
+            lines.append(f"- [{title}]({url}) [{compat}]{suffix}")
+        lines.append("")
+
+    return lines
+
+
+def _build_func_index(docs_dir: Path, base: str, built_at: str) -> list[str]:
+    """Emit a flat one-line-per-function catalogue of every Functions-and-Operators
+    page. Same format as `_build_sql_index`.
+    """
+    root = docs_dir / FUNC_REF_ROOT_REL
+    lines: list[str] = [
+        "# MatrixOne Functions Reference — Flat Index",
+        "",
+        f"> Every function supported by MatrixOne, grouped by category, "
+        f"each tagged with its MySQL 8.0 compatibility status. Generated from "
+        f"`mysql_compat` frontmatter on {built_at} (UTC).",
+        "",
+        "Legend: `[full]` MySQL-compatible · `[partial]` compatible with "
+        "caveats (see linked page for `differs_from_mysql:`) · "
+        "`[mo-only]` MatrixOne-only, no MySQL counterpart · "
+        "`[unknown]` frontmatter missing.",
+        "",
+        f"Compatibility matrix (grouped table view): {base}/{COMPAT_MATRIX_REL}",
+        "",
+    ]
+    if not root.exists():
+        lines.append("_No Functions-and-Operators pages found._")
+        return lines
+
+    buckets: dict[str, list[tuple[str, str, str, str]]] = {k: [] for k, _ in FUNC_CATEGORY_ORDER}
+    uncategorised: list[tuple[str, str, str, str]] = []
+    for src in sorted(root.rglob("*.md")):
+        rel_to_ref = src.relative_to(root)
+        parts = rel_to_ref.parts
+        category = parts[0] if len(parts) > 1 else "__root__"
+        text = _read(src) or ""
+        fm, _ = _split_frontmatter(text)
+        compat = COMPAT_TAG.get(fm.get("mysql_compat", "unknown"), "unknown")
+        title = fm.get("title") or _page_title(src) or rel_to_ref.as_posix()
+        desc = _page_description(src) or ""
+        rel_from_docs = src.relative_to(docs_dir).as_posix()
+        url = f"{base}/{rel_from_docs}"
+        row = (title, url, compat, desc)
+        if category in buckets:
+            buckets[category].append(row)
+        else:
+            uncategorised.append(row)
+
+    for key, label in FUNC_CATEGORY_ORDER:
+        rows = buckets.get(key) or []
+        if not rows:
+            continue
+        lines.append(f"## {label}")
+        lines.append("")
+        for title, url, compat, desc in sorted(rows, key=lambda r: r[0].lower()):
+            suffix = f": {desc}" if desc else ""
+            lines.append(f"- [{title}]({url}) [{compat}]{suffix}")
+        lines.append("")
+
+    if uncategorised:
+        lines.append("## Uncategorised")
+        lines.append("")
+        for title, url, compat, desc in sorted(uncategorised, key=lambda r: r[0].lower()):
+            suffix = f": {desc}" if desc else ""
+            lines.append(f"- [{title}]({url}) [{compat}]{suffix}")
+        lines.append("")
+
+    return lines
+
+
+def _build_op_index(docs_dir: Path, base: str, built_at: str) -> list[str]:
+    """Emit a flat one-line-per-operator catalogue of every Operators page."""
+    root = docs_dir / OP_REF_ROOT_REL
+    lines: list[str] = [
+        "# MatrixOne Operators Reference — Flat Index",
+        "",
+        f"> Every operator supported by MatrixOne, grouped by category, "
+        f"each tagged with its MySQL 8.0 compatibility status. Generated from "
+        f"`mysql_compat` frontmatter on {built_at} (UTC).",
+        "",
+        "Legend: `[full]` MySQL-compatible · `[partial]` compatible with "
+        "caveats (see linked page for `differs_from_mysql:`) · "
+        "`[mo-only]` MatrixOne-only, no MySQL counterpart · "
+        "`[unknown]` frontmatter missing.",
+        "",
+        f"Compatibility matrix (grouped table view): {base}/{COMPAT_MATRIX_REL}",
+        "",
+    ]
+    if not root.exists():
+        lines.append("_No Operators pages found._")
+        return lines
+
+    buckets: dict[str, list[tuple[str, str, str, str]]] = {k: [] for k, _ in OP_CATEGORY_ORDER}
+    uncategorised: list[tuple[str, str, str, str]] = []
+    for src in sorted(root.rglob("*.md")):
+        rel_to_ref = src.relative_to(root)
+        parts = rel_to_ref.parts
+        # Operators/ tree has an extra `operators/` prefix; skip it.
+        if parts[0] == "operators":
+            category = parts[1] if len(parts) > 2 else "operators"
+        else:
+            category = parts[0] if len(parts) > 0 else "__root__"
+        text = _read(src) or ""
+        fm, _ = _split_frontmatter(text)
+        compat = COMPAT_TAG.get(fm.get("mysql_compat", "unknown"), "unknown")
+        title = fm.get("title") or _page_title(src) or rel_to_ref.as_posix()
+        desc = _page_description(src) or ""
+        rel_from_docs = src.relative_to(docs_dir).as_posix()
+        url = f"{base}/{rel_from_docs}"
+        row = (title, url, compat, desc)
+        if category in buckets:
+            buckets[category].append(row)
+        else:
+            uncategorised.append(row)
+
+    for key, label in OP_CATEGORY_ORDER:
         rows = buckets.get(key) or []
         if not rows:
             continue

--- a/docs/superpowers/plans/2026-05-26-multi-agent-parallel-verification.md
+++ b/docs/superpowers/plans/2026-05-26-multi-agent-parallel-verification.md
@@ -1,0 +1,948 @@
+# Multi-Agent Parallel Verification (MO 3.0.13) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Create agent prompt templates, JSON schemas, and orchestration scripts to run 28 parallel agents (14 static + 14 live) verifying `mysql_compat` accuracy for all 402 SQL Reference files against MO 3.0.13, with Merge Agent cross-referencing both passes into `final-report.json`.
+
+**Architecture:** Each static/live agent gets an identical prompt template parameterized by bucket name. 28 agents run in parallel. A Merge Agent consumes all 28 JSON reports and produces the final cross-referenced report. All prompts are self-contained markdown files; the orchestrator handles pre-flight (Docker, databases) and triggers agent dispatch.
+
+**Tech Stack:** Bash (orchestration), JSON Schema (report validation), Markdown (agent prompts), Docker + mysql CLI (MO connection)
+
+---
+
+## File Structure
+
+```
+scripts/verify-mo313/
+├── orchestrate.sh                    # Pre-flight + agent dispatch instructions
+├── prompts/
+│   ├── static-agent.md               # Static agent prompt template
+│   ├── live-agent.md                 # Live agent prompt template
+│   └── merge-agent.md                # Merge agent prompt template
+├── schemas/
+│   ├── static-report.schema.json     # Static agent output schema
+│   ├── live-report.schema.json       # Live agent output schema
+│   └── final-report.schema.json      # Merge agent output schema
+└── README.md                         # Usage instructions
+```
+
+---
+
+### Task 1: Create JSON output schemas
+
+**Files:**
+- Create: `scripts/verify-mo313/schemas/static-report.schema.json`
+- Create: `scripts/verify-mo313/schemas/live-report.schema.json`
+- Create: `scripts/verify-mo313/schemas/final-report.schema.json`
+
+- [ ] **Step 1: Create static agent report schema**
+
+Write `scripts/verify-mo313/schemas/static-report.schema.json`:
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "static-report",
+  "type": "object",
+  "required": ["agent", "bucket", "mo_version", "generated_at", "files"],
+  "properties": {
+    "agent": { "const": "static" },
+    "bucket": { "type": "string", "description": "Bucket name from bucket-manifest.json" },
+    "mo_version": { "type": "string", "description": "Target MO version, e.g. 3.0.13" },
+    "generated_at": { "type": "string", "format": "date-time" },
+    "summary": {
+      "type": "object",
+      "properties": {
+        "total_files": { "type": "integer" },
+        "total_claims": { "type": "integer" },
+        "pass": { "type": "integer" },
+        "fail": { "type": "integer" },
+        "warn": { "type": "integer" },
+        "skipped": { "type": "integer" }
+      }
+    },
+    "files": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["file", "current_compat", "findings"],
+        "properties": {
+          "file": { "type": "string", "description": "Path relative to repo root" },
+          "current_compat": { "enum": ["full", "partial", "mo_only", "none", "unknown"] },
+          "suggested_compat": { "enum": ["full", "partial", "mo_only", "none", "unknown"] },
+          "findings": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["verdict", "severity", "description", "evidence"],
+              "properties": {
+                "verdict": { "enum": ["PASS", "FAIL", "WARN", "SKIPPED"] },
+                "severity": { "enum": ["CRITICAL", "HIGH", "MEDIUM", "LOW"] },
+                "field_checked": { "type": "string", "description": "Which compat aspect: compat_label, differs_list, mo_only_list, body_text, missing_from_doc" },
+                "description": { "type": "string" },
+                "evidence": {
+                  "type": "object",
+                  "required": ["mysql_ref"],
+                  "properties": {
+                    "mysql_ref": { "type": "string", "description": "MySQL 8.0 doc URL or section reference" },
+                    "mysql_behavior": { "type": "string" },
+                    "mo_doc_claim": { "type": "string" },
+                    "suggestion": { "type": "string" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "incomplete": { "type": "boolean", "description": "True if agent timed out before finishing all files" }
+  }
+}
+```
+
+- [ ] **Step 2: Create live agent report schema**
+
+Write `scripts/verify-mo313/schemas/live-report.schema.json`:
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "live-report",
+  "type": "object",
+  "required": ["agent", "bucket", "mo_version", "generated_at", "files"],
+  "properties": {
+    "agent": { "const": "live" },
+    "bucket": { "type": "string" },
+    "mo_version": { "type": "string" },
+    "generated_at": { "type": "string", "format": "date-time" },
+    "summary": {
+      "type": "object",
+      "properties": {
+        "total_files": { "type": "integer" },
+        "total_claims": { "type": "integer" },
+        "pass": { "type": "integer" },
+        "fail": { "type": "integer" },
+        "warn": { "type": "integer" },
+        "skipped": { "type": "integer" },
+        "errors": { "type": "integer" }
+      }
+    },
+    "files": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["file", "current_compat", "findings"],
+        "properties": {
+          "file": { "type": "string" },
+          "current_compat": { "enum": ["full", "partial", "mo_only", "none", "unknown"] },
+          "findings": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["verdict", "severity", "description", "evidence"],
+              "properties": {
+                "verdict": { "enum": ["PASS", "FAIL", "WARN", "SKIPPED", "ERROR"] },
+                "severity": { "enum": ["CRITICAL", "HIGH", "MEDIUM", "LOW"] },
+                "field_checked": { "type": "string" },
+                "description": { "type": "string" },
+                "evidence": {
+                  "type": "object",
+                  "required": ["sql_executed", "actual_output"],
+                  "properties": {
+                    "sql_executed": { "type": "string" },
+                    "actual_output": { "type": "string" },
+                    "expected_behavior": { "type": "string" },
+                    "matches_doc": { "type": "boolean" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "incomplete": { "type": "boolean" }
+  }
+}
+```
+
+- [ ] **Step 3: Create final report schema**
+
+Write `scripts/verify-mo313/schemas/final-report.schema.json`:
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "final-report",
+  "type": "object",
+  "required": ["meta", "summary", "by_severity", "by_bucket", "findings"],
+  "properties": {
+    "meta": {
+      "type": "object",
+      "required": ["mo_version", "generated_at", "total_files", "total_buckets", "static_agents", "live_agents"],
+      "properties": {
+        "mo_version": { "type": "string" },
+        "generated_at": { "type": "string", "format": "date-time" },
+        "total_files": { "type": "integer" },
+        "total_buckets": { "type": "integer" },
+        "static_agents": { "type": "integer" },
+        "live_agents": { "type": "integer" },
+        "missing_buckets": { "type": "array", "items": { "type": "string" }, "description": "Buckets where an agent failed to produce a report" }
+      }
+    },
+    "summary": {
+      "type": "object",
+      "required": ["total_claims_checked", "pass", "confirmed_fail", "conflict", "live_only", "static_only", "needs_human_review"],
+      "properties": {
+        "total_claims_checked": { "type": "integer" },
+        "pass": { "type": "integer" },
+        "confirmed_fail": { "type": "integer" },
+        "conflict": { "type": "integer" },
+        "live_only": { "type": "integer" },
+        "static_only": { "type": "integer" },
+        "needs_human_review": { "type": "integer" }
+      }
+    },
+    "by_severity": {
+      "type": "object",
+      "properties": {
+        "critical": { "type": "integer" },
+        "high": { "type": "integer" },
+        "medium": { "type": "integer" },
+        "low": { "type": "integer" }
+      }
+    },
+    "by_bucket": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "pass": { "type": "integer" },
+          "confirmed_fail": { "type": "integer" },
+          "conflict": { "type": "integer" }
+        }
+      }
+    },
+    "findings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["file", "merge_verdict", "severity", "description"],
+        "properties": {
+          "file": { "type": "string" },
+          "merge_verdict": { "enum": ["PASS", "CONFIRMED FAIL", "CONFLICT", "LIVE_ONLY", "STATIC_ONLY"] },
+          "severity": { "enum": ["CRITICAL", "HIGH", "MEDIUM", "LOW"] },
+          "description": { "type": "string" },
+          "static_evidence": { "type": "object" },
+          "live_evidence": { "type": "object" },
+          "auto_resolved": { "type": "boolean" },
+          "needs_human_review": { "type": "boolean" },
+          "suggested_action": { "type": "string" }
+        }
+      }
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/verify-mo313/schemas/
+git commit -m "feat: add JSON schemas for static, live, and final reports"
+```
+
+---
+
+### Task 2: Create Static Agent prompt template
+
+**Files:**
+- Create: `scripts/verify-mo313/prompts/static-agent.md`
+
+- [ ] **Step 1: Write static agent prompt**
+
+Write `scripts/verify-mo313/prompts/static-agent.md`:
+
+```markdown
+# Static Verification Agent — Bucket: {{BUCKET_NAME}}
+
+You are verifying the `mysql_compat` frontmatter field accuracy for a subset of MatrixOne SQL documentation files by comparing them against MySQL 8.0 reference documentation.
+
+## Your Bucket
+
+Read `bucket-manifest.json` and extract all files belonging to bucket `{{BUCKET_NAME}}`. This is your file list.
+
+For context, the JSON structure is:
+```json
+{
+  "buckets": {
+    "{{BUCKET_NAME}}": {
+      "file_count": N,
+      "files": [
+        { "path": "docs/MatrixOne/Reference/...", "mysql_compat": "full|partial|mo_only|none|unknown", "has_sql_blocks": true }
+      ]
+    }
+  }
+}
+```
+
+## What You Check
+
+For each file in your bucket, read the `.md` source. For each compat label, verify it against MySQL 8.0 docs:
+
+### compat = `full`
+- Does the MatrixOne documentation describe behavior identical to MySQL 8.0?
+- Check MySQL 8.0 reference docs (use WebFetch on https://dev.mysql.com/doc/refman/8.0/en/ for the corresponding feature)
+- If any behavioral difference is found → FAIL with evidence
+
+### compat = `partial`
+- Is each entry in `differs_from_mysql` accurate? (cross-check against MySQL 8.0 docs)
+- Are there obvious MySQL behaviors that MO differs on but are NOT listed in `differs_from_mysql`?
+- Are any claimed differences actually NOT different? (MO now matches MySQL)
+
+### compat = `mo_only`
+- Is this feature genuinely absent from MySQL 8.0?
+- Search MySQL 8.0 docs for equivalent syntax/function
+- If MySQL has it (or introduced it in 8.0.x) → FAIL
+
+### compat = `none`
+- Does MySQL 8.0 have this feature?
+- If MySQL also doesn't have it → PASS (correctly labeled as unsupported by both)
+- If MySQL has it and MO claims unsupported → FAIL (should likely be `partial` or `full`)
+- If MO page doesn't exist at all for a MySQL feature → STATIC_ONLY finding
+
+### compat = `unknown`
+- Based on MySQL 8.0 comparison, suggest a classification
+- If clearly matching MySQL → suggest `full`
+- If matching with differences → suggest `partial`
+- If clearly MO-only → suggest `mo_only`
+- If clearly unsupported → suggest `none`
+
+## Evidence Requirements
+
+Every finding MUST include:
+- `mysql_ref`: specific MySQL 8.0 doc URL or section (e.g., "https://dev.mysql.com/doc/refman/8.0/en/create-table.html")
+- `mysql_behavior`: what MySQL 8.0 does
+- `mo_doc_claim`: what the MO doc currently says
+- `suggestion`: what action to take
+
+## Output Format
+
+Produce a single JSON file: `static-{{BUCKET_NAME}}-report.json`
+
+Use the schema defined in `scripts/verify-mo313/schemas/static-report.schema.json`.
+
+Key rules:
+- One JSON object per file, with an array of findings
+- Each finding has: verdict (PASS/FAIL/WARN/SKIPPED), severity (CRITICAL/HIGH/MEDIUM/LOW), description, evidence
+- FAIL on classification errors, missing differences, incorrect mo_only claims
+- WARN on minor issues (unclear phrasing, missing edge cases)
+- SKIP files with no SQL content and no MySQL analog (e.g., pure MO architecture pages)
+- Include summary counts (total_files, total_claims, pass, fail, warn, skipped)
+
+## Important
+
+- Work file by file. Do NOT skip any file in your bucket.
+- For MySQL 8.0 lookups, use WebFetch on dev.mysql.com. If WebFetch fails, note the URL and mark finding as WARN with note "MySQL doc unreachable".
+- Do NOT connect to any database. This is purely a documentation comparison.
+- Write the JSON output to disk when complete.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add scripts/verify-mo313/prompts/static-agent.md
+git commit -m "feat: add static agent prompt template"
+```
+
+---
+
+### Task 3: Create Live Agent prompt template
+
+**Files:**
+- Create: `scripts/verify-mo313/prompts/live-agent.md`
+
+- [ ] **Step 1: Write live agent prompt**
+
+Write `scripts/verify-mo313/prompts/live-agent.md`:
+
+```markdown
+# Live Verification Agent — Bucket: {{BUCKET_NAME}}
+
+You are verifying the `mysql_compat` frontmatter field accuracy by executing SQL examples from MatrixOne documentation against a running MO 3.0.13 instance.
+
+## Connection
+
+- Host: 127.0.0.1
+- Port: 6001
+- User: root
+- Password: 111
+- Database: `audit_{{BUCKET_NAME}}`
+
+Before starting any checks, connect and verify:
+```bash
+mysql -h127.0.0.1 -P6001 -uroot -p111 -e "SELECT VERSION(); USE audit_{{BUCKET_NAME}}; SELECT DATABASE();"
+```
+
+## Your Bucket
+
+Read `bucket-manifest.json` and extract all files belonging to bucket `{{BUCKET_NAME}}`.
+
+## What You Check
+
+For each file in your bucket, read the `.md` source, extract SQL examples, and execute them.
+
+### compat = `full`
+- Execute all SQL examples from the documentation
+- Verify the actual output matches the expected output shown in the doc
+- If syntax error or different result → FAIL
+- If works exactly as documented → PASS
+
+### compat = `partial`
+- Execute SQL examples that exercise each `differs_from_mysql` entry
+- Verify the described difference is actually present in MO 3.0.13
+- If the claimed difference no longer exists (MO now matches MySQL) → FAIL (differs list is stale)
+- If the difference is accurately described → PASS
+
+### compat = `mo_only`
+- Execute the MO-specific syntax/functions documented
+- Verify they actually work in MO 3.0.13
+- If syntax error or feature missing → FAIL
+
+### compat = `none` (CRITICAL — this is the priority check)
+- Construct the MySQL-standard syntax for the claimed-unsupported feature
+- Execute it on MO 3.0.13
+- If you get "unsupported" / "syntax error" / "not supported" → PASS (truly unsupported)
+- If it EXECUTES SUCCESSFULLY → CRITICAL FAIL (the feature IS supported, compat should be changed)
+- If you get a different error (permissions, resource limits, etc.) → WARN (inconclusive)
+
+### compat = `unknown`
+- Execute SQL examples
+- Based on behavior, suggest: `full` (matches MySQL), `partial` (works but differs), `mo_only` (MO-specific), or `none` (unsupported)
+
+## Edge Cases
+
+- **SQL needs prior setup** (CREATE TABLE before INSERT, etc.): Build the minimal reproduction. Create temp tables, insert test data.
+- **SQL cannot execute** (needs special privileges, external data): Mark `SKIPPED` with explicit reason.
+- **Execution causes server crash/panic**: Mark `ERROR` with severity CRITICAL. This is an MO bug.
+- **Execution hangs**: Set a 30-second timeout per statement. Mark `ERROR` if timeout.
+
+## Cleanup
+
+After each file's checks, drop any test tables you created in `audit_{{BUCKET_NAME}}` to avoid cross-file interference.
+
+## Output Format
+
+Produce a single JSON file: `live-{{BUCKET_NAME}}-report.json`
+
+Use the schema defined in `scripts/verify-mo313/schemas/live-report.schema.json`.
+
+Key rules:
+- One JSON object per file, with an array of findings
+- Each finding has: verdict (PASS/FAIL/WARN/SKIPPED/ERROR), severity, description, evidence
+- evidence MUST include `sql_executed` and `actual_output`
+- Include summary counts
+- Mark `incomplete: true` only if you cannot finish all files
+
+## Important
+
+- Work file by file. Do NOT skip any file in your bucket.
+- For each file, first read the .md source to understand the claims, THEN execute SQL.
+- Always use the `audit_{{BUCKET_NAME}}` database. Create/drop test tables within it.
+- Always clean up test tables after each file.
+- Write the JSON output to disk when complete.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add scripts/verify-mo313/prompts/live-agent.md
+git commit -m "feat: add live agent prompt template"
+```
+
+---
+
+### Task 4: Create Merge Agent prompt template
+
+**Files:**
+- Create: `scripts/verify-mo313/prompts/merge-agent.md`
+
+- [ ] **Step 1: Write merge agent prompt**
+
+Write `scripts/verify-mo313/prompts/merge-agent.md`:
+
+```markdown
+# Merge Agent — Cross-Reference Static and Live Reports
+
+You merge the findings from 14 static agents and 14 live agents into a single `final-report.json`.
+
+## Inputs
+
+Read all 28 JSON report files. They follow these naming patterns:
+- `static-{bucket}-report.json` (14 files)
+- `live-{bucket}-report.json` (14 files)
+
+If any expected file is missing, note it in `meta.missing_buckets`.
+
+## Phase 1: Normalize
+
+For each file that appears in BOTH a static and live report:
+
+1. Match by `file` path (exact string match)
+2. Within the same file, match findings by semantic similarity. Two findings match if they describe the same issue (e.g., both mention "AUTO_INCREMENT differ"). Match generously — it's better to flag two findings as related than to miss a connection.
+3. Findings in static but not live → STATIC_ONLY
+4. Findings in live but not static → LIVE_ONLY
+
+## Phase 2: Cross-Reference
+
+For each matched finding pair, apply the merge matrix:
+
+| Static | Live   | Merge Verdict   |
+|--------|--------|-----------------|
+| PASS   | PASS   | PASS            |
+| FAIL   | FAIL   | CONFIRMED FAIL  |
+| PASS   | FAIL   | CONFLICT        |
+| FAIL   | PASS   | CONFLICT        |
+| WARN   | PASS   | PASS (downgrade)|
+| WARN   | FAIL   | CONFIRMED FAIL  |
+| WARN   | WARN   | CONFIRMED FAIL (promote WARN) |
+| (none) | PASS   | LIVE_ONLY       |
+| (none) | FAIL   | LIVE_ONLY       |
+| PASS   | (none) | STATIC_ONLY     |
+| FAIL   | (none) | STATIC_ONLY     |
+
+## Phase 3: CONFLICT Resolution
+
+For each CONFLICT pair:
+- Read both evidence objects carefully
+- If one side has clearly stronger evidence (e.g., live execution result trumps static assumption), set `auto_resolved: true` and pick the winning verdict, with explanation in `description`
+- If both sides have credible but contradictory evidence, set `needs_human_review: true`
+
+## Phase 4: Output
+
+Write `final-report.json` following the schema at `scripts/verify-mo313/schemas/final-report.schema.json`.
+
+Required aggregations:
+- `summary`: count all PASS / CONFIRMED FAIL / CONFLICT / LIVE_ONLY / STATIC_ONLY / needs_human_review
+- `by_severity`: count CRITICAL / HIGH / MEDIUM / LOW
+- `by_bucket`: per-bucket counts of pass / confirmed_fail / conflict
+
+Each finding entry must include:
+- `file`: the doc file path
+- `merge_verdict`: from the merge matrix
+- `severity`: highest severity from either agent (CRITICAL > HIGH > MEDIUM > LOW)
+- `description`: synthesized description combining both agents' findings
+- `static_evidence`: the static agent's evidence object (if exists)
+- `live_evidence`: the live agent's evidence object (if exists)
+- `auto_resolved`: true if the conflict was automatically resolved
+- `needs_human_review`: true if human judgment is needed
+- `suggested_action`: what to do (update frontmatter, fix body text, add to differs list, etc.)
+
+## Important
+
+- If a bucket has only a static report or only a live report (the other agent failed), still include those findings (they will all be STATIC_ONLY or LIVE_ONLY).
+- Sort findings by severity (CRITICAL first), then by bucket.
+- Always include `suggested_action` — make it actionable for a human or script.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add scripts/verify-mo313/prompts/merge-agent.md
+git commit -m "feat: add merge agent prompt template"
+```
+
+---
+
+### Task 5: Create orchestration script
+
+**Files:**
+- Create: `scripts/verify-mo313/orchestrate.sh`
+
+- [ ] **Step 1: Write orchestration script**
+
+Write `scripts/verify-mo313/orchestrate.sh`:
+
+```bash
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+print_success() { echo -e "${GREEN}==${NC} $1"; }
+print_warning() { echo -e "${YELLOW}==${NC} $1"; }
+print_error()   { echo -e "${RED}==${NC} $1"; }
+print_info()    { echo -e "${CYAN}--${NC} $1"; }
+
+# Bucket names (must match bucket-manifest.json keys)
+BUCKETS=(
+    "DDL"
+    "DML"
+    "DCL"
+    "DQL-base"
+    "DQL-apply"
+    "Other-SQL"
+    "Data-Types"
+    "Func-String"
+    "Func-Math"
+    "Func-Datetime"
+    "Func-Aggregate"
+    "Func-Other"
+    "Operators"
+    "Misc"
+)
+
+MO_VERSION="${MO_VERSION:-3.0.13}"
+OUTPUT_DIR="${REPO_ROOT}/audit-output-${MO_VERSION}"
+
+usage() {
+    echo "Usage: $0 {preflight|dispatch|merge|status|cleanup}"
+    echo ""
+    echo "Commands:"
+    echo "  preflight  Start MO ${MO_VERSION} Docker, create audit databases"
+    echo "  dispatch   Print agent dispatch instructions (28 agents + 1 merge)"
+    echo "  merge      Run the merge agent on collected reports"
+    echo "  status     Check which reports exist in ${OUTPUT_DIR}"
+    echo "  cleanup    Stop MO container, remove audit databases"
+    echo ""
+    echo "Environment:"
+    echo "  MO_VERSION   Target MatrixOne version (default: 3.0.13)"
+}
+
+# ---- Pre-flight ----
+
+do_preflight() {
+    echo "============================================================"
+    echo " Pre-flight: MO ${MO_VERSION}"
+    echo "============================================================"
+
+    # 1. Start MO Docker
+    print_info "Starting MO ${MO_VERSION} Docker..."
+    cd "$REPO_ROOT"
+    bash scripts/mo-test-env.sh start "$MO_VERSION"
+
+    # 2. Wait for readiness
+    print_info "Waiting for MO to be ready..."
+    sleep 5
+    for i in $(seq 1 30); do
+        if mysql -h127.0.0.1 -P6001 -uroot -p111 -e "SELECT 1" >/dev/null 2>&1; then
+            print_success "MO is ready"
+            break
+        fi
+        sleep 2
+    done
+
+    # 3. Create isolated databases
+    print_info "Creating audit databases..."
+    for bucket in "${BUCKETS[@]}"; do
+        local db_name="audit_${bucket//-/_}"
+        mysql -h127.0.0.1 -P6001 -uroot -p111 -e "DROP DATABASE IF EXISTS \`${db_name}\`; CREATE DATABASE \`${db_name}\`;" 2>/dev/null
+        print_success "Database ${db_name} created"
+    done
+
+    # 4. Create output directory
+    mkdir -p "$OUTPUT_DIR"
+    print_success "Output dir: ${OUTPUT_DIR}"
+
+    # 5. Verify bucket-manifest.json
+    if [ ! -f "$REPO_ROOT/bucket-manifest.json" ]; then
+        print_error "bucket-manifest.json not found!"
+        exit 1
+    fi
+    local file_count
+    file_count=$(python3 -c "import json; m=json.load(open('$REPO_ROOT/bucket-manifest.json')); print(m['total_files'])")
+    print_success "bucket-manifest.json has ${file_count} files across ${#BUCKETS[@]} buckets"
+}
+
+# ---- Dispatch ----
+
+do_dispatch() {
+    echo "============================================================"
+    echo " Agent Dispatch Instructions"
+    echo "============================================================"
+    echo ""
+    echo "Output directory: ${OUTPUT_DIR}"
+    echo ""
+    echo "--- STATIC AGENTS (14) ---"
+    echo ""
+    for bucket in "${BUCKETS[@]}"; do
+        local prompt_file="${SCRIPT_DIR}/prompts/static-agent.md"
+        local prompt_content
+        prompt_content=$(sed "s/{{BUCKET_NAME}}/${bucket}/g" "$prompt_file")
+        echo "### static-${bucket}"
+        echo "Prompt: ${prompt_file} (with BUCKET_NAME=${bucket})"
+        echo "Output: ${OUTPUT_DIR}/static-${bucket}-report.json"
+        echo ""
+    done
+
+    echo "--- LIVE AGENTS (14) ---"
+    echo ""
+    for bucket in "${BUCKETS[@]}"; do
+        local prompt_file="${SCRIPT_DIR}/prompts/live-agent.md"
+        local prompt_content
+        prompt_content=$(sed "s/{{BUCKET_NAME}}/${bucket}/g" "$prompt_file")
+        local db_name="audit_${bucket//-/_}"
+        echo "### live-${bucket}"
+        echo "Database: ${db_name}"
+        echo "Prompt: ${prompt_file} (with BUCKET_NAME=${bucket})"
+        echo "Output: ${OUTPUT_DIR}/live-${bucket}-report.json"
+        echo ""
+    done
+
+    echo "--- DISPATCH PLAN ---"
+    echo ""
+    echo "Launch all 28 agents in parallel as background agents."
+    echo "Each agent:"
+    echo "  1. Read its prompt file (already parameterized with bucket name)"
+    echo "  2. Execute verification"
+    echo "  3. Write JSON report to ${OUTPUT_DIR}/"
+    echo ""
+    echo "After all 28 complete (or timeout):"
+    echo "  Run: $0 merge"
+    echo ""
+    echo "--- AGENT DISPATCH COMMANDS ---"
+    echo ""
+    echo "For each bucket, dispatch two agents concurrently:"
+    echo ""
+    echo '```'
+    echo '# Example for bucket DDL:'
+    echo ''
+    echo '# Static agent:'
+    echo 'cat scripts/verify-mo313/prompts/static-agent.md | sed "s/{{BUCKET_NAME}}/DDL/g"'
+    echo ''
+    echo '# Live agent:'
+    echo 'cat scripts/verify-mo313/prompts/live-agent.md | sed "s/{{BUCKET_NAME}}/DDL/g"'
+    echo '```'
+}
+
+# ---- Merge ----
+
+do_merge() {
+    echo "============================================================"
+    echo " Merge Reports"
+    echo "============================================================"
+
+    # Count available reports
+    local static_count live_count
+    static_count=$(ls "${OUTPUT_DIR}"/static-*-report.json 2>/dev/null | wc -l | tr -d ' ')
+    live_count=$(ls "${OUTPUT_DIR}"/live-*-report.json 2>/dev/null | wc -l | tr -d ' ')
+
+    print_info "Static reports found: ${static_count}/14"
+    print_info "Live reports found: ${live_count}/14"
+
+    if [ "$static_count" -eq 0 ] && [ "$live_count" -eq 0 ]; then
+        print_error "No reports found in ${OUTPUT_DIR}"
+        exit 1
+    fi
+
+    print_info "To run the merge, provide the merge agent prompt to a Claude Code agent:"
+    echo ""
+    echo "  Prompt file: scripts/verify-mo313/prompts/merge-agent.md"
+    echo "  Input dir: ${OUTPUT_DIR}"
+    echo "  Output: ${OUTPUT_DIR}/final-report.json"
+}
+
+# ---- Status ----
+
+do_status() {
+    echo "Report Status for MO ${MO_VERSION}:"
+    echo ""
+
+    for bucket in "${BUCKETS[@]}"; do
+        local s_ok l_ok
+        if [ -f "${OUTPUT_DIR}/static-${bucket}-report.json" ]; then
+            s_ok="${GREEN}DONE${NC}"
+        else
+            s_ok="${RED}MISS${NC}"
+        fi
+        if [ -f "${OUTPUT_DIR}/live-${bucket}-report.json" ]; then
+            l_ok="${GREEN}DONE${NC}"
+        else
+            l_ok="${RED}MISS${NC}"
+        fi
+        printf "  %-15s  static: %b  live: %b\n" "$bucket" "$s_ok" "$l_ok"
+    done
+
+    if [ -f "${OUTPUT_DIR}/final-report.json" ]; then
+        echo ""
+        print_success "final-report.json exists"
+    fi
+}
+
+# ---- Cleanup ----
+
+do_cleanup() {
+    print_info "Stopping MO container..."
+    cd "$REPO_ROOT"
+    bash scripts/mo-test-env.sh stop
+    print_success "Cleanup complete"
+}
+
+# ---- Main ----
+
+case "${1:-}" in
+    preflight) do_preflight ;;
+    dispatch)  do_dispatch ;;
+    merge)     do_merge ;;
+    status)    do_status ;;
+    cleanup)   do_cleanup ;;
+    *)
+        usage
+        exit 1
+        ;;
+esac
+```
+
+- [ ] **Step 2: Make executable**
+
+```bash
+chmod +x scripts/verify-mo313/orchestrate.sh
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/verify-mo313/orchestrate.sh
+git commit -m "feat: add orchestration script for pre-flight, dispatch, merge, and cleanup"
+```
+
+---
+
+### Task 6: Create README with usage instructions
+
+**Files:**
+- Create: `scripts/verify-mo313/README.md`
+
+- [ ] **Step 1: Write README**
+
+Write `scripts/verify-mo313/README.md`:
+
+```markdown
+# verify-mo313 — Multi-Agent Parallel Documentation Verification
+
+Verifies `mysql_compat` frontmatter accuracy for all 402 SQL Reference docs against MatrixOne 3.0.13 using 28 parallel agents (14 static + 14 live) with cross-referenced merge.
+
+## Quick Start
+
+```bash
+# 1. Start MO 3.0.13 and create test databases
+./scripts/verify-mo313/orchestrate.sh preflight
+
+# 2. Print dispatch instructions
+./scripts/verify-mo313/orchestrate.sh dispatch
+
+# 3. Dispatch 28 agents in Claude Code (see dispatch output above)
+#    Each agent gets a parameterized prompt from prompts/static-agent.md or prompts/live-agent.md
+#    Run static and live agents for ALL 14 buckets
+
+# 4. Check which reports are done
+./scripts/verify-mo313/orchestrate.sh status
+
+# 5. When all 28 reports exist, run merge
+./scripts/verify-mo313/orchestrate.sh merge
+
+# 6. Clean up
+./scripts/verify-mo313/orchestrate.sh cleanup
+```
+
+## Files
+
+```
+scripts/verify-mo313/
+├── orchestrate.sh              # Pre-flight, dispatch, merge, status, cleanup
+├── prompts/
+│   ├── static-agent.md         # Template: static verification per bucket
+│   ├── live-agent.md           # Template: live SQL execution per bucket
+│   └── merge-agent.md          # Template: cross-reference 28 reports
+├── schemas/
+│   ├── static-report.schema.json
+│   ├── live-report.schema.json
+│   └── final-report.schema.json
+└── README.md
+```
+
+## Agent Dispatch (manual, in Claude Code)
+
+For each of the 14 buckets, launch two agents in Claude Code:
+
+**Static agent:**
+```
+Read prompts/static-agent.md (replace {{BUCKET_NAME}} with the bucket name).
+Read bucket-manifest.json for your bucket's file list.
+For each file, compare MO doc against MySQL 8.0 docs.
+Output to audit-output-3.0.13/static-{bucket}-report.json
+```
+
+**Live agent:**
+```
+Read prompts/live-agent.md (replace {{BUCKET_NAME}} with the bucket name).
+Connect to MO 3.0.13 at 127.0.0.1:6001 (root/111), use database audit_{bucket}.
+Read bucket-manifest.json for your bucket's file list.
+For each file, execute SQL examples against MO.
+Output to audit-output-3.0.13/live-{bucket}-report.json
+```
+
+Launch all 28 in parallel. Each agent works independently.
+
+## Merge
+
+After all 28 reports are collected:
+
+```
+Read prompts/merge-agent.md.
+Read all 28 report files from audit-output-3.0.13/.
+Cross-reference, resolve conflicts, output final-report.json.
+```
+
+## Output
+
+- `audit-output-3.0.13/static-{bucket}-report.json` (14 files)
+- `audit-output-3.0.13/live-{bucket}-report.json` (14 files)
+- `audit-output-3.0.13/final-report.json` (1 file, merged)
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add scripts/verify-mo313/README.md
+git commit -m "docs: add verify-mo313 README with usage instructions"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+- Static agent check logic (full/partial/mo_only/none/unknown) → Task 2 (static prompt)
+- Live agent check logic, none validation priority, isolation → Task 3 (live prompt)
+- Merge agent normalize, cross-reference, conflict resolution → Task 4 (merge prompt)
+- JSON output schemas for all three agent types → Task 1 (schemas)
+- Orchestration pre-flight, dispatch, timeout/retry, merge → Task 5 (orchestrate.sh)
+- Deliverable final-report.json → Task 1 schema + Task 4 merge prompt
+- Coverage: All spec sections accounted for.
+
+**2. Placeholder scan:**
+- No TBD, TODO, or "implement later"
+- All prompt content is complete and self-contained
+- All schemas are fully specified
+- All shell script logic is implemented
+
+**3. Type consistency:**
+- Schema field names match across static, live, and final schemas
+- `verdict` values: PASS/FAIL/WARN/SKIPPED/ERROR — consistent
+- `severity` values: CRITICAL/HIGH/MEDIUM/LOW — identical across schemas
+- `evidence` objects: each agent type has its own evidence schema, merge references both
+- Bucket names in orchestrate.sh match the keys in bucket-manifest.json
+
+**4. Gap check:**
+- Timeout/retry: orchestrate.sh `do_dispatch` mentions timeout handling in instructions; actual retry is done manually by the orchestrator (re-launch failed agent)
+- Agent isolation (live): database-per-agent (`audit_{bucket}`) covered in preflight
+- Incomplete flag: called out in both agent prompts and schemas

--- a/docs/superpowers/specs/2026-05-26-multi-agent-parallel-verification-design.md
+++ b/docs/superpowers/specs/2026-05-26-multi-agent-parallel-verification-design.md
@@ -1,0 +1,210 @@
+# Multi-Agent Parallel Verification Design (MO 3.0.13)
+
+## Goal
+
+Verify `mysql_compat` frontmatter accuracy for all 402 SQL Reference files against MO 3.0.13. Check whether `full`/`partial`/`mo_only` claims are correct, and whether `none` (unsupport) claims are genuinely unsupported.
+
+## Architecture
+
+```
+Orchestrator (启动 28 agent + 1 merge)
+    │
+    ├── 14 Static Agents  (MySQL 8.0 doc comparison)
+    └── 14 Live Agents    (MO 3.0.13 SQL execution)
+            │
+            ▼
+      Merge Agent (交叉比对 → 最终报告)
+```
+
+28 independent agents run in parallel. A Merge Agent runs after all complete, cross-referencing static and live findings into a single `final-report.json`.
+
+- **Static Agent**: Compares MO doc content against MySQL 8.0 reference docs. No MO instance needed.
+- **Live Agent**: Connects to MO 3.0.13 Docker, executes SQL examples, validates behavior.
+- **Merge Agent**: Normalizes, cross-references, resolves conflicts, outputs final structured report.
+- **File allocation**: Reuses existing `bucket-manifest.json` (14 buckets, 402 files).
+
+---
+
+## Static Agent
+
+### Input
+- File list from `bucket-manifest.json` for its bucket
+- MatrixOne .md source (frontmatter + body)
+- MySQL 8.0 docs (WebFetch or local cache)
+
+### Check Logic
+
+| compat | Check | Evidence Required |
+|--------|-------|-------------------|
+| `full` | MO doc matches MySQL 8.0 syntax/semantics | MySQL doc section reference, version |
+| `partial` | `differs_from_mysql` accurate, no missing differences | Per-difference MySQL cross-reference |
+| `mo_only` | Feature genuinely absent from MySQL 8.0 | Search confirmation of no MySQL equivalent |
+| `none` | MySQL has it, MO claims unsupported | Confirm MySQL has it, MO has no doc |
+| `unknown` | Classify with recommendation | MySQL doc comparison |
+
+### Output (per file)
+
+```json
+{
+  "file": "docs/MatrixOne/Reference/.../create-table.md",
+  "bucket": "DDL",
+  "agent": "static",
+  "current_compat": "partial",
+  "findings": [
+    {
+      "field": "partial",
+      "verdict": "PASS|FAIL|WARN",
+      "severity": "CRITICAL|HIGH|MEDIUM|LOW",
+      "description": "...",
+      "evidence": { "mysql_ref": "...", "mysql_behavior": "...", "mo_doc_claim": "...", "suggestion": "..." }
+    }
+  ],
+  "suggested_compat": "partial",
+  "checked_at": "ISO8601"
+}
+```
+
+---
+
+## Live Agent
+
+### Prerequisites
+- MO 3.0.13 Docker running locally
+- Isolated database per agent (`audit_DDL`, `audit_DML`, ...)
+- MySQL protocol connection
+
+### Check Logic
+
+| compat | Check | Action |
+|--------|-------|--------|
+| `full` | Full syntax/semantics compatibility | Execute all SQL examples, validate output |
+| `partial` | Documented behavior matches reality | Execute SQL, verify each `differs_from_mysql` entry |
+| `mo_only` | Feature exists and works | Execute MO-specific syntax/functions |
+| `none` | Truly unsupported | Execute MySQL-standard syntax on MO, confirm it errors |
+| `unknown` | Determine actual compat | Execute examples, compare with MySQL behavior |
+
+### `none` Validation (critical)
+
+1. Extract MySQL-standard syntax for the feature
+2. Execute on MO
+3. "unsupported" / "syntax error" → `none` confirmed
+4. Executes successfully → CRITICAL FAIL (should be `full`/`partial`)
+5. Other error (permissions, resources) → WARN (inconclusive)
+
+### Isolation
+
+Each live agent uses a dedicated database (`audit_bucket_<name>`) to avoid cross-agent interference.
+
+### Output (per file)
+
+```json
+{
+  "file": "docs/MatrixOne/Reference/.../create-table.md",
+  "bucket": "DDL",
+  "agent": "live",
+  "current_compat": "partial",
+  "mo_version": "3.0.13",
+  "findings": [
+    {
+      "field": "partial",
+      "verdict": "PASS|FAIL|WARN",
+      "severity": "CRITICAL|HIGH|MEDIUM|LOW",
+      "description": "...",
+      "evidence": { "sql_executed": "...", "actual_output": "...", "expected_behavior": "...", "matches_doc": true }
+    }
+  ],
+  "checked_at": "ISO8601"
+}
+```
+
+### Edge Cases
+- SQL needs context (data, multi-step) → build minimal reproduction
+- Cannot execute → `SKIPPED` with reason
+- Timeout / server panic → `ERROR` (likely MO bug)
+
+---
+
+## Merge Agent
+
+### 3 Phases
+
+1. **Normalize**: Match static and live findings per file. Direct `file` path match first; within same file, match findings by LLM semantic similarity (threshold: 0.7). Unmatched findings become STATIC_ONLY or LIVE_ONLY.
+2. **Cross-reference**: Apply merge matrix to classify each finding
+3. **Output**: Generate `final-report.json`
+
+### Merge Matrix
+
+```
+static × live → merge_verdict
+
+PASS  × PASS   → PASS              (both agree, correct)
+FAIL  × FAIL   → CONFIRMED FAIL    (both agree, issue confirmed)
+PASS  × FAIL   → CONFLICT          (disagree, needs human review)
+FAIL  × PASS   → CONFLICT          (disagree, needs human review)
+WARN  × (any)  → (keeps the non-WARN verdict, or WARN if both WARN)
+(无)  × PASS   → LIVE_ONLY         (only live agent caught this)
+(无)  × FAIL   → LIVE_ONLY
+PASS  × (无)   → STATIC_ONLY       (only static agent caught this)
+FAIL  × (无)   → STATIC_ONLY
+```
+
+### CONFLICT Resolution
+- Compare evidence strength; if one side clearly outweighs the other → `auto_resolved: true` with reasoning
+- If genuinely ambiguous → `needs_human_review: true`
+
+### Final Report Schema
+
+```json
+{
+  "meta": { "mo_version": "3.0.13", "generated_at": "ISO8601", "total_files": 402, "total_buckets": 14, "static_agents": 14, "live_agents": 14 },
+  "summary": { "total_claims_checked": 0, "pass": 0, "confirmed_fail": 0, "conflict": 0, "live_only": 0, "static_only": 0, "needs_human_review": 0 },
+  "by_severity": { "critical": 0, "high": 0, "medium": 0, "low": 0 },
+  "by_bucket": { "DDL": { "pass": 0, "confirmed_fail": 0, "conflict": 0 }, "..." : {} },
+  "findings": [
+    {
+      "file": "...",
+      "merge_verdict": "CONFIRMED FAIL",
+      "severity": "HIGH",
+      "description": "...",
+      "static_evidence": {},
+      "live_evidence": {},
+      "auto_resolved": false,
+      "suggested_action": "..."
+    }
+  ]
+}
+```
+
+---
+
+## Orchestration
+
+### Pre-flight (manual/scripted)
+1. Verify `bucket-manifest.json` is current
+2. Start MO 3.0.13 Docker instance
+3. Create 14 isolated databases: `audit_DDL` .. `audit_Misc`
+4. Verify MO connectivity
+
+### Launch
+All 28 agents launched in parallel. Each produces `{type}-{bucket}-report.json`.
+
+### Timeout & Retry
+- Per-agent timeout: 30 min
+- Partial results saved on timeout (marked `incomplete: true`)
+- Crash → retry once, then skip bucket
+- Merge triggers when all agents complete or timeout
+
+### Merge
+- Runs after all 28 agents finish
+- Outputs `final-report.json`
+
+### Post-Merge (optional)
+- Filter by severity=CRITICAL for immediate human review
+- Deep-verify CONFLICT items
+- Batch-apply confirmed fixes to doc frontmatter
+
+---
+
+## Deliverable
+
+Single structured JSON file: `final-report.json`. Machine-consumable. Contains all findings with evidence, severity classification, and merge verdicts.

--- a/scripts/generate-compat-matrix.js
+++ b/scripts/generate-compat-matrix.js
@@ -1,12 +1,12 @@
 #!/usr/bin/env node
 /**
- * Build `docs/MatrixOne/Reference/mysql-compatibility-matrix.md` from the
- * `mysql_compat` frontmatter across every SQL-Reference page.
+ * Build `docs/MatrixOne/Reference/mysql-compatibility-matrix.md` and
+ * `mysql-compatibility-matrix.json` from the `mysql_compat` frontmatter across
+ * all Reference pages.
  *
- * The output page groups SQL-Reference pages by their top-level category
- * (DDL/DML/DCL/DQL/Other) and shows their compatibility status plus any
- * declared differences. Regenerated deterministically from source — do not
- * edit the output file by hand.
+ * Outputs:
+ *   - Markdown table (human-readable, merged Notes column)
+ *   - JSON sidecar (agent-friendly, structured, filterable)
  */
 
 import glob from 'fast-glob'
@@ -14,17 +14,9 @@ import { readFileSync, writeFileSync } from 'node:fs'
 import path from 'node:path'
 import { parseFrontmatter } from './doc-validator/checkers/compat-frontmatter.js'
 
-const ROOT = 'docs/MatrixOne/Reference/SQL-Reference'
-const OUTPUT = 'docs/MatrixOne/Reference/mysql-compatibility-matrix.md'
-
-const CATEGORY_ORDER = [
-  ['Data-Definition-Language', 'Data Definition Language (DDL)'],
-  ['Data-Manipulation-Language', 'Data Manipulation Language (DML)'],
-  ['Data-Query-Language', 'Data Query Language (DQL)'],
-  ['Data-Control-Language', 'Data Control Language (DCL)'],
-  ['Other', 'Other'],
-  ['__root__', 'Uncategorized'],
-]
+const ROOT = 'docs/MatrixOne/Reference'
+const OUTPUT_MD = 'docs/MatrixOne/Reference/mysql-compatibility-matrix.md'
+const OUTPUT_JSON = 'docs/MatrixOne/Reference/mysql-compatibility-matrix.json'
 
 const COMPAT_LABEL = {
   full: '✅ Full',
@@ -34,35 +26,223 @@ const COMPAT_LABEL = {
   unknown: '❓ Unknown',
 }
 
+const SOURCES = [
+  { dir: 'SQL-Reference',            label: 'SQL Statements',      colName: 'Statement' },
+  { dir: 'Functions-and-Operators',  label: 'Functions',           colName: 'Function' },
+  { dir: 'Operators',                label: 'Operators',           colName: 'Operator' },
+  { dir: 'Data-Types',               label: 'Data Types',          colName: 'Data Type' },
+  { dir: 'Language-Structure',       label: 'Language Structure',  colName: 'Element' },
+]
+
+const SUBDIR_LABELS = {
+  'Aggregate-Functions': 'Aggregate Functions',
+  'Window-Functions': 'Window Functions',
+  'system-ops': 'System Operations',
+  'Data-Definition-Language': 'Data Definition Language (DDL)',
+  'Data-Manipulation-Language': 'Data Manipulation Language (DML)',
+  'Data-Query-Language': 'Data Query Language (DQL)',
+  'Data-Control-Language': 'Data Control Language (DCL)',
+  'date-time-data-types': 'Date/Time Data Types',
+  'arithmetic-operators': 'Arithmetic Operators',
+  'assignment-operators': 'Assignment Operators',
+  'bit-functions-and-operators': 'Bit Functions and Operators',
+  'cast-functions-and-operators': 'Cast Functions and Operators',
+  'comparison-functions-and-operators': 'Comparison Functions and Operators',
+  'flow-control-functions': 'Flow Control Functions',
+  'logical-operators': 'Logical Operators',
+}
+
+/** Source-dir -> short prefix for entry IDs. */
+const SOURCE_ID_PREFIX = {
+  'SQL-Reference': 'sql',
+  'Functions-and-Operators': 'func',
+  'Operators': 'op',
+  'Data-Types': 'dtype',
+  'Language-Structure': 'lang',
+}
+
+function subdirLabel(dir) {
+  return SUBDIR_LABELS[dir] || dir.replace(/-/g, ' ')
+}
+
 function categoryOf(relPath) {
   const parts = relPath.split('/')
   if (parts.length <= 1) return '__root__'
   return parts[0]
 }
 
-async function main() {
-  const files = await glob(`${ROOT}/**/*.md`)
+function cleanRelPath(sourceDir, relPath) {
+  if (sourceDir === 'Operators') {
+    const parts = relPath.split('/')
+    if (parts[0] === 'operators') return parts.slice(1).join('/')
+  }
+  return relPath
+}
+
+/** Derive a stable machine-readable ID from a source-relative path. */
+function entryId(sourceDir, relPath) {
+  const prefix = SOURCE_ID_PREFIX[sourceDir] || sourceDir.toLowerCase()
+  // Strip .md, replace path separators and dashes with dots
+  const slug = cleanRelPath(sourceDir, relPath)
+    .replace(/\.md$/, '')
+    .replace(/[\/\\]/g, '.')
+    .replace(/-/g, '_')
+    .toLowerCase()
+  return `${prefix}.${slug}`
+}
+
+/** Build the JSON structure consumed by agents. */
+function buildJson(rowsBySource, totals) {
+  const sections = []
+  for (const source of SOURCES) {
+    const rows = rowsBySource[source.dir]
+    if (!rows || rows.length === 0) continue
+
+    const categories = [...new Set(rows.map(r => r.category))]
+    categories.sort((a, b) => {
+      if (a === '__root__') return -1
+      if (b === '__root__') return 1
+      return a.localeCompare(b)
+    })
+
+    const cats = []
+    for (const cat of categories) {
+      const catRows = rows.filter(r => r.category === cat)
+      const label = cat === '__root__' ? source.label : subdirLabel(cat)
+      cats.push({
+        id: cat === '__root__' ? '_root' : cat.toLowerCase().replace(/[\/\\]/g, '.').replace(/-/g, '_'),
+        label,
+        entries: catRows.map(r => ({
+          id: entryId(source.dir, r.rel),
+          title: r.title,
+          path: `${ROOT}/${source.dir}/${r.rel}`,
+          compat: r.compat,
+          notes: [...(r.differs.length ? r.differs : []), ...(r.mo_only.length ? r.mo_only.map(s => `[MO-only] ${s}`) : [])],
+        })).sort((a, b) => a.title.localeCompare(b.title)),
+      })
+    }
+
+    sections.push({
+      id: source.dir.toLowerCase(),
+      label: source.label,
+      summary: {
+        full: rows.filter(r => r.compat === 'full').length,
+        partial: rows.filter(r => r.compat === 'partial').length,
+        none: rows.filter(r => r.compat === 'none').length,
+        mo_only: rows.filter(r => r.compat === 'mo_only').length,
+        unknown: rows.filter(r => r.compat === 'unknown').length,
+      },
+      categories: cats,
+    })
+  }
+
+  return {
+    generated_at: new Date().toISOString(),
+    summary: {
+      total: Object.values(totals).reduce((a, b) => a + b, 0),
+      full: totals.full || 0,
+      partial: totals.partial || 0,
+      none: totals.none || 0,
+      mo_only: totals.mo_only || 0,
+      unknown: totals.unknown || 0,
+    },
+    sections,
+  }
+}
+
+async function scanSource(sourceDir) {
+  const sourceRoot = `${ROOT}/${sourceDir}`
+  const files = await glob(`${sourceRoot}/**/*.md`)
   const rows = []
   for (const file of files) {
-    const rel = path.relative(ROOT, file)
+    const rel = path.relative(sourceRoot, file)
     const raw = readFileSync(file, 'utf-8')
     const fm = parseFrontmatter(raw) || {}
+    const displayRel = cleanRelPath(sourceDir, rel)
     rows.push({
       file,
-      rel,
-      category: categoryOf(rel),
-      title: fm.title || rel.replace(/\.md$/, ''),
+      rel: displayRel,
+      category: categoryOf(displayRel),
+      title: fm.title || path.basename(displayRel, '.md'),
       compat: fm.mysql_compat || 'unknown',
       differs: Array.isArray(fm.differs_from_mysql) ? fm.differs_from_mysql : [],
       mo_only: Array.isArray(fm.mo_only) ? fm.mo_only : [],
     })
   }
+  return rows
+}
 
-  const totals = rows.reduce((acc, r) => {
-    acc[r.compat] = (acc[r.compat] || 0) + 1
-    return acc
-  }, {})
+function escapeCell(s) {
+  return String(s).replace(/\|/g, '\\|')
+}
 
+/** Render a single row's notes cell. Combines differs + mo_only when both present. */
+function renderNotes(r) {
+  const parts = []
+  if (r.differs.length) parts.push(...r.differs)
+  if (r.mo_only.length) {
+    const labeled = r.mo_only.map(s => `[MO-only] ${s}`)
+    parts.push(...labeled)
+  }
+  return parts.length ? parts.map(escapeCell).join('<br/>') : '—'
+}
+
+function renderSection(source, rows) {
+  const out = []
+  out.push(`## ${source.label}`)
+  out.push('')
+
+  const secTotals = rows.reduce((acc, r) => { acc[r.compat] = (acc[r.compat] || 0) + 1; return acc }, {})
+  out.push('| Status | Count |')
+  out.push('|---|---|')
+  for (const key of ['full', 'partial', 'none', 'mo_only', 'unknown']) {
+    if (secTotals[key]) out.push(`| ${COMPAT_LABEL[key]} | ${secTotals[key]} |`)
+  }
+  out.push(`| **Total** | **${rows.length}** |`)
+  out.push('')
+
+  const categories = [...new Set(rows.map(r => r.category))]
+  categories.sort((a, b) => {
+    if (a === '__root__') return -1
+    if (b === '__root__') return 1
+    return a.localeCompare(b)
+  })
+
+  for (const cat of categories) {
+    const catRows = rows.filter(r => r.category === cat)
+    const label = cat === '__root__' ? source.label : subdirLabel(cat)
+    out.push(`### ${label}`)
+    out.push('')
+    out.push(`| ${source.colName} | MySQL Compat | Notes |`)
+    out.push('|---|---|---|')
+    catRows.sort((a, b) => a.title.localeCompare(b.title))
+    for (const r of catRows) {
+      const link = `[${escapeCell(r.title)}](./${source.dir}/${r.rel.replace(/\\/g, '/')})`
+      const compat = COMPAT_LABEL[r.compat] || r.compat
+      out.push(`| ${link} | ${compat} | ${renderNotes(r)} |`)
+    }
+    out.push('')
+  }
+
+  return out
+}
+
+async function main() {
+  const allRows = []
+  const rowsBySource = {}
+  const sections = []
+
+  for (const source of SOURCES) {
+    const rows = await scanSource(source.dir)
+    if (rows.length === 0) continue
+    rowsBySource[source.dir] = rows
+    allRows.push(...rows)
+    sections.push(renderSection(source, rows))
+  }
+
+  const totals = allRows.reduce((acc, r) => { acc[r.compat] = (acc[r.compat] || 0) + 1; return acc }, {})
+
+  // ---- Markdown output ----
   const out = []
   out.push('---')
   out.push('title: "MySQL Compatibility Matrix"')
@@ -72,9 +252,9 @@ async function main() {
   out.push('# MySQL Compatibility Matrix')
   out.push('')
   out.push('> Auto-generated from `mysql_compat` frontmatter across')
-  out.push('> `docs/MatrixOne/Reference/SQL-Reference/**`. Do not edit by hand —')
-  out.push('> re-run `node scripts/generate-compat-matrix.js` after updating any')
-  out.push('> source page.')
+  out.push(`> ${SOURCES.map(s => `\`${ROOT}/${s.dir}/**\``).join(', ')}.`)
+  out.push('> Do not edit by hand — re-run `node scripts/generate-compat-matrix.js`')
+  out.push('> after updating any source page.')
   out.push('')
   out.push('## Summary')
   out.push('')
@@ -83,34 +263,22 @@ async function main() {
   for (const key of ['full', 'partial', 'none', 'mo_only', 'unknown']) {
     out.push(`| ${COMPAT_LABEL[key]} | ${totals[key] || 0} |`)
   }
-  out.push(`| **Total** | **${rows.length}** |`)
+  out.push(`| **Total** | **${allRows.length}** |`)
   out.push('')
 
-  for (const [key, label] of CATEGORY_ORDER) {
-    const catRows = rows.filter(r => r.category === key)
-    if (catRows.length === 0) continue
-    out.push(`## ${label}`)
-    out.push('')
-    out.push('| Statement | MySQL Compat | Differences from MySQL | MatrixOne-only |')
-    out.push('|---|---|---|---|')
-    catRows.sort((a, b) => a.title.localeCompare(b.title))
-    for (const r of catRows) {
-      const link = `[${escapeCell(r.title)}](./SQL-Reference/${r.rel.replace(/\\/g, '/')})`
-      const compat = COMPAT_LABEL[r.compat] || r.compat
-      const differs = r.differs.length ? r.differs.map(escapeCell).join('<br/>') : '—'
-      const moOnly = r.mo_only.length ? r.mo_only.map(escapeCell).join('<br/>') : '—'
-      out.push(`| ${link} | ${compat} | ${differs} | ${moOnly} |`)
-    }
-    out.push('')
+  for (const section of sections) {
+    out.push(...section)
   }
 
-  writeFileSync(OUTPUT, out.join('\n'), 'utf-8')
-  console.log(`✓ Wrote ${OUTPUT}`)
-  console.log(`  ${rows.length} rows, distribution: ${Object.entries(totals).map(([k, v]) => `${k}=${v}`).join(', ')}`)
-}
+  writeFileSync(OUTPUT_MD, out.join('\n'), 'utf-8')
+  console.log(`✓ Wrote ${OUTPUT_MD}`)
 
-function escapeCell(s) {
-  return String(s).replace(/\|/g, '\\|')
+  // ---- JSON output (agent-friendly) ----
+  const json = buildJson(rowsBySource, totals)
+  writeFileSync(OUTPUT_JSON, JSON.stringify(json, null, 2), 'utf-8')
+  console.log(`✓ Wrote ${OUTPUT_JSON}`)
+
+  console.log(`  ${allRows.length} rows, distribution: ${Object.entries(totals).map(([k, v]) => `${k}=${v}`).join(', ')}`)
 }
 
 main().catch(err => { console.error(err); process.exit(1) })

--- a/scripts/verify-mo313/README.md
+++ b/scripts/verify-mo313/README.md
@@ -1,0 +1,81 @@
+# verify-mo313 — Multi-Agent Parallel Documentation Verification
+
+Verifies `mysql_compat` frontmatter accuracy for all 402 SQL Reference docs against MatrixOne 3.0.13 using 28 parallel agents (14 static + 14 live) with cross-referenced merge.
+
+## Quick Start
+
+```bash
+# 1. Start MO 3.0.13 and create test databases
+./scripts/verify-mo313/orchestrate.sh preflight
+
+# 2. Print dispatch instructions
+./scripts/verify-mo313/orchestrate.sh dispatch
+
+# 3. Dispatch 28 agents in Claude Code (see dispatch output above)
+#    Each agent gets a parameterized prompt from prompts/static-agent.md or prompts/live-agent.md
+#    Run static and live agents for ALL 14 buckets
+
+# 4. Check which reports are done
+./scripts/verify-mo313/orchestrate.sh status
+
+# 5. When all 28 reports exist, run merge
+./scripts/verify-mo313/orchestrate.sh merge
+
+# 6. Clean up
+./scripts/verify-mo313/orchestrate.sh cleanup
+```
+
+## Files
+
+```
+scripts/verify-mo313/
+├── orchestrate.sh              # Pre-flight, dispatch, merge, status, cleanup
+├── prompts/
+│   ├── static-agent.md         # Template: static verification per bucket
+│   ├── live-agent.md           # Template: live SQL execution per bucket
+│   └── merge-agent.md          # Template: cross-reference 28 reports
+├── schemas/
+│   ├── static-report.schema.json
+│   ├── live-report.schema.json
+│   └── final-report.schema.json
+└── README.md
+```
+
+## Agent Dispatch (manual, in Claude Code)
+
+For each of the 14 buckets, launch two agents in Claude Code:
+
+**Static agent:**
+```
+Read prompts/static-agent.md (replace {{BUCKET_NAME}} with the bucket name).
+Read bucket-manifest.json for your bucket's file list.
+For each file, compare MO doc against MySQL 8.0 docs.
+Output to audit-output-3.0.13/static-{bucket}-report.json
+```
+
+**Live agent:**
+```
+Read prompts/live-agent.md (replace {{BUCKET_NAME}} with the bucket name).
+Connect to MO 3.0.13 at 127.0.0.1:6001 (root/111), use database audit_{bucket}.
+Read bucket-manifest.json for your bucket's file list.
+For each file, execute SQL examples against MO.
+Output to audit-output-3.0.13/live-{bucket}-report.json
+```
+
+Launch all 28 in parallel. Each agent works independently.
+
+## Merge
+
+After all 28 reports are collected:
+
+```
+Read prompts/merge-agent.md.
+Read all 28 report files from audit-output-3.0.13/.
+Cross-reference, resolve conflicts, output final-report.json.
+```
+
+## Output
+
+- `audit-output-3.0.13/static-{bucket}-report.json` (14 files)
+- `audit-output-3.0.13/live-{bucket}-report.json` (14 files)
+- `audit-output-3.0.13/final-report.json` (1 file, merged)

--- a/scripts/verify-mo313/README.md
+++ b/scripts/verify-mo313/README.md
@@ -2,6 +2,13 @@
 
 Verifies `mysql_compat` frontmatter accuracy for all 402 SQL Reference docs against MatrixOne 3.0.13 using 28 parallel agents (14 static + 14 live) with cross-referenced merge.
 
+## Prerequisites
+
+- Docker running locally
+- `mysql` CLI installed and on PATH
+- `python3` installed and on PATH
+- `scripts/mo-test-env.sh` helper script present
+
 ## Quick Start
 
 ```bash

--- a/scripts/verify-mo313/orchestrate.sh
+++ b/scripts/verify-mo313/orchestrate.sh
@@ -44,7 +44,7 @@ usage() {
     echo "  dispatch   Print agent dispatch instructions (28 agents + 1 merge)"
     echo "  merge      Run the merge agent on collected reports"
     echo "  status     Check which reports exist in ${OUTPUT_DIR}"
-    echo "  cleanup    Stop MO container, remove audit databases"
+    echo "  cleanup    Stop MO container"
     echo ""
     echo "Environment:"
     echo "  MO_VERSION   Target MatrixOne version (default: 3.0.13)"
@@ -72,11 +72,15 @@ do_preflight() {
         fi
         sleep 2
     done
+    if ! mysql -h127.0.0.1 -P6001 -uroot -p111 -e "SELECT 1" >/dev/null 2>&1; then
+        print_error "MO did not become ready after 60 seconds"
+        exit 1
+    fi
 
     # 3. Create isolated databases
     print_info "Creating audit databases..."
     for bucket in "${BUCKETS[@]}"; do
-        local db_name="audit_${bucket//-/_}"
+        local db_name="audit_${bucket}"
         mysql -h127.0.0.1 -P6001 -uroot -p111 -e "DROP DATABASE IF EXISTS \`${db_name}\`; CREATE DATABASE \`${db_name}\`;" 2>/dev/null
         print_success "Database ${db_name} created"
     done
@@ -91,7 +95,7 @@ do_preflight() {
         exit 1
     fi
     local file_count
-    file_count=$(python3 -c "import json; m=json.load(open('$REPO_ROOT/bucket-manifest.json')); print(m['total_files'])")
+    file_count=$(python3 -c "import json; with open('${REPO_ROOT}/bucket-manifest.json') as f: m=json.load(f); print(m['total_files'])")
     print_success "bucket-manifest.json has ${file_count} files across ${#BUCKETS[@]} buckets"
 }
 
@@ -108,8 +112,6 @@ do_dispatch() {
     echo ""
     for bucket in "${BUCKETS[@]}"; do
         local prompt_file="${SCRIPT_DIR}/prompts/static-agent.md"
-        local prompt_content
-        prompt_content=$(sed "s/{{BUCKET_NAME}}/${bucket}/g" "$prompt_file")
         echo "### static-${bucket}"
         echo "Prompt: ${prompt_file} (with BUCKET_NAME=${bucket})"
         echo "Output: ${OUTPUT_DIR}/static-${bucket}-report.json"
@@ -120,9 +122,7 @@ do_dispatch() {
     echo ""
     for bucket in "${BUCKETS[@]}"; do
         local prompt_file="${SCRIPT_DIR}/prompts/live-agent.md"
-        local prompt_content
-        prompt_content=$(sed "s/{{BUCKET_NAME}}/${bucket}/g" "$prompt_file")
-        local db_name="audit_${bucket//-/_}"
+        local db_name="audit_${bucket}"
         echo "### live-${bucket}"
         echo "Database: ${db_name}"
         echo "Prompt: ${prompt_file} (with BUCKET_NAME=${bucket})"

--- a/scripts/verify-mo313/orchestrate.sh
+++ b/scripts/verify-mo313/orchestrate.sh
@@ -1,0 +1,234 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+print_success() { echo -e "${GREEN}==${NC} $1"; }
+print_warning() { echo -e "${YELLOW}==${NC} $1"; }
+print_error()   { echo -e "${RED}==${NC} $1"; }
+print_info()    { echo -e "${CYAN}--${NC} $1"; }
+
+# Bucket names (must match bucket-manifest.json keys)
+BUCKETS=(
+    "DDL"
+    "DML"
+    "DCL"
+    "DQL-base"
+    "DQL-apply"
+    "Other-SQL"
+    "Data-Types"
+    "Func-String"
+    "Func-Math"
+    "Func-Datetime"
+    "Func-Aggregate"
+    "Func-Other"
+    "Operators"
+    "Misc"
+)
+
+MO_VERSION="${MO_VERSION:-3.0.13}"
+OUTPUT_DIR="${REPO_ROOT}/audit-output-${MO_VERSION}"
+
+usage() {
+    echo "Usage: $0 {preflight|dispatch|merge|status|cleanup}"
+    echo ""
+    echo "Commands:"
+    echo "  preflight  Start MO ${MO_VERSION} Docker, create audit databases"
+    echo "  dispatch   Print agent dispatch instructions (28 agents + 1 merge)"
+    echo "  merge      Run the merge agent on collected reports"
+    echo "  status     Check which reports exist in ${OUTPUT_DIR}"
+    echo "  cleanup    Stop MO container, remove audit databases"
+    echo ""
+    echo "Environment:"
+    echo "  MO_VERSION   Target MatrixOne version (default: 3.0.13)"
+}
+
+# ---- Pre-flight ----
+
+do_preflight() {
+    echo "============================================================"
+    echo " Pre-flight: MO ${MO_VERSION}"
+    echo "============================================================"
+
+    # 1. Start MO Docker
+    print_info "Starting MO ${MO_VERSION} Docker..."
+    cd "$REPO_ROOT"
+    bash scripts/mo-test-env.sh start "$MO_VERSION"
+
+    # 2. Wait for readiness
+    print_info "Waiting for MO to be ready..."
+    sleep 5
+    for i in $(seq 1 30); do
+        if mysql -h127.0.0.1 -P6001 -uroot -p111 -e "SELECT 1" >/dev/null 2>&1; then
+            print_success "MO is ready"
+            break
+        fi
+        sleep 2
+    done
+
+    # 3. Create isolated databases
+    print_info "Creating audit databases..."
+    for bucket in "${BUCKETS[@]}"; do
+        local db_name="audit_${bucket//-/_}"
+        mysql -h127.0.0.1 -P6001 -uroot -p111 -e "DROP DATABASE IF EXISTS \`${db_name}\`; CREATE DATABASE \`${db_name}\`;" 2>/dev/null
+        print_success "Database ${db_name} created"
+    done
+
+    # 4. Create output directory
+    mkdir -p "$OUTPUT_DIR"
+    print_success "Output dir: ${OUTPUT_DIR}"
+
+    # 5. Verify bucket-manifest.json
+    if [ ! -f "$REPO_ROOT/bucket-manifest.json" ]; then
+        print_error "bucket-manifest.json not found!"
+        exit 1
+    fi
+    local file_count
+    file_count=$(python3 -c "import json; m=json.load(open('$REPO_ROOT/bucket-manifest.json')); print(m['total_files'])")
+    print_success "bucket-manifest.json has ${file_count} files across ${#BUCKETS[@]} buckets"
+}
+
+# ---- Dispatch ----
+
+do_dispatch() {
+    echo "============================================================"
+    echo " Agent Dispatch Instructions"
+    echo "============================================================"
+    echo ""
+    echo "Output directory: ${OUTPUT_DIR}"
+    echo ""
+    echo "--- STATIC AGENTS (14) ---"
+    echo ""
+    for bucket in "${BUCKETS[@]}"; do
+        local prompt_file="${SCRIPT_DIR}/prompts/static-agent.md"
+        local prompt_content
+        prompt_content=$(sed "s/{{BUCKET_NAME}}/${bucket}/g" "$prompt_file")
+        echo "### static-${bucket}"
+        echo "Prompt: ${prompt_file} (with BUCKET_NAME=${bucket})"
+        echo "Output: ${OUTPUT_DIR}/static-${bucket}-report.json"
+        echo ""
+    done
+
+    echo "--- LIVE AGENTS (14) ---"
+    echo ""
+    for bucket in "${BUCKETS[@]}"; do
+        local prompt_file="${SCRIPT_DIR}/prompts/live-agent.md"
+        local prompt_content
+        prompt_content=$(sed "s/{{BUCKET_NAME}}/${bucket}/g" "$prompt_file")
+        local db_name="audit_${bucket//-/_}"
+        echo "### live-${bucket}"
+        echo "Database: ${db_name}"
+        echo "Prompt: ${prompt_file} (with BUCKET_NAME=${bucket})"
+        echo "Output: ${OUTPUT_DIR}/live-${bucket}-report.json"
+        echo ""
+    done
+
+    echo "--- DISPATCH PLAN ---"
+    echo ""
+    echo "Launch all 28 agents in parallel as background agents."
+    echo "Each agent:"
+    echo "  1. Read its prompt file (already parameterized with bucket name)"
+    echo "  2. Execute verification"
+    echo "  3. Write JSON report to ${OUTPUT_DIR}/"
+    echo ""
+    echo "After all 28 complete (or timeout):"
+    echo "  Run: $0 merge"
+    echo ""
+    echo "--- AGENT DISPATCH COMMANDS ---"
+    echo ""
+    echo "For each bucket, dispatch two agents concurrently:"
+    echo ""
+    echo '```'
+    echo '# Example for bucket DDL:'
+    echo ''
+    echo '# Static agent:'
+    echo 'cat scripts/verify-mo313/prompts/static-agent.md | sed "s/{{BUCKET_NAME}}/DDL/g"'
+    echo ''
+    echo '# Live agent:'
+    echo 'cat scripts/verify-mo313/prompts/live-agent.md | sed "s/{{BUCKET_NAME}}/DDL/g"'
+    echo '```'
+}
+
+# ---- Merge ----
+
+do_merge() {
+    echo "============================================================"
+    echo " Merge Reports"
+    echo "============================================================"
+
+    # Count available reports
+    local static_count live_count
+    static_count=$(ls "${OUTPUT_DIR}"/static-*-report.json 2>/dev/null | wc -l | tr -d ' ')
+    live_count=$(ls "${OUTPUT_DIR}"/live-*-report.json 2>/dev/null | wc -l | tr -d ' ')
+
+    print_info "Static reports found: ${static_count}/14"
+    print_info "Live reports found: ${live_count}/14"
+
+    if [ "$static_count" -eq 0 ] && [ "$live_count" -eq 0 ]; then
+        print_error "No reports found in ${OUTPUT_DIR}"
+        exit 1
+    fi
+
+    print_info "To run the merge, provide the merge agent prompt to a Claude Code agent:"
+    echo ""
+    echo "  Prompt file: scripts/verify-mo313/prompts/merge-agent.md"
+    echo "  Input dir: ${OUTPUT_DIR}"
+    echo "  Output: ${OUTPUT_DIR}/final-report.json"
+}
+
+# ---- Status ----
+
+do_status() {
+    echo "Report Status for MO ${MO_VERSION}:"
+    echo ""
+
+    for bucket in "${BUCKETS[@]}"; do
+        local s_ok l_ok
+        if [ -f "${OUTPUT_DIR}/static-${bucket}-report.json" ]; then
+            s_ok="${GREEN}DONE${NC}"
+        else
+            s_ok="${RED}MISS${NC}"
+        fi
+        if [ -f "${OUTPUT_DIR}/live-${bucket}-report.json" ]; then
+            l_ok="${GREEN}DONE${NC}"
+        else
+            l_ok="${RED}MISS${NC}"
+        fi
+        printf "  %-15s  static: %b  live: %b\n" "$bucket" "$s_ok" "$l_ok"
+    done
+
+    if [ -f "${OUTPUT_DIR}/final-report.json" ]; then
+        echo ""
+        print_success "final-report.json exists"
+    fi
+}
+
+# ---- Cleanup ----
+
+do_cleanup() {
+    print_info "Stopping MO container..."
+    cd "$REPO_ROOT"
+    bash scripts/mo-test-env.sh stop
+    print_success "Cleanup complete"
+}
+
+# ---- Main ----
+
+case "${1:-}" in
+    preflight) do_preflight ;;
+    dispatch)  do_dispatch ;;
+    merge)     do_merge ;;
+    status)    do_status ;;
+    cleanup)   do_cleanup ;;
+    *)
+        usage
+        exit 1
+        ;;
+esac

--- a/scripts/verify-mo313/prompts/live-agent.md
+++ b/scripts/verify-mo313/prompts/live-agent.md
@@ -1,0 +1,84 @@
+# Live Verification Agent — Bucket: {{BUCKET_NAME}}
+
+You are verifying the `mysql_compat` frontmatter field accuracy by executing SQL examples from MatrixOne documentation against a running MO 3.0.13 instance.
+
+## Connection
+
+- Host: 127.0.0.1
+- Port: 6001
+- User: root
+- Password: 111
+- Database: `audit_{{BUCKET_NAME}}`
+
+Before starting any checks, connect and verify:
+```bash
+mysql -h127.0.0.1 -P6001 -uroot -p111 -e "SELECT VERSION(); USE audit_{{BUCKET_NAME}}; SELECT DATABASE();"
+```
+
+## Your Bucket
+
+Read `bucket-manifest.json` and extract all files belonging to bucket `{{BUCKET_NAME}}`.
+
+## What You Check
+
+For each file in your bucket, read the `.md` source, extract SQL examples, and execute them.
+
+### compat = `full`
+- Execute all SQL examples from the documentation
+- Verify the actual output matches the expected output shown in the doc
+- If syntax error or different result → FAIL
+- If works exactly as documented → PASS
+
+### compat = `partial`
+- Execute SQL examples that exercise each `differs_from_mysql` entry
+- Verify the described difference is actually present in MO 3.0.13
+- If the claimed difference no longer exists (MO now matches MySQL) → FAIL (differs list is stale)
+- If the difference is accurately described → PASS
+
+### compat = `mo_only`
+- Execute the MO-specific syntax/functions documented
+- Verify they actually work in MO 3.0.13
+- If syntax error or feature missing → FAIL
+
+### compat = `none` (CRITICAL — this is the priority check)
+- Construct the MySQL-standard syntax for the claimed-unsupported feature
+- Execute it on MO 3.0.13
+- If you get "unsupported" / "syntax error" / "not supported" → PASS (truly unsupported)
+- If it EXECUTES SUCCESSFULLY → CRITICAL FAIL (the feature IS supported, compat should be changed)
+- If you get a different error (permissions, resource limits, etc.) → WARN (inconclusive)
+
+### compat = `unknown`
+- Execute SQL examples
+- Based on behavior, suggest: `full` (matches MySQL), `partial` (works but differs), `mo_only` (MO-specific), or `none` (unsupported)
+
+## Edge Cases
+
+- **SQL needs prior setup** (CREATE TABLE before INSERT, etc.): Build the minimal reproduction. Create temp tables, insert test data.
+- **SQL cannot execute** (needs special privileges, external data): Mark `SKIPPED` with explicit reason.
+- **Execution causes server crash/panic**: Mark `ERROR` with severity CRITICAL. This is an MO bug.
+- **Execution hangs**: Set a 30-second timeout per statement. Mark `ERROR` if timeout.
+
+## Cleanup
+
+After each file's checks, drop any test tables you created in `audit_{{BUCKET_NAME}}` to avoid cross-file interference.
+
+## Output Format
+
+Produce a single JSON file: `live-{{BUCKET_NAME}}-report.json`
+
+Use the schema defined in `scripts/verify-mo313/schemas/live-report.schema.json`.
+
+Key rules:
+- One JSON object per file, with an array of findings
+- Each finding has: verdict (PASS/FAIL/WARN/SKIPPED/ERROR), severity, description, evidence
+- evidence MUST include `sql_executed` and `actual_output`
+- Include summary counts
+- Mark `incomplete: true` only if you cannot finish all files
+
+## Important
+
+- Work file by file. Do NOT skip any file in your bucket.
+- For each file, first read the .md source to understand the claims, THEN execute SQL.
+- Always use the `audit_{{BUCKET_NAME}}` database. Create/drop test tables within it.
+- Always clean up test tables after each file.
+- Write the JSON output to disk when complete.

--- a/scripts/verify-mo313/prompts/merge-agent.md
+++ b/scripts/verify-mo313/prompts/merge-agent.md
@@ -1,0 +1,71 @@
+# Merge Agent — Cross-Reference Static and Live Reports
+
+You merge the findings from 14 static agents and 14 live agents into a single `final-report.json`.
+
+## Inputs
+
+Read all 28 JSON report files. They follow these naming patterns:
+- `static-{bucket}-report.json` (14 files)
+- `live-{bucket}-report.json` (14 files)
+
+If any expected file is missing, note it in `meta.missing_buckets`.
+
+## Phase 1: Normalize
+
+For each file that appears in BOTH a static and live report:
+
+1. Match by `file` path (exact string match)
+2. Within the same file, match findings by semantic similarity. Two findings match if they describe the same issue (e.g., both mention "AUTO_INCREMENT differ"). Match generously — it's better to flag two findings as related than to miss a connection.
+3. Findings in static but not live → STATIC_ONLY
+4. Findings in live but not static → LIVE_ONLY
+
+## Phase 2: Cross-Reference
+
+For each matched finding pair, apply the merge matrix:
+
+| Static | Live   | Merge Verdict   |
+|--------|--------|-----------------|
+| PASS   | PASS   | PASS            |
+| FAIL   | FAIL   | CONFIRMED FAIL  |
+| PASS   | FAIL   | CONFLICT        |
+| FAIL   | PASS   | CONFLICT        |
+| WARN   | PASS   | PASS (downgrade)|
+| WARN   | FAIL   | CONFIRMED FAIL  |
+| WARN   | WARN   | CONFIRMED FAIL (promote WARN) |
+| (none) | PASS   | LIVE_ONLY       |
+| (none) | FAIL   | LIVE_ONLY       |
+| PASS   | (none) | STATIC_ONLY     |
+| FAIL   | (none) | STATIC_ONLY     |
+
+## Phase 3: CONFLICT Resolution
+
+For each CONFLICT pair:
+- Read both evidence objects carefully
+- If one side has clearly stronger evidence (e.g., live execution result trumps static assumption), set `auto_resolved: true` and pick the winning verdict, with explanation in `description`
+- If both sides have credible but contradictory evidence, set `needs_human_review: true`
+
+## Phase 4: Output
+
+Write `final-report.json` following the schema at `scripts/verify-mo313/schemas/final-report.schema.json`.
+
+Required aggregations:
+- `summary`: count all PASS / CONFIRMED FAIL / CONFLICT / LIVE_ONLY / STATIC_ONLY / needs_human_review
+- `by_severity`: count CRITICAL / HIGH / MEDIUM / LOW
+- `by_bucket`: per-bucket counts of pass / confirmed_fail / conflict
+
+Each finding entry must include:
+- `file`: the doc file path
+- `merge_verdict`: from the merge matrix
+- `severity`: highest severity from either agent (CRITICAL > HIGH > MEDIUM > LOW)
+- `description`: synthesized description combining both agents' findings
+- `static_evidence`: the static agent's evidence object (if exists)
+- `live_evidence`: the live agent's evidence object (if exists)
+- `auto_resolved`: true if the conflict was automatically resolved
+- `needs_human_review`: true if human judgment is needed
+- `suggested_action`: what to do (update frontmatter, fix body text, add to differs list, etc.)
+
+## Important
+
+- If a bucket has only a static report or only a live report (the other agent failed), still include those findings (they will all be STATIC_ONLY or LIVE_ONLY).
+- Sort findings by severity (CRITICAL first), then by bucket.
+- Always include `suggested_action` — make it actionable for a human or script.

--- a/scripts/verify-mo313/prompts/static-agent.md
+++ b/scripts/verify-mo313/prompts/static-agent.md
@@ -1,0 +1,82 @@
+# Static Verification Agent — Bucket: {{BUCKET_NAME}}
+
+You are verifying the `mysql_compat` frontmatter field accuracy for a subset of MatrixOne SQL documentation files by comparing them against MySQL 8.0 reference documentation.
+
+## Your Bucket
+
+Read `bucket-manifest.json` and extract all files belonging to bucket `{{BUCKET_NAME}}`. This is your file list.
+
+For context, the JSON structure is:
+```json
+{
+  "buckets": {
+    "{{BUCKET_NAME}}": {
+      "file_count": N,
+      "files": [
+        { "path": "docs/MatrixOne/Reference/...", "mysql_compat": "full|partial|mo_only|none|unknown", "has_sql_blocks": true }
+      ]
+    }
+  }
+}
+```
+
+## What You Check
+
+For each file in your bucket, read the `.md` source. For each compat label, verify it against MySQL 8.0 docs:
+
+### compat = `full`
+- Does the MatrixOne documentation describe behavior identical to MySQL 8.0?
+- Check MySQL 8.0 reference docs (use WebFetch on https://dev.mysql.com/doc/refman/8.0/en/ for the corresponding feature)
+- If any behavioral difference is found → FAIL with evidence
+
+### compat = `partial`
+- Is each entry in `differs_from_mysql` accurate? (cross-check against MySQL 8.0 docs)
+- Are there obvious MySQL behaviors that MO differs on but are NOT listed in `differs_from_mysql`?
+- Are any claimed differences actually NOT different? (MO now matches MySQL)
+
+### compat = `mo_only`
+- Is this feature genuinely absent from MySQL 8.0?
+- Search MySQL 8.0 docs for equivalent syntax/function
+- If MySQL has it (or introduced it in 8.0.x) → FAIL
+
+### compat = `none`
+- Does MySQL 8.0 have this feature?
+- If MySQL also doesn't have it → PASS (correctly labeled as unsupported by both)
+- If MySQL has it and MO claims unsupported → FAIL (should likely be `partial` or `full`)
+- If MO page doesn't exist at all for a MySQL feature → STATIC_ONLY finding
+
+### compat = `unknown`
+- Based on MySQL 8.0 comparison, suggest a classification
+- If clearly matching MySQL → suggest `full`
+- If matching with differences → suggest `partial`
+- If clearly MO-only → suggest `mo_only`
+- If clearly unsupported → suggest `none`
+
+## Evidence Requirements
+
+Every finding MUST include:
+- `mysql_ref`: specific MySQL 8.0 doc URL or section (e.g., "https://dev.mysql.com/doc/refman/8.0/en/create-table.html")
+- `mysql_behavior`: what MySQL 8.0 does
+- `mo_doc_claim`: what the MO doc currently says
+- `suggestion`: what action to take
+
+## Output Format
+
+Produce a single JSON file: `static-{{BUCKET_NAME}}-report.json`
+
+Use the schema defined in `scripts/verify-mo313/schemas/static-report.schema.json`.
+
+Key rules:
+- One JSON object per file, with an array of findings
+- Each finding has: verdict (PASS/FAIL/WARN/SKIPPED), severity (CRITICAL/HIGH/MEDIUM/LOW), description, evidence
+- FAIL on classification errors, missing differences, incorrect mo_only claims
+- WARN on minor issues (unclear phrasing, missing edge cases)
+- SKIP files with no SQL content and no MySQL analog (e.g., pure MO architecture pages)
+- Include summary counts (total_files, total_claims, pass, fail, warn, skipped)
+
+## Important
+
+- Work file by file. Do NOT skip any file in your bucket.
+- For MySQL 8.0 lookups, use WebFetch on dev.mysql.com. If WebFetch fails, note the URL and mark finding as WARN with note "MySQL doc unreachable".
+- Do NOT connect to any database. This is purely a documentation comparison.
+- Write the JSON output to disk when complete.

--- a/scripts/verify-mo313/schemas/final-report.schema.json
+++ b/scripts/verify-mo313/schemas/final-report.schema.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "final-report",
+  "type": "object",
+  "required": ["meta", "summary", "by_severity", "by_bucket", "findings"],
+  "properties": {
+    "meta": {
+      "type": "object",
+      "required": ["mo_version", "generated_at", "total_files", "total_buckets", "static_agents", "live_agents"],
+      "properties": {
+        "mo_version": { "type": "string" },
+        "generated_at": { "type": "string", "format": "date-time" },
+        "total_files": { "type": "integer" },
+        "total_buckets": { "type": "integer" },
+        "static_agents": { "type": "integer" },
+        "live_agents": { "type": "integer" },
+        "missing_buckets": { "type": "array", "items": { "type": "string" }, "description": "Buckets where an agent failed to produce a report" }
+      }
+    },
+    "summary": {
+      "type": "object",
+      "required": ["total_claims_checked", "pass", "confirmed_fail", "conflict", "live_only", "static_only", "needs_human_review"],
+      "properties": {
+        "total_claims_checked": { "type": "integer" },
+        "pass": { "type": "integer" },
+        "confirmed_fail": { "type": "integer" },
+        "conflict": { "type": "integer" },
+        "live_only": { "type": "integer" },
+        "static_only": { "type": "integer" },
+        "needs_human_review": { "type": "integer" }
+      }
+    },
+    "by_severity": {
+      "type": "object",
+      "properties": {
+        "critical": { "type": "integer" },
+        "high": { "type": "integer" },
+        "medium": { "type": "integer" },
+        "low": { "type": "integer" }
+      }
+    },
+    "by_bucket": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "pass": { "type": "integer" },
+          "confirmed_fail": { "type": "integer" },
+          "conflict": { "type": "integer" }
+        }
+      }
+    },
+    "findings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["file", "merge_verdict", "severity", "description"],
+        "properties": {
+          "file": { "type": "string" },
+          "merge_verdict": { "enum": ["PASS", "CONFIRMED FAIL", "CONFLICT", "LIVE_ONLY", "STATIC_ONLY"] },
+          "severity": { "enum": ["CRITICAL", "HIGH", "MEDIUM", "LOW"] },
+          "description": { "type": "string" },
+          "static_evidence": { "type": "object" },
+          "live_evidence": { "type": "object" },
+          "auto_resolved": { "type": "boolean" },
+          "needs_human_review": { "type": "boolean" },
+          "suggested_action": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/scripts/verify-mo313/schemas/live-report.schema.json
+++ b/scripts/verify-mo313/schemas/live-report.schema.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "live-report",
+  "type": "object",
+  "required": ["agent", "bucket", "mo_version", "generated_at", "files"],
+  "properties": {
+    "agent": { "const": "live" },
+    "bucket": { "type": "string" },
+    "mo_version": { "type": "string" },
+    "generated_at": { "type": "string", "format": "date-time" },
+    "summary": {
+      "type": "object",
+      "properties": {
+        "total_files": { "type": "integer" },
+        "total_claims": { "type": "integer" },
+        "pass": { "type": "integer" },
+        "fail": { "type": "integer" },
+        "warn": { "type": "integer" },
+        "skipped": { "type": "integer" },
+        "errors": { "type": "integer" }
+      }
+    },
+    "files": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["file", "current_compat", "findings"],
+        "properties": {
+          "file": { "type": "string" },
+          "current_compat": { "enum": ["full", "partial", "mo_only", "none", "unknown"] },
+          "findings": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["verdict", "severity", "description", "evidence"],
+              "properties": {
+                "verdict": { "enum": ["PASS", "FAIL", "WARN", "SKIPPED", "ERROR"] },
+                "severity": { "enum": ["CRITICAL", "HIGH", "MEDIUM", "LOW"] },
+                "field_checked": { "type": "string" },
+                "description": { "type": "string" },
+                "evidence": {
+                  "type": "object",
+                  "required": ["sql_executed", "actual_output"],
+                  "properties": {
+                    "sql_executed": { "type": "string" },
+                    "actual_output": { "type": "string" },
+                    "expected_behavior": { "type": "string" },
+                    "matches_doc": { "type": "boolean" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "incomplete": { "type": "boolean" }
+  }
+}

--- a/scripts/verify-mo313/schemas/static-report.schema.json
+++ b/scripts/verify-mo313/schemas/static-report.schema.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "static-report",
+  "type": "object",
+  "required": ["agent", "bucket", "mo_version", "generated_at", "files"],
+  "properties": {
+    "agent": { "const": "static" },
+    "bucket": { "type": "string", "description": "Bucket name from bucket-manifest.json" },
+    "mo_version": { "type": "string", "description": "Target MO version, e.g. 3.0.13" },
+    "generated_at": { "type": "string", "format": "date-time" },
+    "summary": {
+      "type": "object",
+      "properties": {
+        "total_files": { "type": "integer" },
+        "total_claims": { "type": "integer" },
+        "pass": { "type": "integer" },
+        "fail": { "type": "integer" },
+        "warn": { "type": "integer" },
+        "skipped": { "type": "integer" }
+      }
+    },
+    "files": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["file", "current_compat", "findings"],
+        "properties": {
+          "file": { "type": "string", "description": "Path relative to repo root" },
+          "current_compat": { "enum": ["full", "partial", "mo_only", "none", "unknown"] },
+          "suggested_compat": { "enum": ["full", "partial", "mo_only", "none", "unknown"] },
+          "findings": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["verdict", "severity", "description", "evidence"],
+              "properties": {
+                "verdict": { "enum": ["PASS", "FAIL", "WARN", "SKIPPED"] },
+                "severity": { "enum": ["CRITICAL", "HIGH", "MEDIUM", "LOW"] },
+                "field_checked": { "type": "string", "description": "Which compat aspect: compat_label, differs_list, mo_only_list, body_text, missing_from_doc" },
+                "description": { "type": "string" },
+                "evidence": {
+                  "type": "object",
+                  "required": ["mysql_ref"],
+                  "properties": {
+                    "mysql_ref": { "type": "string", "description": "MySQL 8.0 doc URL or section reference" },
+                    "mysql_behavior": { "type": "string" },
+                    "mo_doc_claim": { "type": "string" },
+                    "suggestion": { "type": "string" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "incomplete": { "type": "boolean", "description": "True if agent timed out before finishing all files" }
+  }
+}


### PR DESCRIPTION
Backport `generate-compat-matrix.js` and `agent_delivery.py` changes plus regenerated compat matrix for v3.0.13.
---
From #700 merged into main.