### PR TITLE
fix: remove cleanRelPath that stripped legitimate operators/ path prefix

### DIFF
--- a/docs/MatrixOne/Reference/mysql-compatibility-matrix.json
+++ b/docs/MatrixOne/Reference/mysql-compatibility-matrix.json
@@ -1,22 +1,22 @@
 {
-  "generated_at": "2026-05-27T10:51:12.013Z",
+  "generated_at": "2026-05-28T07:04:51.639Z",
   "summary": {
-    "total": 370,
-    "full": 142,
-    "partial": 62,
-    "none": 0,
-    "mo_only": 93,
-    "unknown": 73
+    "total": 373,
+    "full": 131,
+    "partial": 97,
+    "none": 1,
+    "mo_only": 96,
+    "unknown": 48
   },
   "sections": [
     {
       "id": "sql-reference",
       "label": "SQL Statements",
       "summary": {
-        "full": 30,
-        "partial": 43,
-        "none": 0,
-        "mo_only": 57,
+        "full": 21,
+        "partial": 58,
+        "none": 1,
+        "mo_only": 53,
         "unknown": 0
       },
       "categories": [
@@ -54,7 +54,12 @@
               "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Control-Language/alter-user.md",
               "compat": "partial",
               "notes": [
-                "Only ALTER USER can change passwords; account-limit clauses not honoured"
+                "Only ALTER USER can change passwords; account-limit clauses not honoured",
+                "Password management options (PASSWORD EXPIRE, PASSWORD HISTORY, PASSWORD REUSE INTERVAL, PASSWORD REQUIRE CURRENT, FAILED_LOGIN_ATTEMPTS, PASSWORD_LOCK_TIME) not supported",
+                "Account locking (ACCOUNT LOCK/UNLOCK) not supported",
+                "REQUIRE clause (TLS/SSL enforcement) not supported",
+                "COMMENT and ATTRIBUTE modification not supported",
+                "Multiple users per statement not supported (MySQL 8.0 allows user [, user] ...)"
               ]
             },
             {
@@ -83,8 +88,11 @@
               "notes": [
                 "IDENTIFIED BY is the only supported password form; IDENTIFIED WITH plugins not supported",
                 "Connection-IP whitelists and connection-limit clauses not supported",
-                "COMMENT and ATTRIBUTE clauses are accepted syntactically but not honoured",
-                "User identifier is a bare username scoped to the current account; MySQL uses 'user'@'host' tuples"
+                "COMMENT and ATTRIBUTE clauses not supported",
+                "'user'@'host' syntax is accepted and host is stored in mo_catalog.mo_user.user_host but may not restrict connections; users are scoped to the current account, not server-global as in MySQL",
+                "Password management options (PASSWORD EXPIRE, PASSWORD HISTORY, PASSWORD REUSE INTERVAL, PASSWORD REQUIRE CURRENT) not supported",
+                "Account locking (ACCOUNT LOCK/UNLOCK) not supported",
+                "REQUIRE clause (TLS/SSL enforcement) not supported"
               ]
             },
             {
@@ -122,8 +130,12 @@
               "notes": [
                 "Authorization logic differs from MySQL — MatrixOne evaluates via its role/account model",
                 "User identifier is a bare username scoped to the current account; MySQL uses 'user'@'host' tuples",
+                "AS user [WITH ROLE ...] clause (MySQL 8.0 privilege restriction) not supported",
+                "GRANT privilege ... TO only accepts roles; users receive privileges indirectly through role membership (GRANT role TO user)",
+                "WITH ADMIN OPTION for role grants is not supported",
                 "[MO-only] `GRANT ... ON ACCOUNT *` — account-level privileges have no MySQL counterpart",
-                "[MO-only] `GRANT ... ON DATABASE *` — MatrixOne-specific database-level grant target"
+                "[MO-only] `GRANT ... ON DATABASE *` — MatrixOne-specific database-level grant target",
+                "[MO-only] GRANT ... ON VIEW db_name.view_name (separate VIEW object_type; MySQL 8.0 only supports TABLE, FUNCTION, PROCEDURE)"
               ]
             },
             {
@@ -134,8 +146,10 @@
               "notes": [
                 "Recovery logic differs from MySQL — privileges return to the role/account graph",
                 "User identifier is a bare username scoped to the current account; MySQL uses 'user'@'host' tuples",
+                "IGNORE UNKNOWN USER clause (MySQL 8.0.30+) not supported",
                 "[MO-only] `REVOKE ... ON ACCOUNT *` — account-level privileges have no MySQL counterpart",
-                "[MO-only] `REVOKE ... ON DATABASE *` — MatrixOne-specific database-level revoke target"
+                "[MO-only] `REVOKE ... ON DATABASE *` — MatrixOne-specific database-level revoke target",
+                "[MO-only] REVOKE ... ON VIEW db_name.view_name (separate VIEW object_type)"
               ]
             },
             {
@@ -202,9 +216,8 @@
               "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/alter-table.md",
               "compat": "partial",
               "notes": [
-                "CHANGE [COLUMN], MODIFY [COLUMN], RENAME COLUMN, ADD/DROP PRIMARY KEY, ALTER COLUMN ORDER BY cannot be combined with other clauses in the same ALTER TABLE",
+                "Multiple ALTER TABLE operations can be combined in one statement, with limitation: DROP PRIMARY KEY cannot be combined with RENAME COLUMN, CHANGE COLUMN, or DROP COLUMN (causes server panic); DROP PK + ADD COLUMN and DROP PK + MODIFY COLUMN work correctly",
                 "Temporary tables cannot be altered",
-                "Tables created with CLUSTER BY cannot be altered",
                 "ALTER TABLE does not support PARTITION operations"
               ]
             },
@@ -214,7 +227,7 @@
               "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/alter-view.md",
               "compat": "partial",
               "notes": [
-                "Inherits CREATE VIEW limitations: no WITH CHECK OPTION, no DEFINER = user clause"
+                "WITH CHECK OPTION is accepted in CREATE VIEW (syntax only, views are read-only) but rejected as a syntax error in ALTER VIEW"
               ]
             },
             {
@@ -248,8 +261,7 @@
               "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/create-database.md",
               "compat": "partial",
               "notes": [
-                "Chinese database names not supported",
-                "Only utf8mb4 / utf8mb4_bin are supported and cannot be changed",
+                "Only utf8mb4 / utf8mb4_bin are functional; other charsets/collations are syntactically accepted but have no effect",
                 "ENCRYPTION clause accepted but inert"
               ]
             },
@@ -295,7 +307,8 @@
               "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/create-function-sql.md",
               "compat": "partial",
               "notes": [
-                "Only LANGUAGE SQL and LANGUAGE PYTHON are supported; usage differs significantly from MySQL stored functions"
+                "Only LANGUAGE SQL and LANGUAGE PYTHON are supported; usage differs significantly from MySQL stored functions",
+                "CREATE OR REPLACE FUNCTION is supported; MySQL 8.0 does not support OR REPLACE for functions (only IF NOT EXISTS since 8.0.29)"
               ]
             },
             {
@@ -304,8 +317,7 @@
               "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/create-index.md",
               "compat": "partial",
               "notes": [
-                "Secondary indexes are syntactically accepted but do not yet provide query speed-up",
-                "Foreign keys do not support ON CASCADE DELETE",
+                "Secondary indexes are supported and participate in query optimization (as of MO 3.0.12, EXPLAIN shows Index Table Scan for secondary index queries). Does not support index hints (USE INDEX, FORCE INDEX, IGNORE INDEX), function-based indexes, or FULLTEXT index via CREATE INDEX syntax (use CREATE FULLTEXT INDEX instead).",
                 "[MO-only] USING IVFFLAT — vector index for approximate nearest neighbour",
                 "[MO-only] USING HNSW — vector index for approximate nearest neighbour",
                 "[MO-only] USING MASTER — composite master index"
@@ -389,12 +401,14 @@
               "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/create-table.md",
               "compat": "partial",
               "notes": [
-                "ENGINE= clause in table definition not supported (MatrixOne has a single TAE engine)",
-                "Spatial and SET types not supported; MEDIUMINT not supported",
+                "ENGINE= clause is syntactically accepted but ignored; MatrixOne uses TAE exclusively",
+                "Spatial type names (GEOMETRY, POINT, etc.) are syntactically accepted but non-functional; MEDIUMINT is syntactically accepted but treated as INT",
                 "BOOL is a native boolean type, not an INT alias as in MySQL",
-                "AUTO_INCREMENT step is always 1; @@auto_increment_increment / @@auto_increment_offset are syntactically accepted but inert",
-                "Partitioning accepts syntax but only HASH and KEY participate in partition pruning (RANGE/LIST/RANGE COLUMNS/LIST COLUMNS are syntax-only); subpartitioning is syntax-only; ADD/DROP/TRUNCATE PARTITION not supported",
-                "[MO-only] CLUSTER BY (col, …) — pre-sort columns to accelerate queries"
+                "AUTO_INCREMENT step is always 1; @@auto_increment_increment is syntactically accepted but inert",
+                "Partitioning accepts syntax but only HASH and KEY participate in partition pruning (RANGE/LIST/RANGE COLUMNS/LIST COLUMNS are syntax-only); subpartitioning causes an internal error; ADD/DROP/TRUNCATE PARTITION not supported",
+                "CHECK constraints are syntactically accepted but not enforced; MySQL 8.0.16+ enforces them",
+                "[MO-only] CLUSTER BY (col, …) — pre-sort columns to accelerate queries",
+                "[MO-only] START TRANSACTION table option — non-standard table option with no MySQL 8.0 equivalent"
               ]
             },
             {
@@ -416,7 +430,9 @@
               "title": "CREATE TASK (SQL Task)",
               "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/sql-task.md",
               "compat": "mo_only",
-              "notes": []
+              "notes": [
+                "[MO-only] CREATE TASK / ALTER TASK / DROP TASK / EXECUTE TASK / SHOW TASKS (MO-specific scheduled SQL tasks; MySQL uses CREATE EVENT instead)"
+              ]
             },
             {
               "id": "sql.data_definition_language.create_view",
@@ -424,9 +440,8 @@
               "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/create-view.md",
               "compat": "partial",
               "notes": [
-                "WITH CHECK OPTION clause not supported",
-                "DEFINER = user clause not supported; SQL SECURITY {DEFINER | INVOKER} is supported",
-                "ALGORITHM = {UNDEFINED | MERGE | TEMPTABLE} clause not supported"
+                "WITH CHECK OPTION is syntactically accepted but not enforced",
+                "Views are read-only; MySQL 8.0 supports INSERT/UPDATE/DELETE through views that meet updatability criteria"
               ]
             },
             {
@@ -479,7 +494,9 @@
               "title": "DATA BRANCH PICK",
               "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/data-branch-pick.md",
               "compat": "mo_only",
-              "notes": []
+              "notes": [
+                "[MO-only] DATA BRANCH PICK (cherry-pick specific rows between branch tables, Git-for-Data feature)"
+              ]
             },
             {
               "id": "sql.data_definition_language.drop_database",
@@ -494,15 +511,18 @@
               "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/drop-function.md",
               "compat": "partial",
               "notes": [
-                "Drops MatrixOne-style SQL / Python functions, not MySQL stored procedures/functions"
+                "Drops MatrixOne-style SQL / Python functions, not MySQL stored procedures/functions",
+                "Requires argument type list on DROP (e.g. DROP FUNCTION py_add(int, int)); MySQL 8.0 accepts only the function name"
               ]
             },
             {
               "id": "sql.data_definition_language.drop_index",
               "title": "DROP INDEX",
               "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/drop-index.md",
-              "compat": "full",
-              "notes": []
+              "compat": "partial",
+              "notes": [
+                "MO accepts DROP INDEX IF EXISTS syntax (MySQL 8.0 does not), but IF EXISTS does not suppress errors for missing indexes; it returns internal error 20101 instead of a silent skip"
+              ]
             },
             {
               "id": "sql.data_definition_language.drop_pitr",
@@ -560,15 +580,19 @@
               "id": "sql.data_definition_language.drop_view",
               "title": "DROP VIEW",
               "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/drop-view.md",
-              "compat": "full",
-              "notes": []
+              "compat": "partial",
+              "notes": [
+                "MO does not support dropping multiple views in a single statement; only a single view per DROP VIEW. MySQL 8.0 supports dropping multiple views (e.g., DROP VIEW v1, v2)."
+              ]
             },
             {
               "id": "sql.data_definition_language.rename_table",
               "title": "Rename Table",
               "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Definition-Language/rename-table.md",
-              "compat": "full",
-              "notes": []
+              "compat": "partial",
+              "notes": [
+                "MO does not support RENAME TABLE across databases; when given cross-database syntax, MO renames the table within its current database instead of raising an error. MySQL 8.0 supports cross-database RENAME TABLE."
+              ]
             },
             {
               "id": "sql.data_definition_language.restore_pitr",
@@ -606,7 +630,9 @@
               "title": "CASE",
               "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Manipulation-Language/case.md",
               "compat": "full",
-              "notes": []
+              "notes": [
+                "This page describes the CASE operator (expression), not the stored-program CASE statement. MatrixOne does not support stored programs, so the stored-program CASE STATEMENT is unavailable; the CASE OPERATOR behaves compatibly."
+              ]
             },
             {
               "id": "sql.data_manipulation_language.information_functions.current_role",
@@ -623,7 +649,8 @@
               "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Manipulation-Language/delete.md",
               "compat": "partial",
               "notes": [
-                "LOW_PRIORITY, QUICK, IGNORE modifiers not supported"
+                "LOW_PRIORITY, QUICK, IGNORE modifiers are syntactically accepted but have no effect",
+                "PARTITION clause not supported"
               ]
             },
             {
@@ -632,15 +659,18 @@
               "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Manipulation-Language/insert.md",
               "compat": "partial",
               "notes": [
-                "Modifiers LOW_PRIORITY / DELAYED / HIGH_PRIORITY not supported"
+                "Modifiers LOW_PRIORITY / DELAYED / HIGH_PRIORITY not supported",
+                "PARTITION clause not supported"
               ]
             },
             {
               "id": "sql.data_manipulation_language.upsert.insert_on_duplicate",
               "title": "INSERT ... ON DUPLICATE KEY UPDATE",
               "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Manipulation-Language/upsert/insert-on-duplicate.md",
-              "compat": "full",
-              "notes": []
+              "compat": "partial",
+              "notes": [
+                "ON DUPLICATE KEY UPDATE only triggers on PRIMARY KEY conflicts; UNIQUE index conflicts are detected but result in errors (ERROR 1062 or ERROR 20102) rather than triggering ON DUPLICATE KEY UPDATE"
+              ]
             },
             {
               "id": "sql.data_manipulation_language.upsert.insert_ignore",
@@ -650,7 +680,8 @@
               "notes": [
                 "LOW_PRIORITY / DELAYED / HIGH_PRIORITY modifiers not supported",
                 "Duplicates are silently ignored; MySQL emits a warning for each skipped row.",
-                "Does not ignore NULL-into-NOT-NULL, type-conversion, or partition-mismatch errors as MySQL does."
+                "Does not ignore NULL-into-NOT-NULL, type-conversion, or partition-mismatch errors as MySQL does.",
+                "PARTITION clause not supported"
               ]
             },
             {
@@ -684,10 +715,13 @@
               "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Manipulation-Language/load-data-infile.md",
               "compat": "partial",
               "notes": [
-                "LOAD DATA LOCAL requires --local-infile on the client",
                 "SET clause only accepts columns_name = nullif(expr1, expr2)",
                 "JSONLines import uses MatrixOne-specific syntax",
-                "Object-storage import (S3/URL) uses MatrixOne-specific syntax"
+                "Object-storage import (S3/URL) uses MatrixOne-specific syntax",
+                "LOW_PRIORITY and CONCURRENT modifiers not supported",
+                "REPLACE and IGNORE modifiers not supported",
+                "[MO-only] PARALLEL clause (controls parallel file loading)",
+                "[MO-only] STRICT clause (controls parallel splitting mode)"
               ]
             },
             {
@@ -705,8 +739,10 @@
               "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Manipulation-Language/replace.md",
               "compat": "partial",
               "notes": [
-                "REPLACE does not support VALUES row_constructor_list",
-                "node-sql-parser rejects REPLACE … WHERE (parser bug, not MatrixOne)"
+                "node-sql-parser rejects REPLACE … WHERE (parser bug, not MatrixOne)",
+                "PARTITION clause not supported",
+                "LOW_PRIORITY and DELAYED modifiers not supported",
+                "REPLACE only detects conflicts on PRIMARY KEY; secondary UNIQUE index conflicts throw ERROR 1062 (MySQL 8.0 handles both). Constraints section incorrectly states UNIQUE index can also trigger REPLACE; this is wrong per actual MO behavior."
               ]
             },
             {
@@ -715,8 +751,10 @@
               "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Manipulation-Language/upsert/replace.md",
               "compat": "partial",
               "notes": [
-                "REPLACE does not support VALUES row_constructor_list",
-                "node-sql-parser rejects REPLACE … WHERE (parser bug, not MatrixOne)"
+                "node-sql-parser rejects REPLACE … WHERE (parser bug, not MatrixOne)",
+                "PARTITION clause not supported",
+                "LOW_PRIORITY and DELAYED modifiers not supported",
+                "REPLACE only detects conflicts on PRIMARY KEY; secondary UNIQUE index conflicts throw ERROR 1062 (MySQL 8.0 handles both). Constraints section incorrectly states UNIQUE index can also trigger REPLACE; this is wrong per actual MO behavior."
               ]
             },
             {
@@ -725,16 +763,19 @@
               "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Manipulation-Language/update.md",
               "compat": "partial",
               "notes": [
-                "LOW_PRIORITY and IGNORE modifiers not supported"
+                "LOW_PRIORITY and IGNORE modifiers are syntactically accepted but have no effect",
+                "PARTITION clause not supported"
               ]
             },
             {
               "id": "sql.data_manipulation_language.upsert.upsert",
               "title": "UPSERT",
               "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Manipulation-Language/upsert/upsert.md",
-              "compat": "mo_only",
+              "compat": "partial",
               "notes": [
-                "[MO-only] UPSERT (convenience alias over INSERT … ON DUPLICATE KEY UPDATE)"
+                "INSERT IGNORE does not suppress NOT NULL or type-conversion errors (MySQL 8.0 does)",
+                "INSERT ON DUPLICATE KEY UPDATE only triggers on PRIMARY KEY conflicts; UNIQUE index conflicts are detected but result in errors (ERROR 1062 or ERROR 20102) rather than triggering ON DUPLICATE KEY UPDATE",
+                "REPLACE does not support REPLACE ... WHERE (parser bug)"
               ]
             }
           ]
@@ -756,9 +797,12 @@
               "id": "sql.data_query_language.union_intersect_minus_overview",
               "title": "Combining Queries (UNION, INTERSECT, MINUS)",
               "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Query-Language/union-intersect-minus-overview.md",
-              "compat": "mo_only",
+              "compat": "partial",
               "notes": [
-                "[MO-only] MINUS, INTERSECT set operators"
+                "MINUS keyword is MO-specific; MySQL 8.0.31+ uses EXCEPT for the same set-difference semantics. MINUS ALL is not yet implemented in MO while MySQL 8.0.31+ supports EXCEPT ALL.",
+                "INTERSECT was added in MySQL 8.0.31; both MO and MySQL support INTERSECT and INTERSECT ALL with matching semantics.",
+                "UNION is standard across both, but MO's type coercion in UNION columns is stricter (errors on incompatible types where MySQL silently coerces).",
+                "[MO-only] MINUS keyword (MO-specific syntax; MySQL 8.0.31+ offers equivalent EXCEPT)"
               ]
             },
             {
@@ -788,16 +832,18 @@
               "id": "sql.data_query_language.subqueries.derived_tables",
               "title": "Derived Tables",
               "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Query-Language/subqueries/derived-tables.md",
-              "compat": "full",
-              "notes": []
+              "compat": "partial",
+              "notes": [
+                "LATERAL derived tables are not supported in MO (MySQL 8.0.14+ supports LATERAL for correlated subqueries in FROM clause)"
+              ]
             },
             {
               "id": "sql.data_query_language.join.full_join",
               "title": "FULL JOIN",
               "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Query-Language/join/full-join.md",
-              "compat": "mo_only",
+              "compat": "none",
               "notes": [
-                "[MO-only] FULL JOIN / FULL OUTER JOIN is not supported in MySQL 8.0 (users must emulate it with LEFT JOIN UNION RIGHT JOIN)."
+                "FULL JOIN with ON clause produces different errors on MO (missing FROM-clause entry) vs MySQL 8.0 (Unknown column in ON clause). FULL JOIN with USING returns INNER JOIN results on both (neither returns unmatched rows). FULL OUTER JOIN produces a syntax error on both. MySQL 8.0 does not natively support either FULL JOIN or FULL OUTER JOIN."
               ]
             },
             {
@@ -811,17 +857,19 @@
               "id": "sql.data_query_language.intersect",
               "title": "INTERSECT",
               "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Query-Language/intersect.md",
-              "compat": "mo_only",
+              "compat": "partial",
               "notes": [
-                "[MO-only] INTERSECT set operator is not available in MySQL 8.0."
+                "INTERSECT was added in MySQL 8.0.31; MO INTERSECT and INTERSECT ALL semantics match MySQL 8.0 (both return identical results for common test cases including duplicate handling)"
               ]
             },
             {
               "id": "sql.data_query_language.join.join",
               "title": "JOIN",
               "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Query-Language/join/join.md",
-              "compat": "full",
-              "notes": []
+              "compat": "partial",
+              "notes": [
+                "FULL JOIN and FULL OUTER JOIN are not fully supported (FULL JOIN with ON produces errors, FULL JOIN with USING returns INNER JOIN results, FULL OUTER JOIN is a syntax error); MySQL 8.0 also does not support FULL JOIN/OUTER JOIN natively"
+              ]
             },
             {
               "id": "sql.data_query_language.join.left_join",
@@ -836,7 +884,9 @@
               "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Query-Language/minus.md",
               "compat": "mo_only",
               "notes": [
-                "[MO-only] MINUS (set-difference query, not in MySQL)"
+                "MINUS keyword is MO-specific; MySQL 8.0.31+ uses EXCEPT for the same set-difference semantics (MINUS is not a recognized keyword in MySQL)",
+                "MINUS ALL is not yet implemented in MO; MySQL 8.0.31+ supports EXCEPT ALL with full duplicate-preserving semantics",
+                "[MO-only] MINUS keyword (MO's set-difference operator; MySQL 8.0.31+ offers equivalent functionality via EXCEPT)"
               ]
             },
             {
@@ -861,7 +911,7 @@
               "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Query-Language/join/outer-join.md",
               "compat": "partial",
               "notes": [
-                "Overview page that includes FULL OUTER JOIN, which MySQL 8.0 does not support."
+                "Overview page that includes FULL OUTER JOIN; neither MO nor MySQL 8.0 natively support FULL OUTER JOIN (MO produces syntax error, same as MySQL)"
               ]
             },
             {
@@ -879,8 +929,11 @@
               "notes": [
                 "SELECT … FOR UPDATE only supports single-table queries",
                 "SELECT INTO OUTFILE is only partially supported",
-                "Unqualified SELECT ... FROM DUAL requires explicit database name (SELECT ... FROM dbname.DUAL)",
-                "[MO-only] { AS OF TIMESTAMP 'YYYY-MM-DD HH:MM:SS' } — time-travel query against snapshot/PITR",
+                "AS OF TIMESTAMP time-travel queries require PITR/snapshot to be enabled on the database; without PITR the syntax produces an error",
+                "SELECT ... FOR SHARE is not supported",
+                "FOR UPDATE NOWAIT and SKIP LOCKED modifiers are not supported",
+                "GROUP BY ... WITH ROLLUP row ordering differs: MO places rollup summary rows at the top of the result set, while MySQL 8.0 places them at the bottom (standard MySQL grouping order)",
+                "[MO-only] { AS OF TIMESTAMP 'YYYY-MM-DD HH:MM:SS' } — time-travel query against enabled snapshot/PITR",
                 "[MO-only] ORDER BY ... NULLS { FIRST | LAST } — PostgreSQL-style NULL ordering not available in MySQL"
               ]
             },
@@ -909,10 +962,8 @@
               "id": "sql.data_query_language.subqueries.subquery_with_in",
               "title": "Subqueries with IN",
               "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Query-Language/subqueries/subquery-with-in.md",
-              "compat": "partial",
-              "notes": [
-                "Multi-level correlated subqueries inside IN() are not supported"
-              ]
+              "compat": "full",
+              "notes": []
             },
             {
               "id": "sql.data_query_language.subqueries.subquery",
@@ -920,22 +971,27 @@
               "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Query-Language/subqueries/subquery.md",
               "compat": "partial",
               "notes": [
-                "Multi-level correlated subqueries inside IN() are not supported"
+                "Multi-column scalar subquery comparisons (e.g., WHERE (a,b) = (SELECT ...)) are not supported; use multi-column IN instead"
               ]
             },
             {
               "id": "sql.data_query_language.union",
               "title": "UNION",
               "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Query-Language/union.md",
-              "compat": "full",
-              "notes": []
+              "compat": "partial",
+              "notes": [
+                "UNION type coercion is strict: MO errors on incompatible types in UNION columns (e.g., INT vs VARCHAR), while MySQL 8.0 silently coerces (e.g., varchar to int converts to 0)",
+                "UNION ALL type coercion is similarly strict compared to MySQL 8.0's lenient coercion"
+              ]
             },
             {
               "id": "sql.data_query_language.with_cte",
               "title": "WITH (Common Table Expressions)",
               "path": "docs/MatrixOne/Reference/SQL-Reference/Data-Query-Language/with-cte.md",
-              "compat": "full",
-              "notes": []
+              "compat": "partial",
+              "notes": [
+                "Outer joins (LEFT JOIN, RIGHT JOIN, OUTER JOIN) are not allowed in recursive CTE members; MySQL 8.0 permits them except when the recursive CTE is on the right side of a LEFT JOIN (MySQL allows LEFT JOIN with CTE on the left side; MO rejects all outer joins in recursive CTEs regardless of position)"
+              ]
             }
           ]
         },
@@ -947,8 +1003,23 @@
               "id": "sql.other.prepared_statements.deallocate",
               "title": "DEALLOCATE PREPARE",
               "path": "docs/MatrixOne/Reference/SQL-Reference/Other/Prepared-Statements/deallocate.md",
-              "compat": "full",
-              "notes": []
+              "compat": "partial",
+              "notes": [
+                "DEALLOCATE PREPARE on a non-existent statement silently succeeds; MySQL returns ERROR 1243 (Unknown prepared statement handler)."
+              ]
+            },
+            {
+              "id": "sql.other.describe",
+              "title": "DESCRIBE / DESC",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Other/describe.md",
+              "compat": "partial",
+              "notes": [
+                "DESCRIBE/DESC output includes an extra `Comment` column (7 columns total vs MySQL's 6).",
+                "Type names are displayed in uppercase with display widths (e.g., `INT(32)`, `FLOAT(0)`, `TIMESTAMP(0)`) instead of MySQL's lowercase without widths (e.g., `int`, `float`, `timestamp`).",
+                "Column name filter (`DESC tbl_name col_name`) is non-functional; all columns are returned.",
+                "Wild pattern (`DESC tbl_name 'pattern'`) not supported; produces syntax error.",
+                "For TIMESTAMP columns with DEFAULT CURRENT_TIMESTAMP, MO does not show `DEFAULT_GENERATED` in the Extra column as MySQL does."
+              ]
             },
             {
               "id": "sql.other.prepared_statements.execute",
@@ -963,8 +1034,11 @@
               "path": "docs/MatrixOne/Reference/SQL-Reference/Other/Explain/explain.md",
               "compat": "partial",
               "notes": [
-                "Output format mirrors PostgreSQL, not MySQL",
-                "JSON output not supported"
+                "Output format is a single QUERY PLAN column with tree-structured text (PostgreSQL-style); MySQL uses a multi-column tabular format with id, select_type, table, partitions, type, possible_keys, key, key_len, ref, rows, filtered, Extra",
+                "JSON output (FORMAT=JSON) not supported; MO returns syntax error",
+                "FORMAT=TREE and FORMAT=TRADITIONAL not supported; FORMAT=TEXT bare keyword also errors; only bare keyword forms (EXPLAIN, EXPLAIN ANALYZE, EXPLAIN VERBOSE) work",
+                "EXPLAIN FOR CONNECTION not supported (returns internal error)",
+                "EXPLAIN (ANALYZE TRUE/FALSE) and EXPLAIN (VERBOSE TRUE/FALSE) parenthesized boolean syntax WORKS in MO 3.0.12, contrary to doc claims; only parenthesized FORMAT syntax is unsupported"
               ]
             },
             {
@@ -973,7 +1047,9 @@
               "path": "docs/MatrixOne/Reference/SQL-Reference/Other/Explain/explain-workflow.md",
               "compat": "partial",
               "notes": [
-                "Output format mirrors PostgreSQL; JSON output not supported"
+                "Output is a single QUERY PLAN column with tree-structured text; MySQL uses multi-column tabular EXPLAIN format",
+                "JSON output not supported",
+                "Node types (Sink, Sink Scan, PreInsert, Fuzzy Filter, etc.) are MO-specific and have no MySQL equivalent"
               ]
             },
             {
@@ -991,7 +1067,9 @@
               "path": "docs/MatrixOne/Reference/SQL-Reference/Other/Explain/explain-analyze.md",
               "compat": "partial",
               "notes": [
-                "Output format mirrors PostgreSQL; JSON output not supported"
+                "Output format mirrors PostgreSQL (QUERY PLAN tree with Analyze sub-lines showing timeConsumed, waitTime, inputRows, outputRows, InputSize, OutputSize, MemorySize); MySQL 8.0 EXPLAIN ANALYZE uses TREE format with cost estimation and actual time in a different structure",
+                "JSON output not supported",
+                "MO EXPLAIN ANALYZE produces one output row per plan tree line; MySQL produces a single row with the full plan"
               ]
             },
             {
@@ -1007,7 +1085,8 @@
               "path": "docs/MatrixOne/Reference/SQL-Reference/Other/Prepared-Statements/prepare.md",
               "compat": "partial",
               "notes": [
-                "MatrixOne cannot PREPARE SET statements"
+                "MatrixOne cannot PREPARE SET, DO, or other TCL/DCL statements",
+                "Repreparation on parameter type change may throw a cast error instead of silently converting the value (e.g., passing a string to an integer parameter)."
               ]
             },
             {
@@ -1035,15 +1114,31 @@
               "path": "docs/MatrixOne/Reference/SQL-Reference/Other/SHOW-Statements/show-collation.md",
               "compat": "partial",
               "notes": [
-                "Only utf8mb4_bin is effective; other collations appear but are inert"
+                "Only utf8mb4_bin is effective; other collations appear but are inert",
+                "MO 3.0.12 returns 11 collations (with `Default` and `Pad_attribute` columns); older doc examples show only 1 row with 5 columns",
+                "Output columns (Collation, Charset, Id, Default, Compiled, Sortlen, Pad_attribute) differ slightly from MySQL which also includes Pad_attribute"
               ]
             },
             {
               "id": "sql.other.show_statements.show_columns",
               "title": "SHOW COLUMNS",
               "path": "docs/MatrixOne/Reference/SQL-Reference/Other/SHOW-Statements/show-columns.md",
-              "compat": "full",
-              "notes": []
+              "compat": "partial",
+              "notes": [
+                "MO SHOW COLUMNS (without FULL) already includes the `Comment` column; MySQL only shows Comment with FULL",
+                "MO SHOW FULL COLUMNS returns Collation and Privileges columns but Collation is always NULL",
+                "MO accepts EXTENDED keyword (SHOW EXTENDED COLUMNS) and FIELDS synonym (SHOW FIELDS), both returning same columns as SHOW COLUMNS",
+                "MO Type column includes display width (e.g. INT(32)) while MySQL shows just int"
+              ]
+            },
+            {
+              "id": "sql.other.show_statements.show_create_database",
+              "title": "SHOW CREATE DATABASE",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Other/SHOW-Statements/show-create-database.md",
+              "compat": "partial",
+              "notes": [
+                "Output omits CHARACTER SET, COLLATE, and ENCRYPTION clauses present in MySQL 8.0 SHOW CREATE DATABASE output"
+              ]
             },
             {
               "id": "sql.other.show_statements.show_create_publication",
@@ -1060,7 +1155,8 @@
               "path": "docs/MatrixOne/Reference/SQL-Reference/Other/SHOW-Statements/show-create-table.md",
               "compat": "partial",
               "notes": [
-                "Output reflects MatrixOne-specific extensions (CLUSTER BY, USING IVFFLAT/HNSW, etc.)"
+                "Output reflects MatrixOne-specific extensions (CLUSTER BY, USING IVFFLAT/HNSW, etc.)",
+                "MO output omits ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci appended by MySQL"
               ]
             },
             {
@@ -1069,7 +1165,11 @@
               "path": "docs/MatrixOne/Reference/SQL-Reference/Other/SHOW-Statements/show-create-view.md",
               "compat": "partial",
               "notes": [
-                "DEFINER = user clause absent from output; SQL SECURITY {DEFINER|INVOKER} is emitted"
+                "DEFINER = user clause absent from output; SQL SECURITY {DEFINER|INVOKER} is emitted",
+                "MO output lacks ALGORITHM=UNDEFINED clause that MySQL always includes",
+                "MO does not fully qualify column references (MySQL outputs db.table.col AS alias)",
+                "MO uses unquoted identifiers; MySQL backtick-quotes database, table, and column names",
+                "The rendered Create View output shows `CREATE SQL SECURITY DEFINER VIEW` (not `CREATE ALGORITHM=UNDEFINED DEFINER=user SQL SECURITY DEFINER VIEW` as MySQL does)"
               ]
             },
             {
@@ -1085,7 +1185,8 @@
               "path": "docs/MatrixOne/Reference/SQL-Reference/Other/SHOW-Statements/show-function-status.md",
               "compat": "partial",
               "notes": [
-                "Lists MatrixOne SQL/Python functions, not MySQL stored routines"
+                "Lists MatrixOne SQL/Python functions; MySQL shows stored routines AND built-in sys schema functions (e.g. extract_schema_from_file_name, format_bytes)",
+                "MO only shows user-defined functions; MySQL shows all functions including built-in ones"
               ]
             },
             {
@@ -1094,7 +1195,10 @@
               "path": "docs/MatrixOne/Reference/SQL-Reference/Other/SHOW-Statements/show-grants.md",
               "compat": "partial",
               "notes": [
-                "Results reflect MatrixOne role/account graph and differ from MySQL significantly"
+                "Grant syntax output is completely different: MO uses MO-specific format (GRANT create account ON account, GRANT table all ON table) instead of MySQL standard format (GRANT SELECT, INSERT, UPDATE, DELETE ON *.*)",
+                "MO output includes backtick-quoted user@host inside grant statements; MySQL uses quoted user@host format with TO clause",
+                "USING role_list clause not supported",
+                "MO does not support SHOW GRANTS FOR CURRENT_USER (or CURRENT_USER()) as a shorthand for the current user"
               ]
             },
             {
@@ -1103,7 +1207,12 @@
               "path": "docs/MatrixOne/Reference/SQL-Reference/Other/SHOW-Statements/show-index.md",
               "compat": "partial",
               "notes": [
-                "Reflects MatrixOne index model — secondary index rows appear but may not accelerate queries"
+                "Reflects MatrixOne index model — secondary index rows appear but may not accelerate queries",
+                "Index_type may be empty (MySQL typically shows BTREE)",
+                "Index_comment column is present (MySQL 8.0 also has Index_comment; difference is minor)",
+                "Index_params column is present (MySQL does not have this column)",
+                "Expression column shows the column name for non-functional key parts; MySQL shows NULL for non-functional key parts",
+                "MO SHOW INDEX returns 16 columns vs MySQL 15 columns (MO adds Index_params, lacks the extra Collation behavior)"
               ]
             },
             {
@@ -1121,7 +1230,9 @@
               "path": "docs/MatrixOne/Reference/SQL-Reference/Other/SHOW-Statements/show-processlist.md",
               "compat": "partial",
               "notes": [
-                "Output differs significantly from MySQL due to different implementation"
+                "MO returns 19 columns (node_id, conn_id, session_id, account, user, host, db, session_start, command, info, txn_id, statement_id, statement_type, query_type, sql_source_type, query_start, client_host, role, proxy_host) vs MySQL 8 columns (Id, User, Host, db, Command, Time, State, Info)",
+                "MO column names differ completely: conn_id vs Id, session_start vs Time, no State column, MO adds txn_id/statement_id/statement_type/query_type/sql_source_type/query_start/client_host/role/proxy_host",
+                "SHOW FULL PROCESSLIST is accepted by MO but returns same columns as SHOW PROCESSLIST (no behavioral difference)"
               ]
             },
             {
@@ -1170,12 +1281,25 @@
               ]
             },
             {
+              "id": "sql.other.show_statements.show_table_status",
+              "title": "SHOW TABLE STATUS",
+              "path": "docs/MatrixOne/Reference/SQL-Reference/Other/SHOW-Statements/show-table-status.md",
+              "compat": "partial",
+              "notes": [
+                "Result columns differ from MySQL: MO has 19 cols (adds Role_id, Role_name; omits Version); MySQL has 18 cols (includes Version; no Role_id/Role_name)",
+                "Engine column always shows Tae instead of InnoDB",
+                "MO's Auto_increment defaults to 0 (MySQL shows NULL for tables without auto-increment)",
+                "MO shows views in SHOW TABLE STATUS with Engine=NULL and Comment=VIEW (same as MySQL behavior)"
+              ]
+            },
+            {
               "id": "sql.other.show_statements.show_tables",
               "title": "SHOW TABLES",
               "path": "docs/MatrixOne/Reference/SQL-Reference/Other/SHOW-Statements/show-tables.md",
               "compat": "partial",
               "notes": [
-                "Result column is named 'name' rather than MySQL's 'Tables_in_<dbname>'."
+                "Output column header uses lowercase database name (Tables_in_<db> vs MySQL's Tables_in_<DB>)",
+                "MO does not display a parenthesized LIKE pattern in the column header unlike MySQL"
               ]
             },
             {
@@ -1184,7 +1308,10 @@
               "path": "docs/MatrixOne/Reference/SQL-Reference/Other/SHOW-Statements/show-variables.md",
               "compat": "partial",
               "notes": [
-                "System variables are mostly syntactic stubs; actual behaviour differs from MySQL"
+                "System variables are mostly syntactic stubs; actual behaviour differs from MySQL",
+                "GLOBAL and SESSION scope modifiers are syntactically accepted for both SET and SHOW; SHOW GLOBAL vs SHOW SESSION return different values when SESSION has been overridden, same as MySQL",
+                "MO has a completely different set of variable names (e.g. testbotchvar_nodyn, testbothvar_dyn) alongside MySQL-compatible ones (autocommit, sql_mode)",
+                "Variable values use lowercase ('on'/'off') while MySQL uses uppercase ('ON'/'OFF')"
               ]
             },
             {
@@ -1202,10 +1329,10 @@
       "id": "functions-and-operators",
       "label": "Functions",
       "summary": {
-        "full": 111,
-        "partial": 17,
+        "full": 103,
+        "partial": 26,
         "none": 0,
-        "mo_only": 36,
+        "mo_only": 35,
         "unknown": 0
       },
       "categories": [
@@ -1239,8 +1366,10 @@
               "id": "func.aggregate_functions.avg",
               "title": "AVG",
               "path": "docs/MatrixOne/Reference/Functions-and-Operators/Aggregate-Functions/avg.md",
-              "compat": "full",
-              "notes": []
+              "compat": "partial",
+              "notes": [
+                "AVG() returns DOUBLE for all input types (MySQL returns DECIMAL for exact-value types)"
+              ]
             },
             {
               "id": "func.aggregate_functions.bit_and",
@@ -1320,8 +1449,10 @@
               "id": "func.aggregate_functions.sum",
               "title": "SUM",
               "path": "docs/MatrixOne/Reference/Functions-and-Operators/Aggregate-Functions/sum.md",
-              "compat": "full",
-              "notes": []
+              "compat": "partial",
+              "notes": [
+                "SUM() returns the input integer type rather than DECIMAL for exact-value arguments (MySQL returns DECIMAL)"
+              ]
             },
             {
               "id": "func.aggregate_functions.var_pop",
@@ -1434,10 +1565,8 @@
               "id": "func.datetime.dayofyear",
               "title": "DAYOFYEAR()",
               "path": "docs/MatrixOne/Reference/Functions-and-Operators/Datetime/dayofyear.md",
-              "compat": "partial",
-              "notes": [
-                "Date literals accept only 'yyyy-mm-dd' and 'yyyymmdd' formats; MySQL accepts wider variants."
-              ]
+              "compat": "full",
+              "notes": []
             },
             {
               "id": "func.datetime.extract",
@@ -1540,7 +1669,8 @@
               "path": "docs/MatrixOne/Reference/Functions-and-Operators/Datetime/timestamp.md",
               "compat": "partial",
               "notes": [
-                "MatrixOne TIMESTAMP range is '0001-01-01'–'9999-12-31' vs MySQL '1970-01-01'–'2038-01-19' (compat doc: Data Types)."
+                "MatrixOne TIMESTAMP range is '0001-01-01'–'9999-12-31' vs MySQL '1970-01-01'–'2038-01-19' (compat doc: Data Types).",
+                "Two-argument form TIMESTAMP(expr1, expr2) is not supported; MO only supports single-argument TIMESTAMP(expr)"
               ]
             },
             {
@@ -1666,7 +1796,7 @@
             },
             {
               "id": "func.json.json_extract_string",
-              "title": "JSON_EXTRACT_FLOAT64()",
+              "title": "JSON_EXTRACT_STRING()",
               "path": "docs/MatrixOne/Reference/Functions-and-Operators/Json/json_extract_string.md",
               "compat": "mo_only",
               "notes": [
@@ -1792,8 +1922,11 @@
               "id": "func.mathematical.floor",
               "title": "FLOOR()",
               "path": "docs/MatrixOne/Reference/Functions-and-Operators/Mathematical/floor.md",
-              "compat": "full",
-              "notes": []
+              "compat": "partial",
+              "notes": [
+                "MatrixOne supports an optional second decimals argument (FLOOR(number, decimals)) to specify decimal places; MySQL 8.0 only supports the single-argument form FLOOR(X)",
+                "[MO-only] Two-argument form FLOOR(number, decimals) to specify decimal places"
+              ]
             },
             {
               "id": "func.mathematical.ln",
@@ -1841,8 +1974,10 @@
               "id": "func.mathematical.rand",
               "title": "RAND()",
               "path": "docs/MatrixOne/Reference/Functions-and-Operators/Mathematical/rand.md",
-              "compat": "full",
-              "notes": []
+              "compat": "partial",
+              "notes": [
+                "RAND(seed) is not supported; calling RAND(N) with an integer argument produces ERROR 20203"
+              ]
             },
             {
               "id": "func.mathematical.round",
@@ -1884,9 +2019,9 @@
               "id": "func.other.load_file",
               "title": "LOAD_FILE()",
               "path": "docs/MatrixOne/Reference/Functions-and-Operators/Other/load_file.md",
-              "compat": "mo_only",
+              "compat": "partial",
               "notes": [
-                "[MO-only] LOAD_FILE() takes a DATALINK value (file:// or stage:// URL) rather than MySQL's plain filesystem path argument; semantics differ."
+                "LOAD_FILE() takes a DATALINK value (file:// or stage:// URL) rather than MySQL's plain filesystem path argument"
               ]
             },
             {
@@ -1929,7 +2064,7 @@
               "path": "docs/MatrixOne/Reference/Functions-and-Operators/Other/stage_list.md",
               "compat": "mo_only",
               "notes": [
-                "[MO-only] STAGE_LIST() lists MatrixOne stage contents."
+                "[MO-only] STAGE_LIST() — MO-specific stage management function (currently unimplemented, returns ERROR 20105)"
               ]
             },
             {
@@ -1997,7 +2132,7 @@
               "id": "func.string.concat",
               "title": "CONCAT()",
               "path": "docs/MatrixOne/Reference/Functions-and-Operators/String/concat.md",
-              "compat": "full",
+              "compat": "partial",
               "notes": []
             },
             {
@@ -2050,8 +2185,10 @@
               "id": "func.string.from_base64",
               "title": "FROM_BASE64()",
               "path": "docs/MatrixOne/Reference/Functions-and-Operators/String/from_base64.md",
-              "compat": "full",
-              "notes": []
+              "compat": "partial",
+              "notes": [
+                "FROM_BASE64() may include trailing null bytes in decoded output; MySQL strips them (e.g., FROM_BASE64('YQ==') returns 'a\\\\0\\\\0' instead of 'a')"
+              ]
             },
             {
               "id": "func.string.hex",
@@ -2134,15 +2271,19 @@
               "id": "func.string.oct",
               "title": "OCT(N)",
               "path": "docs/MatrixOne/Reference/Functions-and-Operators/String/oct.md",
-              "compat": "full",
-              "notes": []
+              "compat": "partial",
+              "notes": [
+                "OCT(N) returns a numeric value rather than MySQL's plain string representation"
+              ]
             },
             {
               "id": "func.string.regular_expressions.regexp_instr",
               "title": "REGEXP_INSTR()",
               "path": "docs/MatrixOne/Reference/Functions-and-Operators/String/Regular-Expressions/regexp-instr.md",
-              "compat": "full",
-              "notes": []
+              "compat": "partial",
+              "notes": [
+                "match_type parameter not yet supported; passing it causes ERROR 20203"
+              ]
             },
             {
               "id": "func.string.regular_expressions.regexp_like",
@@ -2162,8 +2303,10 @@
               "id": "func.string.regular_expressions.regexp_substr",
               "title": "REGEXP_SUBSTR()",
               "path": "docs/MatrixOne/Reference/Functions-and-Operators/String/Regular-Expressions/regexp-substr.md",
-              "compat": "full",
-              "notes": []
+              "compat": "partial",
+              "notes": [
+                "match_type parameter not yet supported; passing it causes ERROR 20203"
+              ]
             },
             {
               "id": "func.string.regular_expressions.regular_expression_functions_overview",
@@ -2334,7 +2477,7 @@
               "path": "docs/MatrixOne/Reference/Functions-and-Operators/system-ops/current_user.md",
               "compat": "partial",
               "notes": [
-                "Return format is 'username@0.0.0.0' rather than MySQL's 'username@host' with a resolved client host."
+                "The host part may be returned as 'localhost' or the resolved client host rather than MySQL's explicit 'username@host' format."
               ]
             },
             {
@@ -2398,7 +2541,7 @@
               "path": "docs/MatrixOne/Reference/Functions-and-Operators/Vector/cluster_centers.md",
               "compat": "mo_only",
               "notes": [
-                "[MO-only] Vector type and related distance/norm/clustering functions are MatrixOne extensions (compat doc: Data Types — \\\"MatrixOne supports vector types\\\")."
+                "[MO-only] CLUSTER_CENTERS() — MO-specific vector clustering function (currently unimplemented, returns ERROR 20102)"
               ]
             },
             {
@@ -2540,11 +2683,11 @@
       "id": "operators",
       "label": "Operators",
       "summary": {
-        "full": 1,
-        "partial": 0,
+        "full": 6,
+        "partial": 4,
         "none": 0,
-        "mo_only": 0,
-        "unknown": 61
+        "mo_only": 5,
+        "unknown": 47
       },
       "categories": [
         {
@@ -2553,477 +2696,462 @@
           "entries": [
             {
               "id": "op.interval",
-              "title": "interval",
+              "title": "INTERVAL",
               "path": "docs/MatrixOne/Reference/Operators/interval.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.operator_precedence",
-              "title": "operator-precedence",
-              "path": "docs/MatrixOne/Reference/Operators/operator-precedence.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.operators",
-              "title": "operators",
-              "path": "docs/MatrixOne/Reference/Operators/operators.md",
-              "compat": "unknown",
-              "notes": []
+              "compat": "partial",
+              "notes": [
+                "INTERVAL is internally implemented as a two-argument function rather than as a true SQL keyword; documented syntax INTERVAL(expr,unit) differs from MySQL's INTERVAL expr unit keyword-style notation",
+                "Malformed dates in DATE_ADD/DATE_SUB raise errors rather than returning NULL (MySQL 8.0 returns NULL)"
+              ]
             }
           ]
         },
         {
-          "id": "arithmetic_operators",
-          "label": "Arithmetic Operators",
+          "id": "operators",
+          "label": "operators",
           "entries": [
             {
-              "id": "op.arithmetic_operators.addition",
-              "title": "addition",
-              "path": "docs/MatrixOne/Reference/Operators/arithmetic-operators/addition.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.arithmetic_operators.arithmetic_operators_overview",
-              "title": "arithmetic-operators-overview",
-              "path": "docs/MatrixOne/Reference/Operators/arithmetic-operators/arithmetic-operators-overview.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.arithmetic_operators.div",
-              "title": "div",
-              "path": "docs/MatrixOne/Reference/Operators/arithmetic-operators/div.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.arithmetic_operators.division",
-              "title": "division",
-              "path": "docs/MatrixOne/Reference/Operators/arithmetic-operators/division.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.arithmetic_operators.minus",
-              "title": "minus",
-              "path": "docs/MatrixOne/Reference/Operators/arithmetic-operators/minus.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.arithmetic_operators.mod",
-              "title": "mod",
-              "path": "docs/MatrixOne/Reference/Operators/arithmetic-operators/mod.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.arithmetic_operators.multiplication",
-              "title": "multiplication",
-              "path": "docs/MatrixOne/Reference/Operators/arithmetic-operators/multiplication.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.arithmetic_operators.unary_minus",
-              "title": "unary-minus",
-              "path": "docs/MatrixOne/Reference/Operators/arithmetic-operators/unary-minus.md",
-              "compat": "unknown",
-              "notes": []
-            }
-          ]
-        },
-        {
-          "id": "assignment_operators",
-          "label": "Assignment Operators",
-          "entries": [
-            {
-              "id": "op.assignment_operators.assignment_operators_overview",
-              "title": "assignment-operators-overview",
-              "path": "docs/MatrixOne/Reference/Operators/assignment-operators/assignment-operators-overview.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.assignment_operators.equal",
-              "title": "equal",
-              "path": "docs/MatrixOne/Reference/Operators/assignment-operators/equal.md",
-              "compat": "unknown",
-              "notes": []
-            }
-          ]
-        },
-        {
-          "id": "bit_functions_and_operators",
-          "label": "Bit Functions and Operators",
-          "entries": [
-            {
-              "id": "op.bit_functions_and_operators.bit_functions_and_operators_overview",
-              "title": "bit-functions-and-operators-overview",
-              "path": "docs/MatrixOne/Reference/Operators/bit-functions-and-operators/bit-functions-and-operators-overview.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.bit_functions_and_operators.bitwise_and",
-              "title": "bitwise-and",
-              "path": "docs/MatrixOne/Reference/Operators/bit-functions-and-operators/bitwise-and.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.bit_functions_and_operators.bitwise_inversion",
-              "title": "bitwise-inversion",
-              "path": "docs/MatrixOne/Reference/Operators/bit-functions-and-operators/bitwise-inversion.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.bit_functions_and_operators.bitwise_or",
-              "title": "bitwise-or",
-              "path": "docs/MatrixOne/Reference/Operators/bit-functions-and-operators/bitwise-or.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.bit_functions_and_operators.bitwise_xor",
-              "title": "bitwise-xor",
-              "path": "docs/MatrixOne/Reference/Operators/bit-functions-and-operators/bitwise-xor.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.bit_functions_and_operators.left_shift",
-              "title": "left-shift",
-              "path": "docs/MatrixOne/Reference/Operators/bit-functions-and-operators/left-shift.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.bit_functions_and_operators.right_shift",
-              "title": "right-shift",
-              "path": "docs/MatrixOne/Reference/Operators/bit-functions-and-operators/right-shift.md",
-              "compat": "unknown",
-              "notes": []
-            }
-          ]
-        },
-        {
-          "id": "cast_functions_and_operators",
-          "label": "Cast Functions and Operators",
-          "entries": [
-            {
-              "id": "op.cast_functions_and_operators.binary",
-              "title": "binary",
-              "path": "docs/MatrixOne/Reference/Operators/cast-functions-and-operators/binary.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.cast_functions_and_operators.cast",
-              "title": "cast",
-              "path": "docs/MatrixOne/Reference/Operators/cast-functions-and-operators/cast.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.cast_functions_and_operators.cast_functions_and_operators_overview",
-              "title": "cast-functions-and-operators-overview",
-              "path": "docs/MatrixOne/Reference/Operators/cast-functions-and-operators/cast-functions-and-operators-overview.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.cast_functions_and_operators.convert",
-              "title": "convert",
-              "path": "docs/MatrixOne/Reference/Operators/cast-functions-and-operators/convert.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.cast_functions_and_operators.decode",
-              "title": "decode",
-              "path": "docs/MatrixOne/Reference/Operators/cast-functions-and-operators/decode.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.cast_functions_and_operators.encode",
-              "title": "encode",
-              "path": "docs/MatrixOne/Reference/Operators/cast-functions-and-operators/encode.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.cast_functions_and_operators.serial",
-              "title": "serial",
-              "path": "docs/MatrixOne/Reference/Operators/cast-functions-and-operators/serial.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.cast_functions_and_operators.serial_full",
-              "title": "serial_full",
-              "path": "docs/MatrixOne/Reference/Operators/cast-functions-and-operators/serial_full.md",
-              "compat": "unknown",
-              "notes": []
-            }
-          ]
-        },
-        {
-          "id": "comparison_functions_and_operators",
-          "label": "Comparison Functions and Operators",
-          "entries": [
-            {
-              "id": "op.comparison_functions_and_operators.null_safe_equal",
+              "id": "op.operators.comparison_functions_and_operators.null_safe_equal",
               "title": "<=>",
-              "path": "docs/MatrixOne/Reference/Operators/comparison-functions-and-operators/null-safe-equal.md",
+              "path": "docs/MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/null-safe-equal.md",
               "compat": "full",
               "notes": []
             },
             {
-              "id": "op.comparison_functions_and_operators.assign_equal",
-              "title": "assign-equal",
-              "path": "docs/MatrixOne/Reference/Operators/comparison-functions-and-operators/assign-equal.md",
+              "id": "op.operators.arithmetic_operators.addition",
+              "title": "addition",
+              "path": "docs/MatrixOne/Reference/Operators/operators/arithmetic-operators/addition.md",
               "compat": "unknown",
               "notes": []
             },
             {
-              "id": "op.comparison_functions_and_operators.between",
-              "title": "between",
-              "path": "docs/MatrixOne/Reference/Operators/comparison-functions-and-operators/between.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.comparison_functions_and_operators.coalesce",
-              "title": "coalesce",
-              "path": "docs/MatrixOne/Reference/Operators/comparison-functions-and-operators/coalesce.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.comparison_functions_and_operators.comparison_functions_and_operators_overview",
-              "title": "comparison-functions-and-operators-overview",
-              "path": "docs/MatrixOne/Reference/Operators/comparison-functions-and-operators/comparison-functions-and-operators-overview.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.comparison_functions_and_operators.function_interval",
-              "title": "function_interval",
-              "path": "docs/MatrixOne/Reference/Operators/comparison-functions-and-operators/function_interval.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.comparison_functions_and_operators.function_isnull",
-              "title": "function_isnull",
-              "path": "docs/MatrixOne/Reference/Operators/comparison-functions-and-operators/function_isnull.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.comparison_functions_and_operators.function_least",
-              "title": "function_least",
-              "path": "docs/MatrixOne/Reference/Operators/comparison-functions-and-operators/function_least.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.comparison_functions_and_operators.function_strcmp",
-              "title": "function_strcmp",
-              "path": "docs/MatrixOne/Reference/Operators/comparison-functions-and-operators/function_strcmp.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.comparison_functions_and_operators.greater_than",
-              "title": "greater-than",
-              "path": "docs/MatrixOne/Reference/Operators/comparison-functions-and-operators/greater-than.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.comparison_functions_and_operators.greater_than_or_equal",
-              "title": "greater-than-or-equal",
-              "path": "docs/MatrixOne/Reference/Operators/comparison-functions-and-operators/greater-than-or-equal.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.comparison_functions_and_operators.ilike",
-              "title": "ilike",
-              "path": "docs/MatrixOne/Reference/Operators/comparison-functions-and-operators/ilike.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.comparison_functions_and_operators.in",
-              "title": "in",
-              "path": "docs/MatrixOne/Reference/Operators/comparison-functions-and-operators/in.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.comparison_functions_and_operators.is",
-              "title": "is",
-              "path": "docs/MatrixOne/Reference/Operators/comparison-functions-and-operators/is.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.comparison_functions_and_operators.is_not",
-              "title": "is-not",
-              "path": "docs/MatrixOne/Reference/Operators/comparison-functions-and-operators/is-not.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.comparison_functions_and_operators.is_not_null",
-              "title": "is-not-null",
-              "path": "docs/MatrixOne/Reference/Operators/comparison-functions-and-operators/is-not-null.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.comparison_functions_and_operators.is_null",
-              "title": "is-null",
-              "path": "docs/MatrixOne/Reference/Operators/comparison-functions-and-operators/is-null.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.comparison_functions_and_operators.less_than",
-              "title": "less-than",
-              "path": "docs/MatrixOne/Reference/Operators/comparison-functions-and-operators/less-than.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.comparison_functions_and_operators.less_than_or_equal",
-              "title": "less-than-or-equal",
-              "path": "docs/MatrixOne/Reference/Operators/comparison-functions-and-operators/less-than-or-equal.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.comparison_functions_and_operators.like",
-              "title": "like",
-              "path": "docs/MatrixOne/Reference/Operators/comparison-functions-and-operators/like.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.comparison_functions_and_operators.not_between",
-              "title": "not-between",
-              "path": "docs/MatrixOne/Reference/Operators/comparison-functions-and-operators/not-between.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.comparison_functions_and_operators.not_equal",
-              "title": "not-equal",
-              "path": "docs/MatrixOne/Reference/Operators/comparison-functions-and-operators/not-equal.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.comparison_functions_and_operators.not_in",
-              "title": "not-in",
-              "path": "docs/MatrixOne/Reference/Operators/comparison-functions-and-operators/not-in.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.comparison_functions_and_operators.not_like",
-              "title": "not-like",
-              "path": "docs/MatrixOne/Reference/Operators/comparison-functions-and-operators/not-like.md",
-              "compat": "unknown",
-              "notes": []
-            }
-          ]
-        },
-        {
-          "id": "flow_control_functions",
-          "label": "Flow Control Functions",
-          "entries": [
-            {
-              "id": "op.flow_control_functions.case_when",
-              "title": "case-when",
-              "path": "docs/MatrixOne/Reference/Operators/flow-control-functions/case-when.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.flow_control_functions.flow_control_functions_overview",
-              "title": "flow-control-functions-overview",
-              "path": "docs/MatrixOne/Reference/Operators/flow-control-functions/flow-control-functions-overview.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.flow_control_functions.function_if",
-              "title": "function_if",
-              "path": "docs/MatrixOne/Reference/Operators/flow-control-functions/function_if.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.flow_control_functions.function_ifnull",
-              "title": "function_ifnull",
-              "path": "docs/MatrixOne/Reference/Operators/flow-control-functions/function_ifnull.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.flow_control_functions.function_nullif",
-              "title": "function_nullif",
-              "path": "docs/MatrixOne/Reference/Operators/flow-control-functions/function_nullif.md",
-              "compat": "unknown",
-              "notes": []
-            }
-          ]
-        },
-        {
-          "id": "logical_operators",
-          "label": "Logical Operators",
-          "entries": [
-            {
-              "id": "op.logical_operators.and",
+              "id": "op.operators.logical_operators.and",
               "title": "and",
-              "path": "docs/MatrixOne/Reference/Operators/logical-operators/and.md",
+              "path": "docs/MatrixOne/Reference/Operators/operators/logical-operators/and.md",
               "compat": "unknown",
               "notes": []
             },
             {
-              "id": "op.logical_operators.logical_operators_overview",
+              "id": "op.operators.arithmetic_operators.arithmetic_operators_overview",
+              "title": "arithmetic-operators-overview",
+              "path": "docs/MatrixOne/Reference/Operators/operators/arithmetic-operators/arithmetic-operators-overview.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.comparison_functions_and_operators.assign_equal",
+              "title": "assign-equal",
+              "path": "docs/MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/assign-equal.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.assignment_operators.assignment_operators_overview",
+              "title": "assignment-operators-overview",
+              "path": "docs/MatrixOne/Reference/Operators/operators/assignment-operators/assignment-operators-overview.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.comparison_functions_and_operators.between",
+              "title": "between",
+              "path": "docs/MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/between.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.cast_functions_and_operators.binary",
+              "title": "binary",
+              "path": "docs/MatrixOne/Reference/Operators/operators/cast-functions-and-operators/binary.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.bit_functions_and_operators.bit_functions_and_operators_overview",
+              "title": "bit-functions-and-operators-overview",
+              "path": "docs/MatrixOne/Reference/Operators/operators/bit-functions-and-operators/bit-functions-and-operators-overview.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.bit_functions_and_operators.bitwise_and",
+              "title": "bitwise-and",
+              "path": "docs/MatrixOne/Reference/Operators/operators/bit-functions-and-operators/bitwise-and.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.bit_functions_and_operators.bitwise_inversion",
+              "title": "bitwise-inversion",
+              "path": "docs/MatrixOne/Reference/Operators/operators/bit-functions-and-operators/bitwise-inversion.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.bit_functions_and_operators.bitwise_or",
+              "title": "bitwise-or",
+              "path": "docs/MatrixOne/Reference/Operators/operators/bit-functions-and-operators/bitwise-or.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.bit_functions_and_operators.bitwise_xor",
+              "title": "bitwise-xor",
+              "path": "docs/MatrixOne/Reference/Operators/operators/bit-functions-and-operators/bitwise-xor.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.flow_control_functions.case_when",
+              "title": "CASE WHEN",
+              "path": "docs/MatrixOne/Reference/Operators/operators/flow-control-functions/case-when.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "op.operators.cast_functions_and_operators.cast",
+              "title": "CAST",
+              "path": "docs/MatrixOne/Reference/Operators/operators/cast-functions-and-operators/cast.md",
+              "compat": "partial",
+              "notes": [
+                "CAST('non-numeric' AS SIGNED) raises an error instead of returning 0 or NULL (MySQL 8.0 returns 0 with a warning)",
+                "CAST(datetime_typed_value AS CHAR) may fail in some cases (MySQL 8.0 supports it universally)"
+              ]
+            },
+            {
+              "id": "op.operators.cast_functions_and_operators.cast_functions_and_operators_overview",
+              "title": "cast-functions-and-operators-overview",
+              "path": "docs/MatrixOne/Reference/Operators/operators/cast-functions-and-operators/cast-functions-and-operators-overview.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.comparison_functions_and_operators.coalesce",
+              "title": "coalesce",
+              "path": "docs/MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/coalesce.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.comparison_functions_and_operators.comparison_functions_and_operators_overview",
+              "title": "comparison-functions-and-operators-overview",
+              "path": "docs/MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/comparison-functions-and-operators-overview.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.cast_functions_and_operators.convert",
+              "title": "CONVERT",
+              "path": "docs/MatrixOne/Reference/Operators/operators/cast-functions-and-operators/convert.md",
+              "compat": "partial",
+              "notes": [
+                "CONVERT('non-numeric', SIGNED) raises an error instead of returning 0 or NULL",
+                "CONVERT(datetime_typed_value, CHAR) may fail in some cases (MySQL 8.0 supports it universally)"
+              ]
+            },
+            {
+              "id": "op.operators.cast_functions_and_operators.decode",
+              "title": "DECODE()",
+              "path": "docs/MatrixOne/Reference/Operators/operators/cast-functions-and-operators/decode.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] DECODE() was deprecated in MySQL 5.7 and removed in MySQL 8.0; MatrixOne continues to support it"
+              ]
+            },
+            {
+              "id": "op.operators.arithmetic_operators.div",
+              "title": "div",
+              "path": "docs/MatrixOne/Reference/Operators/operators/arithmetic-operators/div.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.arithmetic_operators.division",
+              "title": "division",
+              "path": "docs/MatrixOne/Reference/Operators/operators/arithmetic-operators/division.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.cast_functions_and_operators.encode",
+              "title": "ENCODE()",
+              "path": "docs/MatrixOne/Reference/Operators/operators/cast-functions-and-operators/encode.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] ENCODE() was deprecated in MySQL 5.7 and removed in MySQL 8.0; MatrixOne continues to support it"
+              ]
+            },
+            {
+              "id": "op.operators.assignment_operators.equal",
+              "title": "equal",
+              "path": "docs/MatrixOne/Reference/Operators/operators/assignment-operators/equal.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.flow_control_functions.flow_control_functions_overview",
+              "title": "flow-control-functions-overview",
+              "path": "docs/MatrixOne/Reference/Operators/operators/flow-control-functions/flow-control-functions-overview.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.flow_control_functions.function_ifnull",
+              "title": "function_ifnull",
+              "path": "docs/MatrixOne/Reference/Operators/operators/flow-control-functions/function_ifnull.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.comparison_functions_and_operators.function_interval",
+              "title": "function_interval",
+              "path": "docs/MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/function_interval.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.comparison_functions_and_operators.function_isnull",
+              "title": "function_isnull",
+              "path": "docs/MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/function_isnull.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.comparison_functions_and_operators.function_least",
+              "title": "function_least",
+              "path": "docs/MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/function_least.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.flow_control_functions.function_nullif",
+              "title": "function_nullif",
+              "path": "docs/MatrixOne/Reference/Operators/operators/flow-control-functions/function_nullif.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.comparison_functions_and_operators.function_strcmp",
+              "title": "function_strcmp",
+              "path": "docs/MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/function_strcmp.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.comparison_functions_and_operators.greater_than",
+              "title": "greater-than",
+              "path": "docs/MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/greater-than.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.comparison_functions_and_operators.greater_than_or_equal",
+              "title": "greater-than-or-equal",
+              "path": "docs/MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/greater-than-or-equal.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.flow_control_functions.function_if",
+              "title": "IF()",
+              "path": "docs/MatrixOne/Reference/Operators/operators/flow-control-functions/function_if.md",
+              "compat": "partial",
+              "notes": [
+                "IF(NULL, expr2, expr3) raises an error instead of returning expr3 (MySQL 8.0 returns expr3)"
+              ]
+            },
+            {
+              "id": "op.operators.comparison_functions_and_operators.ilike",
+              "title": "ILIKE",
+              "path": "docs/MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/ilike.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] ILIKE operator for case-insensitive LIKE matching (PostgreSQL extension)"
+              ]
+            },
+            {
+              "id": "op.operators.comparison_functions_and_operators.in",
+              "title": "IN",
+              "path": "docs/MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/in.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "op.operators.comparison_functions_and_operators.is",
+              "title": "is",
+              "path": "docs/MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/is.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.comparison_functions_and_operators.is_null",
+              "title": "IS NULL",
+              "path": "docs/MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/is-null.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "op.operators.comparison_functions_and_operators.is_not",
+              "title": "is-not",
+              "path": "docs/MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/is-not.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.comparison_functions_and_operators.is_not_null",
+              "title": "is-not-null",
+              "path": "docs/MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/is-not-null.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.bit_functions_and_operators.left_shift",
+              "title": "left-shift",
+              "path": "docs/MatrixOne/Reference/Operators/operators/bit-functions-and-operators/left-shift.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.comparison_functions_and_operators.less_than",
+              "title": "less-than",
+              "path": "docs/MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/less-than.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.comparison_functions_and_operators.less_than_or_equal",
+              "title": "less-than-or-equal",
+              "path": "docs/MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/less-than-or-equal.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.comparison_functions_and_operators.like",
+              "title": "like",
+              "path": "docs/MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/like.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.logical_operators.logical_operators_overview",
               "title": "logical-operators-overview",
-              "path": "docs/MatrixOne/Reference/Operators/logical-operators/logical-operators-overview.md",
+              "path": "docs/MatrixOne/Reference/Operators/operators/logical-operators/logical-operators-overview.md",
               "compat": "unknown",
               "notes": []
             },
             {
-              "id": "op.logical_operators.not",
-              "title": "not",
-              "path": "docs/MatrixOne/Reference/Operators/logical-operators/not.md",
+              "id": "op.operators.arithmetic_operators.minus",
+              "title": "minus",
+              "path": "docs/MatrixOne/Reference/Operators/operators/arithmetic-operators/minus.md",
               "compat": "unknown",
               "notes": []
             },
             {
-              "id": "op.logical_operators.or",
+              "id": "op.operators.arithmetic_operators.mod",
+              "title": "mod",
+              "path": "docs/MatrixOne/Reference/Operators/operators/arithmetic-operators/mod.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.arithmetic_operators.multiplication",
+              "title": "multiplication",
+              "path": "docs/MatrixOne/Reference/Operators/operators/arithmetic-operators/multiplication.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.logical_operators.not",
+              "title": "NOT / !",
+              "path": "docs/MatrixOne/Reference/Operators/operators/logical-operators/not.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "op.operators.comparison_functions_and_operators.not_in",
+              "title": "NOT IN",
+              "path": "docs/MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/not-in.md",
+              "compat": "full",
+              "notes": []
+            },
+            {
+              "id": "op.operators.comparison_functions_and_operators.not_between",
+              "title": "not-between",
+              "path": "docs/MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/not-between.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.comparison_functions_and_operators.not_equal",
+              "title": "not-equal",
+              "path": "docs/MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/not-equal.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.comparison_functions_and_operators.not_like",
+              "title": "not-like",
+              "path": "docs/MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/not-like.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.operator_precedence",
+              "title": "operator-precedence",
+              "path": "docs/MatrixOne/Reference/Operators/operators/operator-precedence.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.operators",
+              "title": "operators",
+              "path": "docs/MatrixOne/Reference/Operators/operators/operators.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.logical_operators.or",
               "title": "or",
-              "path": "docs/MatrixOne/Reference/Operators/logical-operators/or.md",
+              "path": "docs/MatrixOne/Reference/Operators/operators/logical-operators/or.md",
               "compat": "unknown",
               "notes": []
             },
             {
-              "id": "op.logical_operators.xor",
+              "id": "op.operators.bit_functions_and_operators.right_shift",
+              "title": "right-shift",
+              "path": "docs/MatrixOne/Reference/Operators/operators/bit-functions-and-operators/right-shift.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.cast_functions_and_operators.serial_full",
+              "title": "SERIAL_FULL()",
+              "path": "docs/MatrixOne/Reference/Operators/operators/cast-functions-and-operators/serial_full.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] SERIAL_FULL() is a MO-specific serialization function variant with NULL preservation, no MySQL 8.0 counterpart"
+              ]
+            },
+            {
+              "id": "op.operators.cast_functions_and_operators.serial",
+              "title": "SERIAL()",
+              "path": "docs/MatrixOne/Reference/Operators/operators/cast-functions-and-operators/serial.md",
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] SERIAL() is a MO-specific serialization function with no MySQL 8.0 counterpart"
+              ]
+            },
+            {
+              "id": "op.operators.arithmetic_operators.unary_minus",
+              "title": "unary-minus",
+              "path": "docs/MatrixOne/Reference/Operators/operators/arithmetic-operators/unary-minus.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.logical_operators.xor",
               "title": "xor",
-              "path": "docs/MatrixOne/Reference/Operators/logical-operators/xor.md",
+              "path": "docs/MatrixOne/Reference/Operators/operators/logical-operators/xor.md",
               "compat": "unknown",
               "notes": []
             }
@@ -3035,11 +3163,11 @@
       "id": "data-types",
       "label": "Data Types",
       "summary": {
-        "full": 0,
-        "partial": 2,
+        "full": 1,
+        "partial": 7,
         "none": 0,
-        "mo_only": 0,
-        "unknown": 10
+        "mo_only": 3,
+        "unknown": 1
       },
       "categories": [
         {
@@ -3055,24 +3183,33 @@
             },
             {
               "id": "dtype.data_type_conversion",
-              "title": "data-type-conversion",
+              "title": "Data Type Conversion",
               "path": "docs/MatrixOne/Reference/Data-Types/data-type-conversion.md",
-              "compat": "unknown",
-              "notes": []
+              "compat": "partial",
+              "notes": [
+                "BOOLEAN → DECIMAL cast is not supported; other common conversions are supported"
+              ]
             },
             {
               "id": "dtype.data_types",
-              "title": "data-types",
+              "title": "Data Types Overview",
               "path": "docs/MatrixOne/Reference/Data-Types/data-types.md",
-              "compat": "unknown",
-              "notes": []
+              "compat": "partial",
+              "notes": [
+                "TIMESTAMP range is 0001-01-01 to 9999-12-31 (MySQL: 1970-01-01 to 2038-01-19)",
+                "DATETIME lower bound is 0001-01-01 (MySQL: 1000-01-01)",
+                "Non-standard type names FLOAT32/FLOAT64 in addition to MySQL's FLOAT/DOUBLE"
+              ]
             },
             {
               "id": "dtype.datalink_type",
-              "title": "datalink-type",
+              "title": "DATALINK Type",
               "path": "docs/MatrixOne/Reference/Data-Types/datalink-type.md",
-              "compat": "unknown",
-              "notes": []
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] DATALINK data type with STAGE integration, file:// and stage:// URL schemes",
+                "[MO-only] load_file() integration for reading DATALINK values"
+              ]
             },
             {
               "id": "dtype.enum_type",
@@ -3083,16 +3220,18 @@
             },
             {
               "id": "dtype.fixed_point_types",
-              "title": "fixed-point-types",
+              "title": "Fixed-Point Types (Exact Value) - DECIMAL",
               "path": "docs/MatrixOne/Reference/Data-Types/fixed-point-types.md",
-              "compat": "unknown",
-              "notes": []
+              "compat": "partial",
+              "notes": [
+                "DECIMAL precision supports up to 65 digits via DECIMAL256"
+              ]
             },
             {
               "id": "dtype.json_type",
-              "title": "json-type",
+              "title": "JSON Type",
               "path": "docs/MatrixOne/Reference/Data-Types/json-type.md",
-              "compat": "unknown",
+              "compat": "full",
               "notes": []
             },
             {
@@ -3104,17 +3243,24 @@
             },
             {
               "id": "dtype.uuid_type",
-              "title": "uuid-type",
+              "title": "UUID Type",
               "path": "docs/MatrixOne/Reference/Data-Types/uuid-type.md",
-              "compat": "unknown",
-              "notes": []
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] UUID as a native column type (MySQL 8.0 has UUID() function only, no UUID column type)",
+                "[MO-only] DEFAULT uuid() on UUID columns"
+              ]
             },
             {
               "id": "dtype.vector_type",
-              "title": "vector-type",
+              "title": "Vector Type",
               "path": "docs/MatrixOne/Reference/Data-Types/vector-type.md",
-              "compat": "unknown",
-              "notes": []
+              "compat": "mo_only",
+              "notes": [
+                "[MO-only] vecf32 and vecf64 vector data types for embedding storage and similarity search",
+                "[MO-only] Binary vector insert via hex encoding",
+                "[MO-only] Dimension specification syntax in column definition"
+              ]
             }
           ]
         },
@@ -3124,16 +3270,21 @@
           "entries": [
             {
               "id": "dtype.date_time_data_types.timestamp_initialization",
-              "title": "timestamp-initialization",
+              "title": "TIMESTAMP Initialization",
               "path": "docs/MatrixOne/Reference/Data-Types/date-time-data-types/timestamp-initialization.md",
-              "compat": "unknown",
-              "notes": []
+              "compat": "partial",
+              "notes": [
+                "TIMESTAMP range is 0001-9999 (MySQL 8.0: 1970-2038); auto-initialization behavior near range boundaries may differ",
+                "DATETIME DEFAULT 0 is not supported (MySQL 8.0 supports it)",
+                "TIMESTAMP ON UPDATE CURRENT_TIMESTAMP without explicit DEFAULT defaults to NULL (MySQL 8.0 defaults to 0)",
+                "DATETIME NOT NULL ON UPDATE CURRENT_TIMESTAMP without explicit DEFAULT rejects NULL insert (MySQL 8.0 defaults to 0)"
+              ]
             },
             {
               "id": "dtype.date_time_data_types.year_type",
-              "title": "year-type",
+              "title": "YEAR Type",
               "path": "docs/MatrixOne/Reference/Data-Types/date-time-data-types/year-type.md",
-              "compat": "unknown",
+              "compat": "partial",
               "notes": []
             }
           ]
@@ -3145,10 +3296,10 @@
       "label": "Language Structure",
       "summary": {
         "full": 0,
-        "partial": 0,
+        "partial": 2,
         "none": 0,
         "mo_only": 0,
-        "unknown": 2
+        "unknown": 0
       },
       "categories": [
         {
@@ -3157,17 +3308,22 @@
           "entries": [
             {
               "id": "lang.comment",
-              "title": "comment",
+              "title": "Comments",
               "path": "docs/MatrixOne/Reference/Language-Structure/comment.md",
-              "compat": "unknown",
-              "notes": []
+              "compat": "partial",
+              "notes": [
+                "Supports // single-line comments (C++ style); MySQL 8.0 does not support // comments",
+                "Does not support /*!...*/ conditional/executable comments (MySQL 8.0 does)"
+              ]
             },
             {
               "id": "lang.keywords",
-              "title": "keywords",
+              "title": "Keywords",
               "path": "docs/MatrixOne/Reference/Language-Structure/keywords.md",
-              "compat": "unknown",
-              "notes": []
+              "compat": "partial",
+              "notes": [
+                "MatrixOne-specific keywords marked with (M) in the keyword list"
+              ]
             }
           ]
         }

--- a/docs/MatrixOne/Reference/mysql-compatibility-matrix.md
+++ b/docs/MatrixOne/Reference/mysql-compatibility-matrix.md
@@ -14,21 +14,22 @@ mysql_compat: full
 
 | Status | Count |
 |---|---|
-| ✅ Full | 142 |
-| ⚠️ Partial | 62 |
-| ❌ None | 0 |
-| 🟣 MatrixOne-only | 93 |
-| ❓ Unknown | 73 |
-| **Total** | **370** |
+| ✅ Full | 131 |
+| ⚠️ Partial | 97 |
+| ❌ None | 1 |
+| 🟣 MatrixOne-only | 96 |
+| ❓ Unknown | 48 |
+| **Total** | **373** |
 
 ## SQL Statements
 
 | Status | Count |
 |---|---|
-| ✅ Full | 30 |
-| ⚠️ Partial | 43 |
-| 🟣 MatrixOne-only | 57 |
-| **Total** | **130** |
+| ✅ Full | 21 |
+| ⚠️ Partial | 58 |
+| ❌ None | 1 |
+| 🟣 MatrixOne-only | 53 |
+| **Total** | **133** |
 
 ### SQL Statements
 
@@ -41,15 +42,15 @@ mysql_compat: full
 | Statement | MySQL Compat | Notes |
 |---|---|---|
 | [ALTER ACCOUNT](./SQL-Reference/Data-Control-Language/alter-account.md) | 🟣 MatrixOne-only | [MO-only] ALTER ACCOUNT |
-| [ALTER USER](./SQL-Reference/Data-Control-Language/alter-user.md) | ⚠️ Partial | Only ALTER USER can change passwords; account-limit clauses not honoured |
+| [ALTER USER](./SQL-Reference/Data-Control-Language/alter-user.md) | ⚠️ Partial | Only ALTER USER can change passwords; account-limit clauses not honoured<br/>Password management options (PASSWORD EXPIRE, PASSWORD HISTORY, PASSWORD REUSE INTERVAL, PASSWORD REQUIRE CURRENT, FAILED_LOGIN_ATTEMPTS, PASSWORD_LOCK_TIME) not supported<br/>Account locking (ACCOUNT LOCK/UNLOCK) not supported<br/>REQUIRE clause (TLS/SSL enforcement) not supported<br/>COMMENT and ATTRIBUTE modification not supported<br/>Multiple users per statement not supported (MySQL 8.0 allows user [, user] ...) |
 | [CREATE ACCOUNT](./SQL-Reference/Data-Control-Language/create-account.md) | 🟣 MatrixOne-only | [MO-only] CREATE ACCOUNT … ADMIN_NAME … |
 | [CREATE ROLE](./SQL-Reference/Data-Control-Language/create-role.md) | ⚠️ Partial | Role exists inside MatrixOne's multi-account model; roles are account-scoped, not server-global as in MySQL. |
-| [CREATE USER](./SQL-Reference/Data-Control-Language/create-user.md) | ⚠️ Partial | IDENTIFIED BY is the only supported password form; IDENTIFIED WITH plugins not supported<br/>Connection-IP whitelists and connection-limit clauses not supported<br/>COMMENT and ATTRIBUTE clauses are accepted syntactically but not honoured<br/>User identifier is a bare username scoped to the current account; MySQL uses 'user'@'host' tuples |
+| [CREATE USER](./SQL-Reference/Data-Control-Language/create-user.md) | ⚠️ Partial | IDENTIFIED BY is the only supported password form; IDENTIFIED WITH plugins not supported<br/>Connection-IP whitelists and connection-limit clauses not supported<br/>COMMENT and ATTRIBUTE clauses not supported<br/>'user'@'host' syntax is accepted and host is stored in mo_catalog.mo_user.user_host but may not restrict connections; users are scoped to the current account, not server-global as in MySQL<br/>Password management options (PASSWORD EXPIRE, PASSWORD HISTORY, PASSWORD REUSE INTERVAL, PASSWORD REQUIRE CURRENT) not supported<br/>Account locking (ACCOUNT LOCK/UNLOCK) not supported<br/>REQUIRE clause (TLS/SSL enforcement) not supported |
 | [DROP ACCOUNT](./SQL-Reference/Data-Control-Language/drop-account.md) | 🟣 MatrixOne-only | [MO-only] DROP ACCOUNT |
 | [DROP ROLE](./SQL-Reference/Data-Control-Language/drop-role.md) | ⚠️ Partial | Role exists inside MatrixOne's multi-account model; roles are account-scoped, not server-global as in MySQL. |
 | [DROP USER](./SQL-Reference/Data-Control-Language/drop-user.md) | ⚠️ Partial | User identifier is a bare username scoped to the current account; MySQL uses 'user'@'host' tuples. |
-| [GRANT](./SQL-Reference/Data-Control-Language/grant.md) | ⚠️ Partial | Authorization logic differs from MySQL — MatrixOne evaluates via its role/account model<br/>User identifier is a bare username scoped to the current account; MySQL uses 'user'@'host' tuples<br/>[MO-only] `GRANT ... ON ACCOUNT *` — account-level privileges have no MySQL counterpart<br/>[MO-only] `GRANT ... ON DATABASE *` — MatrixOne-specific database-level grant target |
-| [REVOKE](./SQL-Reference/Data-Control-Language/revoke.md) | ⚠️ Partial | Recovery logic differs from MySQL — privileges return to the role/account graph<br/>User identifier is a bare username scoped to the current account; MySQL uses 'user'@'host' tuples<br/>[MO-only] `REVOKE ... ON ACCOUNT *` — account-level privileges have no MySQL counterpart<br/>[MO-only] `REVOKE ... ON DATABASE *` — MatrixOne-specific database-level revoke target |
+| [GRANT](./SQL-Reference/Data-Control-Language/grant.md) | ⚠️ Partial | Authorization logic differs from MySQL — MatrixOne evaluates via its role/account model<br/>User identifier is a bare username scoped to the current account; MySQL uses 'user'@'host' tuples<br/>AS user [WITH ROLE ...] clause (MySQL 8.0 privilege restriction) not supported<br/>GRANT privilege ... TO only accepts roles; users receive privileges indirectly through role membership (GRANT role TO user)<br/>WITH ADMIN OPTION for role grants is not supported<br/>[MO-only] `GRANT ... ON ACCOUNT *` — account-level privileges have no MySQL counterpart<br/>[MO-only] `GRANT ... ON DATABASE *` — MatrixOne-specific database-level grant target<br/>[MO-only] GRANT ... ON VIEW db_name.view_name (separate VIEW object_type; MySQL 8.0 only supports TABLE, FUNCTION, PROCEDURE) |
+| [REVOKE](./SQL-Reference/Data-Control-Language/revoke.md) | ⚠️ Partial | Recovery logic differs from MySQL — privileges return to the role/account graph<br/>User identifier is a bare username scoped to the current account; MySQL uses 'user'@'host' tuples<br/>IGNORE UNKNOWN USER clause (MySQL 8.0.30+) not supported<br/>[MO-only] `REVOKE ... ON ACCOUNT *` — account-level privileges have no MySQL counterpart<br/>[MO-only] `REVOKE ... ON DATABASE *` — MatrixOne-specific database-level revoke target<br/>[MO-only] REVOKE ... ON VIEW db_name.view_name (separate VIEW object_type) |
 | [Role Rewrite Rules (ALTER ROLE ... RULE / SHOW RULES)](./SQL-Reference/Data-Control-Language/role-rule.md) | 🟣 MatrixOne-only | — |
 
 ### Data Definition Language (DDL)
@@ -61,18 +62,18 @@ mysql_compat: full
 | [ALTER REINDEX](./SQL-Reference/Data-Definition-Language/alter-reindex.md) | 🟣 MatrixOne-only | [MO-only] ALTER … REINDEX (rebuild vector index) |
 | [ALTER SEQUENCE](./SQL-Reference/Data-Definition-Language/alter-sequence.md) | 🟣 MatrixOne-only | [MO-only] ALTER SEQUENCE |
 | [ALTER STAGE](./SQL-Reference/Data-Definition-Language/alter-stage.md) | 🟣 MatrixOne-only | [MO-only] ALTER STAGE |
-| [ALTER TABLE](./SQL-Reference/Data-Definition-Language/alter-table.md) | ⚠️ Partial | CHANGE [COLUMN], MODIFY [COLUMN], RENAME COLUMN, ADD/DROP PRIMARY KEY, ALTER COLUMN ORDER BY cannot be combined with other clauses in the same ALTER TABLE<br/>Temporary tables cannot be altered<br/>Tables created with CLUSTER BY cannot be altered<br/>ALTER TABLE does not support PARTITION operations |
-| [ALTER VIEW](./SQL-Reference/Data-Definition-Language/alter-view.md) | ⚠️ Partial | Inherits CREATE VIEW limitations: no WITH CHECK OPTION, no DEFINER = user clause |
+| [ALTER TABLE](./SQL-Reference/Data-Definition-Language/alter-table.md) | ⚠️ Partial | Multiple ALTER TABLE operations can be combined in one statement, with limitation: DROP PRIMARY KEY cannot be combined with RENAME COLUMN, CHANGE COLUMN, or DROP COLUMN (causes server panic); DROP PK + ADD COLUMN and DROP PK + MODIFY COLUMN work correctly<br/>Temporary tables cannot be altered<br/>ALTER TABLE does not support PARTITION operations |
+| [ALTER VIEW](./SQL-Reference/Data-Definition-Language/alter-view.md) | ⚠️ Partial | WITH CHECK OPTION is accepted in CREATE VIEW (syntax only, views are read-only) but rejected as a syntax error in ALTER VIEW |
 | [Branch Protect Snapshots](./SQL-Reference/Data-Definition-Language/branch-protect-snapshots.md) | 🟣 MatrixOne-only | — |
 | [CREATE CLONE](./SQL-Reference/Data-Definition-Language/create-clone.md) | 🟣 MatrixOne-only | [MO-only] CREATE TABLE … CLONE db.table [TO ACCOUNT …] |
 | [CREATE CLUSTER TABLE](./SQL-Reference/Data-Definition-Language/create-cluster-table.md) | 🟣 MatrixOne-only | [MO-only] CREATE CLUSTER TABLE |
-| [CREATE DATABASE](./SQL-Reference/Data-Definition-Language/create-database.md) | ⚠️ Partial | Chinese database names not supported<br/>Only utf8mb4 / utf8mb4_bin are supported and cannot be changed<br/>ENCRYPTION clause accepted but inert |
+| [CREATE DATABASE](./SQL-Reference/Data-Definition-Language/create-database.md) | ⚠️ Partial | Only utf8mb4 / utf8mb4_bin are functional; other charsets/collations are syntactically accepted but have no effect<br/>ENCRYPTION clause accepted but inert |
 | [CREATE DYNAMIC TABLE](./SQL-Reference/Data-Definition-Language/create-dynamic-table.md) | 🟣 MatrixOne-only | [MO-only] CREATE DYNAMIC TABLE |
 | [CREATE EXTERNAL TABLE](./SQL-Reference/Data-Definition-Language/create-external-table.md) | 🟣 MatrixOne-only | [MO-only] CREATE EXTERNAL TABLE |
 | [Create Fulltext Index](./SQL-Reference/Data-Definition-Language/create-fulltext-index.md) | ⚠️ Partial | MatrixOne full-text index is implemented on TAE storage with CJK/English optimizations; MySQL implements it on InnoDB/MyISAM with different stopword and parser semantics. |
 | [CREATE FUNCTION...LANGUAGE PYTHON AS](./SQL-Reference/Data-Definition-Language/create-function-python.md) | 🟣 MatrixOne-only | [MO-only] CREATE FUNCTION … LANGUAGE PYTHON AS … |
-| [CREATE FUNCTION...LANGUAGE SQL AS](./SQL-Reference/Data-Definition-Language/create-function-sql.md) | ⚠️ Partial | Only LANGUAGE SQL and LANGUAGE PYTHON are supported; usage differs significantly from MySQL stored functions |
-| [CREATE INDEX](./SQL-Reference/Data-Definition-Language/create-index.md) | ⚠️ Partial | Secondary indexes are syntactically accepted but do not yet provide query speed-up<br/>Foreign keys do not support ON CASCADE DELETE<br/>[MO-only] USING IVFFLAT — vector index for approximate nearest neighbour<br/>[MO-only] USING HNSW — vector index for approximate nearest neighbour<br/>[MO-only] USING MASTER — composite master index |
+| [CREATE FUNCTION...LANGUAGE SQL AS](./SQL-Reference/Data-Definition-Language/create-function-sql.md) | ⚠️ Partial | Only LANGUAGE SQL and LANGUAGE PYTHON are supported; usage differs significantly from MySQL stored functions<br/>CREATE OR REPLACE FUNCTION is supported; MySQL 8.0 does not support OR REPLACE for functions (only IF NOT EXISTS since 8.0.29) |
+| [CREATE INDEX](./SQL-Reference/Data-Definition-Language/create-index.md) | ⚠️ Partial | Secondary indexes are supported and participate in query optimization (as of MO 3.0.12, EXPLAIN shows Index Table Scan for secondary index queries). Does not support index hints (USE INDEX, FORCE INDEX, IGNORE INDEX), function-based indexes, or FULLTEXT index via CREATE INDEX syntax (use CREATE FULLTEXT INDEX instead).<br/>[MO-only] USING IVFFLAT — vector index for approximate nearest neighbour<br/>[MO-only] USING HNSW — vector index for approximate nearest neighbour<br/>[MO-only] USING MASTER — composite master index |
 | [CREATE INDEX USING HNSW](./SQL-Reference/Data-Definition-Language/create-index-hnsw.md) | 🟣 MatrixOne-only | [MO-only] CREATE INDEX … USING HNSW |
 | [CREATE INDEX USING IVFFLAT](./SQL-Reference/Data-Definition-Language/create-index-ivfflat.md) | 🟣 MatrixOne-only | [MO-only] CREATE INDEX … USING IVFFLAT |
 | [CREATE PITR](./SQL-Reference/Data-Definition-Language/create-pitr.md) | 🟣 MatrixOne-only | [MO-only] CREATE PITR … RANGE N {h\|d\|mo\|y} |
@@ -81,28 +82,28 @@ mysql_compat: full
 | [CREATE SNAPSHOT](./SQL-Reference/Data-Definition-Language/create-snapshot.md) | 🟣 MatrixOne-only | [MO-only] CREATE SNAPSHOT FOR {ACCOUNT\|DATABASE\|TABLE\|CLUSTER} |
 | [CREATE SOURCE](./SQL-Reference/Data-Definition-Language/create-source.md) | 🟣 MatrixOne-only | [MO-only] CREATE SOURCE (stream/Kafka connector) |
 | [CREATE STAGE](./SQL-Reference/Data-Definition-Language/create-stage.md) | 🟣 MatrixOne-only | [MO-only] CREATE STAGE (external file-system binding) |
-| [CREATE TABLE](./SQL-Reference/Data-Definition-Language/create-table.md) | ⚠️ Partial | ENGINE= clause in table definition not supported (MatrixOne has a single TAE engine)<br/>Spatial and SET types not supported; MEDIUMINT not supported<br/>BOOL is a native boolean type, not an INT alias as in MySQL<br/>AUTO_INCREMENT step is always 1; @@auto_increment_increment / @@auto_increment_offset are syntactically accepted but inert<br/>Partitioning accepts syntax but only HASH and KEY participate in partition pruning (RANGE/LIST/RANGE COLUMNS/LIST COLUMNS are syntax-only); subpartitioning is syntax-only; ADD/DROP/TRUNCATE PARTITION not supported<br/>[MO-only] CLUSTER BY (col, …) — pre-sort columns to accelerate queries |
+| [CREATE TABLE](./SQL-Reference/Data-Definition-Language/create-table.md) | ⚠️ Partial | ENGINE= clause is syntactically accepted but ignored; MatrixOne uses TAE exclusively<br/>Spatial type names (GEOMETRY, POINT, etc.) are syntactically accepted but non-functional; MEDIUMINT is syntactically accepted but treated as INT<br/>BOOL is a native boolean type, not an INT alias as in MySQL<br/>AUTO_INCREMENT step is always 1; @@auto_increment_increment is syntactically accepted but inert<br/>Partitioning accepts syntax but only HASH and KEY participate in partition pruning (RANGE/LIST/RANGE COLUMNS/LIST COLUMNS are syntax-only); subpartitioning causes an internal error; ADD/DROP/TRUNCATE PARTITION not supported<br/>CHECK constraints are syntactically accepted but not enforced; MySQL 8.0.16+ enforces them<br/>[MO-only] CLUSTER BY (col, …) — pre-sort columns to accelerate queries<br/>[MO-only] START TRANSACTION table option — non-standard table option with no MySQL 8.0 equivalent |
 | [CREATE TABLE ... LIKE](./SQL-Reference/Data-Definition-Language/create-table-like.md) | ✅ Full | — |
 | [CREATE TABLE AS SELECT](./SQL-Reference/Data-Definition-Language/create-table-as-select.md) | ✅ Full | — |
-| [CREATE TASK (SQL Task)](./SQL-Reference/Data-Definition-Language/sql-task.md) | 🟣 MatrixOne-only | — |
-| [CREATE VIEW](./SQL-Reference/Data-Definition-Language/create-view.md) | ⚠️ Partial | WITH CHECK OPTION clause not supported<br/>DEFINER = user clause not supported; SQL SECURITY {DEFINER \| INVOKER} is supported<br/>ALGORITHM = {UNDEFINED \| MERGE \| TEMPTABLE} clause not supported |
+| [CREATE TASK (SQL Task)](./SQL-Reference/Data-Definition-Language/sql-task.md) | 🟣 MatrixOne-only | [MO-only] CREATE TASK / ALTER TASK / DROP TASK / EXECUTE TASK / SHOW TASKS (MO-specific scheduled SQL tasks; MySQL uses CREATE EVENT instead) |
+| [CREATE VIEW](./SQL-Reference/Data-Definition-Language/create-view.md) | ⚠️ Partial | WITH CHECK OPTION is syntactically accepted but not enforced<br/>Views are read-only; MySQL 8.0 supports INSERT/UPDATE/DELETE through views that meet updatability criteria |
 | [CREATE...FROM...PUBLICATION...](./SQL-Reference/Data-Definition-Language/create-subscription.md) | 🟣 MatrixOne-only | [MO-only] CREATE DATABASE … FROM … PUBLICATION … |
 | [DATA BRANCH CREATE](./SQL-Reference/Data-Definition-Language/data-branch-create-en.md) | 🟣 MatrixOne-only | [MO-only] DATA BRANCH CREATE (Git-for-Data) |
 | [DATA BRANCH DELETE](./SQL-Reference/Data-Definition-Language/data-branch-delete-en.md) | 🟣 MatrixOne-only | [MO-only] DATA BRANCH DELETE |
 | [DATA BRANCH DIFF](./SQL-Reference/Data-Definition-Language/data-branch-diff-en.md) | 🟣 MatrixOne-only | [MO-only] DATA BRANCH DIFF |
 | [DATA BRANCH MERGE](./SQL-Reference/Data-Definition-Language/data-branch-merge-en.md) | 🟣 MatrixOne-only | [MO-only] DATA BRANCH MERGE |
-| [DATA BRANCH PICK](./SQL-Reference/Data-Definition-Language/data-branch-pick.md) | 🟣 MatrixOne-only | — |
+| [DATA BRANCH PICK](./SQL-Reference/Data-Definition-Language/data-branch-pick.md) | 🟣 MatrixOne-only | [MO-only] DATA BRANCH PICK (cherry-pick specific rows between branch tables, Git-for-Data feature) |
 | [DROP DATABASE](./SQL-Reference/Data-Definition-Language/drop-database.md) | ✅ Full | — |
-| [DROP FUNCTION](./SQL-Reference/Data-Definition-Language/drop-function.md) | ⚠️ Partial | Drops MatrixOne-style SQL / Python functions, not MySQL stored procedures/functions |
-| [DROP INDEX](./SQL-Reference/Data-Definition-Language/drop-index.md) | ✅ Full | — |
+| [DROP FUNCTION](./SQL-Reference/Data-Definition-Language/drop-function.md) | ⚠️ Partial | Drops MatrixOne-style SQL / Python functions, not MySQL stored procedures/functions<br/>Requires argument type list on DROP (e.g. DROP FUNCTION py_add(int, int)); MySQL 8.0 accepts only the function name |
+| [DROP INDEX](./SQL-Reference/Data-Definition-Language/drop-index.md) | ⚠️ Partial | MO accepts DROP INDEX IF EXISTS syntax (MySQL 8.0 does not), but IF EXISTS does not suppress errors for missing indexes; it returns internal error 20101 instead of a silent skip |
 | [DROP PITR](./SQL-Reference/Data-Definition-Language/drop-pitr.md) | 🟣 MatrixOne-only | [MO-only] DROP PITR |
 | [DROP PUBLICATION](./SQL-Reference/Data-Definition-Language/drop-publication.md) | 🟣 MatrixOne-only | [MO-only] DROP PUBLICATION |
 | [DROP SEQUENCE](./SQL-Reference/Data-Definition-Language/drop-sequence.md) | 🟣 MatrixOne-only | [MO-only] DROP SEQUENCE |
 | [DROP SNAPSHOT](./SQL-Reference/Data-Definition-Language/drop-snapshot.md) | 🟣 MatrixOne-only | [MO-only] DROP SNAPSHOT |
 | [DROP STAGE](./SQL-Reference/Data-Definition-Language/drop-stage.md) | 🟣 MatrixOne-only | [MO-only] DROP STAGE |
 | [DROP TABLE](./SQL-Reference/Data-Definition-Language/drop-table.md) | ✅ Full | — |
-| [DROP VIEW](./SQL-Reference/Data-Definition-Language/drop-view.md) | ✅ Full | — |
-| [Rename Table](./SQL-Reference/Data-Definition-Language/rename-table.md) | ✅ Full | — |
+| [DROP VIEW](./SQL-Reference/Data-Definition-Language/drop-view.md) | ⚠️ Partial | MO does not support dropping multiple views in a single statement; only a single view per DROP VIEW. MySQL 8.0 supports dropping multiple views (e.g., DROP VIEW v1, v2). |
+| [Rename Table](./SQL-Reference/Data-Definition-Language/rename-table.md) | ⚠️ Partial | MO does not support RENAME TABLE across databases; when given cross-database syntax, MO renames the table within its current database instead of raising an error. MySQL 8.0 supports cross-database RENAME TABLE. |
 | [RESTORE ... FROM PITR](./SQL-Reference/Data-Definition-Language/restore-pitr.md) | 🟣 MatrixOne-only | [MO-only] RESTORE … FROM PITR |
 | [RESTORE ... SNAPSHOT](./SQL-Reference/Data-Definition-Language/restore-snapshot.md) | 🟣 MatrixOne-only | [MO-only] RESTORE … FROM SNAPSHOT |
 | [TRUNCATE TABLE](./SQL-Reference/Data-Definition-Language/truncate-table.md) | ✅ Full | — |
@@ -111,92 +112,95 @@ mysql_compat: full
 
 | Statement | MySQL Compat | Notes |
 |---|---|---|
-| [CASE](./SQL-Reference/Data-Manipulation-Language/case.md) | ✅ Full | — |
+| [CASE](./SQL-Reference/Data-Manipulation-Language/case.md) | ✅ Full | This page describes the CASE operator (expression), not the stored-program CASE statement. MatrixOne does not support stored programs, so the stored-program CASE STATEMENT is unavailable; the CASE OPERATOR behaves compatibly. |
 | [CURRENT_ROLE()](./SQL-Reference/Data-Manipulation-Language/information-functions/current_role.md) | ⚠️ Partial | Returns a single active role name; MySQL 8.0 can return multiple comma-separated active roles or 'NONE'. |
-| [DELETE](./SQL-Reference/Data-Manipulation-Language/delete.md) | ⚠️ Partial | LOW_PRIORITY, QUICK, IGNORE modifiers not supported |
-| [INSERT](./SQL-Reference/Data-Manipulation-Language/insert.md) | ⚠️ Partial | Modifiers LOW_PRIORITY / DELAYED / HIGH_PRIORITY not supported |
-| [INSERT ... ON DUPLICATE KEY UPDATE](./SQL-Reference/Data-Manipulation-Language/upsert/insert-on-duplicate.md) | ✅ Full | — |
-| [INSERT IGNORE](./SQL-Reference/Data-Manipulation-Language/upsert/insert-ignore.md) | ⚠️ Partial | LOW_PRIORITY / DELAYED / HIGH_PRIORITY modifiers not supported<br/>Duplicates are silently ignored; MySQL emits a warning for each skipped row.<br/>Does not ignore NULL-into-NOT-NULL, type-conversion, or partition-mismatch errors as MySQL does. |
+| [DELETE](./SQL-Reference/Data-Manipulation-Language/delete.md) | ⚠️ Partial | LOW_PRIORITY, QUICK, IGNORE modifiers are syntactically accepted but have no effect<br/>PARTITION clause not supported |
+| [INSERT](./SQL-Reference/Data-Manipulation-Language/insert.md) | ⚠️ Partial | Modifiers LOW_PRIORITY / DELAYED / HIGH_PRIORITY not supported<br/>PARTITION clause not supported |
+| [INSERT ... ON DUPLICATE KEY UPDATE](./SQL-Reference/Data-Manipulation-Language/upsert/insert-on-duplicate.md) | ⚠️ Partial | ON DUPLICATE KEY UPDATE only triggers on PRIMARY KEY conflicts; UNIQUE index conflicts are detected but result in errors (ERROR 1062 or ERROR 20102) rather than triggering ON DUPLICATE KEY UPDATE |
+| [INSERT IGNORE](./SQL-Reference/Data-Manipulation-Language/upsert/insert-ignore.md) | ⚠️ Partial | LOW_PRIORITY / DELAYED / HIGH_PRIORITY modifiers not supported<br/>Duplicates are silently ignored; MySQL emits a warning for each skipped row.<br/>Does not ignore NULL-into-NOT-NULL, type-conversion, or partition-mismatch errors as MySQL does.<br/>PARTITION clause not supported |
 | [INSERT INTO SELECT](./SQL-Reference/Data-Manipulation-Language/insert-into-select.md) | ✅ Full | — |
 | [LAST_INSERT_ID()](./SQL-Reference/Data-Manipulation-Language/information-functions/last-insert-id.md) | ⚠️ Partial | Multi-row INSERT returns the last inserted auto-increment value; MySQL returns the first inserted value. |
 | [LAST_QUERY_ID](./SQL-Reference/Data-Manipulation-Language/information-functions/last-query-id.md) | 🟣 MatrixOne-only | [MO-only] LAST_QUERY_ID() |
-| [LOAD DATA](./SQL-Reference/Data-Manipulation-Language/load-data-infile.md) | ⚠️ Partial | LOAD DATA LOCAL requires --local-infile on the client<br/>SET clause only accepts columns_name = nullif(expr1, expr2)<br/>JSONLines import uses MatrixOne-specific syntax<br/>Object-storage import (S3/URL) uses MatrixOne-specific syntax |
+| [LOAD DATA](./SQL-Reference/Data-Manipulation-Language/load-data-infile.md) | ⚠️ Partial | SET clause only accepts columns_name = nullif(expr1, expr2)<br/>JSONLines import uses MatrixOne-specific syntax<br/>Object-storage import (S3/URL) uses MatrixOne-specific syntax<br/>LOW_PRIORITY and CONCURRENT modifiers not supported<br/>REPLACE and IGNORE modifiers not supported<br/>[MO-only] PARALLEL clause (controls parallel file loading)<br/>[MO-only] STRICT clause (controls parallel splitting mode) |
 | [LOAD DATA INLINE](./SQL-Reference/Data-Manipulation-Language/load-data-inline.md) | 🟣 MatrixOne-only | [MO-only] LOAD DATA INLINE (stage-sourced import) |
-| [REPLACE](./SQL-Reference/Data-Manipulation-Language/replace.md) | ⚠️ Partial | REPLACE does not support VALUES row_constructor_list<br/>node-sql-parser rejects REPLACE … WHERE (parser bug, not MatrixOne) |
-| [REPLACE](./SQL-Reference/Data-Manipulation-Language/upsert/replace.md) | ⚠️ Partial | REPLACE does not support VALUES row_constructor_list<br/>node-sql-parser rejects REPLACE … WHERE (parser bug, not MatrixOne) |
-| [UPDATE](./SQL-Reference/Data-Manipulation-Language/update.md) | ⚠️ Partial | LOW_PRIORITY and IGNORE modifiers not supported |
-| [UPSERT](./SQL-Reference/Data-Manipulation-Language/upsert/upsert.md) | 🟣 MatrixOne-only | [MO-only] UPSERT (convenience alias over INSERT … ON DUPLICATE KEY UPDATE) |
+| [REPLACE](./SQL-Reference/Data-Manipulation-Language/replace.md) | ⚠️ Partial | node-sql-parser rejects REPLACE … WHERE (parser bug, not MatrixOne)<br/>PARTITION clause not supported<br/>LOW_PRIORITY and DELAYED modifiers not supported<br/>REPLACE only detects conflicts on PRIMARY KEY; secondary UNIQUE index conflicts throw ERROR 1062 (MySQL 8.0 handles both). Constraints section incorrectly states UNIQUE index can also trigger REPLACE; this is wrong per actual MO behavior. |
+| [REPLACE](./SQL-Reference/Data-Manipulation-Language/upsert/replace.md) | ⚠️ Partial | node-sql-parser rejects REPLACE … WHERE (parser bug, not MatrixOne)<br/>PARTITION clause not supported<br/>LOW_PRIORITY and DELAYED modifiers not supported<br/>REPLACE only detects conflicts on PRIMARY KEY; secondary UNIQUE index conflicts throw ERROR 1062 (MySQL 8.0 handles both). Constraints section incorrectly states UNIQUE index can also trigger REPLACE; this is wrong per actual MO behavior. |
+| [UPDATE](./SQL-Reference/Data-Manipulation-Language/update.md) | ⚠️ Partial | LOW_PRIORITY and IGNORE modifiers are syntactically accepted but have no effect<br/>PARTITION clause not supported |
+| [UPSERT](./SQL-Reference/Data-Manipulation-Language/upsert/upsert.md) | ⚠️ Partial | INSERT IGNORE does not suppress NOT NULL or type-conversion errors (MySQL 8.0 does)<br/>INSERT ON DUPLICATE KEY UPDATE only triggers on PRIMARY KEY conflicts; UNIQUE index conflicts are detected but result in errors (ERROR 1062 or ERROR 20102) rather than triggering ON DUPLICATE KEY UPDATE<br/>REPLACE does not support REPLACE ... WHERE (parser bug) |
 
 ### Data Query Language (DQL)
 
 | Statement | MySQL Compat | Notes |
 |---|---|---|
 | [BY RANK WITH OPTION](./SQL-Reference/Data-Query-Language/by-rank-with-option.md) | 🟣 MatrixOne-only | [MO-only] BY RANK WITH OPTION (IVF vector ranking) |
-| [Combining Queries (UNION, INTERSECT, MINUS)](./SQL-Reference/Data-Query-Language/union-intersect-minus-overview.md) | 🟣 MatrixOne-only | [MO-only] MINUS, INTERSECT set operators |
+| [Combining Queries (UNION, INTERSECT, MINUS)](./SQL-Reference/Data-Query-Language/union-intersect-minus-overview.md) | ⚠️ Partial | MINUS keyword is MO-specific; MySQL 8.0.31+ uses EXCEPT for the same set-difference semantics. MINUS ALL is not yet implemented in MO while MySQL 8.0.31+ supports EXCEPT ALL.<br/>INTERSECT was added in MySQL 8.0.31; both MO and MySQL support INTERSECT and INTERSECT ALL with matching semantics.<br/>UNION is standard across both, but MO's type coercion in UNION columns is stricter (errors on incompatible types where MySQL silently coerces).<br/>[MO-only] MINUS keyword (MO-specific syntax; MySQL 8.0.31+ offers equivalent EXCEPT) |
 | [Comparisons Using Subqueries](./SQL-Reference/Data-Query-Language/subqueries/comparisons-using-subqueries.md) | ✅ Full | — |
 | [CROSS APPLY](./SQL-Reference/Data-Query-Language/apply/cross-apply.md) | 🟣 MatrixOne-only | [MO-only] CROSS APPLY (SQL Server-style, not in MySQL) |
 | [CROSS JOIN](./SQL-Reference/Data-Query-Language/join/cross-join.md) | ✅ Full | — |
-| [Derived Tables](./SQL-Reference/Data-Query-Language/subqueries/derived-tables.md) | ✅ Full | — |
-| [FULL JOIN](./SQL-Reference/Data-Query-Language/join/full-join.md) | 🟣 MatrixOne-only | [MO-only] FULL JOIN / FULL OUTER JOIN is not supported in MySQL 8.0 (users must emulate it with LEFT JOIN UNION RIGHT JOIN). |
+| [Derived Tables](./SQL-Reference/Data-Query-Language/subqueries/derived-tables.md) | ⚠️ Partial | LATERAL derived tables are not supported in MO (MySQL 8.0.14+ supports LATERAL for correlated subqueries in FROM clause) |
+| [FULL JOIN](./SQL-Reference/Data-Query-Language/join/full-join.md) | ❌ None | FULL JOIN with ON clause produces different errors on MO (missing FROM-clause entry) vs MySQL 8.0 (Unknown column in ON clause). FULL JOIN with USING returns INNER JOIN results on both (neither returns unmatched rows). FULL OUTER JOIN produces a syntax error on both. MySQL 8.0 does not natively support either FULL JOIN or FULL OUTER JOIN. |
 | [INNER JOIN](./SQL-Reference/Data-Query-Language/join/inner-join.md) | ✅ Full | — |
-| [INTERSECT](./SQL-Reference/Data-Query-Language/intersect.md) | 🟣 MatrixOne-only | [MO-only] INTERSECT set operator is not available in MySQL 8.0. |
-| [JOIN](./SQL-Reference/Data-Query-Language/join/join.md) | ✅ Full | — |
+| [INTERSECT](./SQL-Reference/Data-Query-Language/intersect.md) | ⚠️ Partial | INTERSECT was added in MySQL 8.0.31; MO INTERSECT and INTERSECT ALL semantics match MySQL 8.0 (both return identical results for common test cases including duplicate handling) |
+| [JOIN](./SQL-Reference/Data-Query-Language/join/join.md) | ⚠️ Partial | FULL JOIN and FULL OUTER JOIN are not fully supported (FULL JOIN with ON produces errors, FULL JOIN with USING returns INNER JOIN results, FULL OUTER JOIN is a syntax error); MySQL 8.0 also does not support FULL JOIN/OUTER JOIN natively |
 | [LEFT JOIN](./SQL-Reference/Data-Query-Language/join/left-join.md) | ✅ Full | — |
-| [MINUS](./SQL-Reference/Data-Query-Language/minus.md) | 🟣 MatrixOne-only | [MO-only] MINUS (set-difference query, not in MySQL) |
+| [MINUS](./SQL-Reference/Data-Query-Language/minus.md) | 🟣 MatrixOne-only | MINUS keyword is MO-specific; MySQL 8.0.31+ uses EXCEPT for the same set-difference semantics (MINUS is not a recognized keyword in MySQL)<br/>MINUS ALL is not yet implemented in MO; MySQL 8.0.31+ supports EXCEPT ALL with full duplicate-preserving semantics<br/>[MO-only] MINUS keyword (MO's set-difference operator; MySQL 8.0.31+ offers equivalent functionality via EXCEPT) |
 | [NATURAL JOIN](./SQL-Reference/Data-Query-Language/join/natural-join.md) | ✅ Full | — |
 | [OUTER APPLY](./SQL-Reference/Data-Query-Language/apply/outer-apply.md) | 🟣 MatrixOne-only | [MO-only] OUTER APPLY (SQL Server-style, not in MySQL) |
-| [OUTER JOIN](./SQL-Reference/Data-Query-Language/join/outer-join.md) | ⚠️ Partial | Overview page that includes FULL OUTER JOIN, which MySQL 8.0 does not support. |
+| [OUTER JOIN](./SQL-Reference/Data-Query-Language/join/outer-join.md) | ⚠️ Partial | Overview page that includes FULL OUTER JOIN; neither MO nor MySQL 8.0 natively support FULL OUTER JOIN (MO produces syntax error, same as MySQL) |
 | [RIGHT JOIN](./SQL-Reference/Data-Query-Language/join/right-join.md) | ✅ Full | — |
-| [SELECT](./SQL-Reference/Data-Query-Language/select.md) | ⚠️ Partial | SELECT … FOR UPDATE only supports single-table queries<br/>SELECT INTO OUTFILE is only partially supported<br/>Unqualified SELECT ... FROM DUAL requires explicit database name (SELECT ... FROM dbname.DUAL)<br/>[MO-only] { AS OF TIMESTAMP 'YYYY-MM-DD HH:MM:SS' } — time-travel query against snapshot/PITR<br/>[MO-only] ORDER BY ... NULLS { FIRST \| LAST } — PostgreSQL-style NULL ordering not available in MySQL |
+| [SELECT](./SQL-Reference/Data-Query-Language/select.md) | ⚠️ Partial | SELECT … FOR UPDATE only supports single-table queries<br/>SELECT INTO OUTFILE is only partially supported<br/>AS OF TIMESTAMP time-travel queries require PITR/snapshot to be enabled on the database; without PITR the syntax produces an error<br/>SELECT ... FOR SHARE is not supported<br/>FOR UPDATE NOWAIT and SKIP LOCKED modifiers are not supported<br/>GROUP BY ... WITH ROLLUP row ordering differs: MO places rollup summary rows at the top of the result set, while MySQL 8.0 places them at the bottom (standard MySQL grouping order)<br/>[MO-only] { AS OF TIMESTAMP 'YYYY-MM-DD HH:MM:SS' } — time-travel query against enabled snapshot/PITR<br/>[MO-only] ORDER BY ... NULLS { FIRST \| LAST } — PostgreSQL-style NULL ordering not available in MySQL |
 | [Subqueries with ALL](./SQL-Reference/Data-Query-Language/subqueries/subquery-with-all.md) | ✅ Full | — |
 | [Subqueries with ANY or SOME](./SQL-Reference/Data-Query-Language/subqueries/subquery-with-any-some.md) | ✅ Full | — |
 | [Subqueries with EXISTS or NOT EXISTS](./SQL-Reference/Data-Query-Language/subqueries/subquery-with-exists.md) | ✅ Full | — |
-| [Subqueries with IN](./SQL-Reference/Data-Query-Language/subqueries/subquery-with-in.md) | ⚠️ Partial | Multi-level correlated subqueries inside IN() are not supported |
-| [SUBQUERY](./SQL-Reference/Data-Query-Language/subqueries/subquery.md) | ⚠️ Partial | Multi-level correlated subqueries inside IN() are not supported |
-| [UNION](./SQL-Reference/Data-Query-Language/union.md) | ✅ Full | — |
-| [WITH (Common Table Expressions)](./SQL-Reference/Data-Query-Language/with-cte.md) | ✅ Full | — |
+| [Subqueries with IN](./SQL-Reference/Data-Query-Language/subqueries/subquery-with-in.md) | ✅ Full | — |
+| [SUBQUERY](./SQL-Reference/Data-Query-Language/subqueries/subquery.md) | ⚠️ Partial | Multi-column scalar subquery comparisons (e.g., WHERE (a,b) = (SELECT ...)) are not supported; use multi-column IN instead |
+| [UNION](./SQL-Reference/Data-Query-Language/union.md) | ⚠️ Partial | UNION type coercion is strict: MO errors on incompatible types in UNION columns (e.g., INT vs VARCHAR), while MySQL 8.0 silently coerces (e.g., varchar to int converts to 0)<br/>UNION ALL type coercion is similarly strict compared to MySQL 8.0's lenient coercion |
+| [WITH (Common Table Expressions)](./SQL-Reference/Data-Query-Language/with-cte.md) | ⚠️ Partial | Outer joins (LEFT JOIN, RIGHT JOIN, OUTER JOIN) are not allowed in recursive CTE members; MySQL 8.0 permits them except when the recursive CTE is on the right side of a LEFT JOIN (MySQL allows LEFT JOIN with CTE on the left side; MO rejects all outer joins in recursive CTEs regardless of position) |
 
 ### Other
 
 | Statement | MySQL Compat | Notes |
 |---|---|---|
-| [DEALLOCATE PREPARE](./SQL-Reference/Other/Prepared-Statements/deallocate.md) | ✅ Full | — |
+| [DEALLOCATE PREPARE](./SQL-Reference/Other/Prepared-Statements/deallocate.md) | ⚠️ Partial | DEALLOCATE PREPARE on a non-existent statement silently succeeds; MySQL returns ERROR 1243 (Unknown prepared statement handler). |
+| [DESCRIBE / DESC](./SQL-Reference/Other/describe.md) | ⚠️ Partial | DESCRIBE/DESC output includes an extra `Comment` column (7 columns total vs MySQL's 6).<br/>Type names are displayed in uppercase with display widths (e.g., `INT(32)`, `FLOAT(0)`, `TIMESTAMP(0)`) instead of MySQL's lowercase without widths (e.g., `int`, `float`, `timestamp`).<br/>Column name filter (`DESC tbl_name col_name`) is non-functional; all columns are returned.<br/>Wild pattern (`DESC tbl_name 'pattern'`) not supported; produces syntax error.<br/>For TIMESTAMP columns with DEFAULT CURRENT_TIMESTAMP, MO does not show `DEFAULT_GENERATED` in the Extra column as MySQL does. |
 | [EXECUTE](./SQL-Reference/Other/Prepared-Statements/execute.md) | ✅ Full | — |
-| [EXPLAIN](./SQL-Reference/Other/Explain/explain.md) | ⚠️ Partial | Output format mirrors PostgreSQL, not MySQL<br/>JSON output not supported |
-| [EXPLAIN Output Format](./SQL-Reference/Other/Explain/explain-workflow.md) | ⚠️ Partial | Output format mirrors PostgreSQL; JSON output not supported |
+| [EXPLAIN](./SQL-Reference/Other/Explain/explain.md) | ⚠️ Partial | Output format is a single QUERY PLAN column with tree-structured text (PostgreSQL-style); MySQL uses a multi-column tabular format with id, select_type, table, partitions, type, possible_keys, key, key_len, ref, rows, filtered, Extra<br/>JSON output (FORMAT=JSON) not supported; MO returns syntax error<br/>FORMAT=TREE and FORMAT=TRADITIONAL not supported; FORMAT=TEXT bare keyword also errors; only bare keyword forms (EXPLAIN, EXPLAIN ANALYZE, EXPLAIN VERBOSE) work<br/>EXPLAIN FOR CONNECTION not supported (returns internal error)<br/>EXPLAIN (ANALYZE TRUE/FALSE) and EXPLAIN (VERBOSE TRUE/FALSE) parenthesized boolean syntax WORKS in MO 3.0.12, contrary to doc claims; only parenthesized FORMAT syntax is unsupported |
+| [EXPLAIN Output Format](./SQL-Reference/Other/Explain/explain-workflow.md) | ⚠️ Partial | Output is a single QUERY PLAN column with tree-structured text; MySQL uses multi-column tabular EXPLAIN format<br/>JSON output not supported<br/>Node types (Sink, Sink Scan, PreInsert, Fuzzy Filter, etc.) are MO-specific and have no MySQL equivalent |
 | [EXPLAIN PREPARED](./SQL-Reference/Other/Explain/explain-prepared.md) | 🟣 MatrixOne-only | [MO-only] EXPLAIN FORCE EXECUTE stmt_name [USING @var] is a MatrixOne extension; MySQL explains prepared statements through EXPLAIN FOR CONNECTION. |
-| [Get information with EXPLAIN ANALYZE](./SQL-Reference/Other/Explain/explain-analyze.md) | ⚠️ Partial | Output format mirrors PostgreSQL; JSON output not supported |
+| [Get information with EXPLAIN ANALYZE](./SQL-Reference/Other/Explain/explain-analyze.md) | ⚠️ Partial | Output format mirrors PostgreSQL (QUERY PLAN tree with Analyze sub-lines showing timeConsumed, waitTime, inputRows, outputRows, InputSize, OutputSize, MemorySize); MySQL 8.0 EXPLAIN ANALYZE uses TREE format with cost estimation and actual time in a different structure<br/>JSON output not supported<br/>MO EXPLAIN ANALYZE produces one output row per plan tree line; MySQL produces a single row with the full plan |
 | [KILL](./SQL-Reference/Other/kill.md) | ✅ Full | — |
-| [PREPARE](./SQL-Reference/Other/Prepared-Statements/prepare.md) | ⚠️ Partial | MatrixOne cannot PREPARE SET statements |
+| [PREPARE](./SQL-Reference/Other/Prepared-Statements/prepare.md) | ⚠️ Partial | MatrixOne cannot PREPARE SET, DO, or other TCL/DCL statements<br/>Repreparation on parameter type change may throw a cast error instead of silently converting the value (e.g., passing a string to an integer parameter). |
 | [SET ROLE](./SQL-Reference/Other/Set/set-role.md) | ⚠️ Partial | Accepts a single role name only; MySQL 8.0 also supports NONE, DEFAULT, ALL, ALL EXCEPT role_list, and role lists.<br/>[MO-only] SET SECONDARY ROLE {NONE \| ALL} — MatrixOne-only primary/secondary role model. |
 | [SHOW ACCOUNTS](./SQL-Reference/Other/SHOW-Statements/show-account.md) | 🟣 MatrixOne-only | [MO-only] SHOW ACCOUNTS |
-| [SHOW COLLATION](./SQL-Reference/Other/SHOW-Statements/show-collation.md) | ⚠️ Partial | Only utf8mb4_bin is effective; other collations appear but are inert |
-| [SHOW COLUMNS](./SQL-Reference/Other/SHOW-Statements/show-columns.md) | ✅ Full | — |
+| [SHOW COLLATION](./SQL-Reference/Other/SHOW-Statements/show-collation.md) | ⚠️ Partial | Only utf8mb4_bin is effective; other collations appear but are inert<br/>MO 3.0.12 returns 11 collations (with `Default` and `Pad_attribute` columns); older doc examples show only 1 row with 5 columns<br/>Output columns (Collation, Charset, Id, Default, Compiled, Sortlen, Pad_attribute) differ slightly from MySQL which also includes Pad_attribute |
+| [SHOW COLUMNS](./SQL-Reference/Other/SHOW-Statements/show-columns.md) | ⚠️ Partial | MO SHOW COLUMNS (without FULL) already includes the `Comment` column; MySQL only shows Comment with FULL<br/>MO SHOW FULL COLUMNS returns Collation and Privileges columns but Collation is always NULL<br/>MO accepts EXTENDED keyword (SHOW EXTENDED COLUMNS) and FIELDS synonym (SHOW FIELDS), both returning same columns as SHOW COLUMNS<br/>MO Type column includes display width (e.g. INT(32)) while MySQL shows just int |
+| [SHOW CREATE DATABASE](./SQL-Reference/Other/SHOW-Statements/show-create-database.md) | ⚠️ Partial | Output omits CHARACTER SET, COLLATE, and ENCRYPTION clauses present in MySQL 8.0 SHOW CREATE DATABASE output |
 | [SHOW CREATE PUBLICATION](./SQL-Reference/Other/SHOW-Statements/show-create-publication.md) | 🟣 MatrixOne-only | [MO-only] SHOW CREATE PUBLICATION |
-| [SHOW CREATE TABLE](./SQL-Reference/Other/SHOW-Statements/show-create-table.md) | ⚠️ Partial | Output reflects MatrixOne-specific extensions (CLUSTER BY, USING IVFFLAT/HNSW, etc.) |
-| [SHOW CREATE VIEW](./SQL-Reference/Other/SHOW-Statements/show-create-view.md) | ⚠️ Partial | DEFINER = user clause absent from output; SQL SECURITY {DEFINER\|INVOKER} is emitted |
+| [SHOW CREATE TABLE](./SQL-Reference/Other/SHOW-Statements/show-create-table.md) | ⚠️ Partial | Output reflects MatrixOne-specific extensions (CLUSTER BY, USING IVFFLAT/HNSW, etc.)<br/>MO output omits ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci appended by MySQL |
+| [SHOW CREATE VIEW](./SQL-Reference/Other/SHOW-Statements/show-create-view.md) | ⚠️ Partial | DEFINER = user clause absent from output; SQL SECURITY {DEFINER\|INVOKER} is emitted<br/>MO output lacks ALGORITHM=UNDEFINED clause that MySQL always includes<br/>MO does not fully qualify column references (MySQL outputs db.table.col AS alias)<br/>MO uses unquoted identifiers; MySQL backtick-quotes database, table, and column names<br/>The rendered Create View output shows `CREATE SQL SECURITY DEFINER VIEW` (not `CREATE ALGORITHM=UNDEFINED DEFINER=user SQL SECURITY DEFINER VIEW` as MySQL does) |
 | [SHOW DATABASES](./SQL-Reference/Other/SHOW-Statements/show-databases.md) | ✅ Full | — |
-| [SHOW FUNCTION STATUS](./SQL-Reference/Other/SHOW-Statements/show-function-status.md) | ⚠️ Partial | Lists MatrixOne SQL/Python functions, not MySQL stored routines |
-| [SHOW GRANTS](./SQL-Reference/Other/SHOW-Statements/show-grants.md) | ⚠️ Partial | Results reflect MatrixOne role/account graph and differ from MySQL significantly |
-| [SHOW INDEX](./SQL-Reference/Other/SHOW-Statements/show-index.md) | ⚠️ Partial | Reflects MatrixOne index model — secondary index rows appear but may not accelerate queries |
+| [SHOW FUNCTION STATUS](./SQL-Reference/Other/SHOW-Statements/show-function-status.md) | ⚠️ Partial | Lists MatrixOne SQL/Python functions; MySQL shows stored routines AND built-in sys schema functions (e.g. extract_schema_from_file_name, format_bytes)<br/>MO only shows user-defined functions; MySQL shows all functions including built-in ones |
+| [SHOW GRANTS](./SQL-Reference/Other/SHOW-Statements/show-grants.md) | ⚠️ Partial | Grant syntax output is completely different: MO uses MO-specific format (GRANT create account ON account, GRANT table all ON table) instead of MySQL standard format (GRANT SELECT, INSERT, UPDATE, DELETE ON *.*)<br/>MO output includes backtick-quoted user@host inside grant statements; MySQL uses quoted user@host format with TO clause<br/>USING role_list clause not supported<br/>MO does not support SHOW GRANTS FOR CURRENT_USER (or CURRENT_USER()) as a shorthand for the current user |
+| [SHOW INDEX](./SQL-Reference/Other/SHOW-Statements/show-index.md) | ⚠️ Partial | Reflects MatrixOne index model — secondary index rows appear but may not accelerate queries<br/>Index_type may be empty (MySQL typically shows BTREE)<br/>Index_comment column is present (MySQL 8.0 also has Index_comment; difference is minor)<br/>Index_params column is present (MySQL does not have this column)<br/>Expression column shows the column name for non-functional key parts; MySQL shows NULL for non-functional key parts<br/>MO SHOW INDEX returns 16 columns vs MySQL 15 columns (MO adds Index_params, lacks the extra Collation behavior) |
 | [SHOW PITR](./SQL-Reference/Other/SHOW-Statements/show-pitrs.md) | 🟣 MatrixOne-only | [MO-only] SHOW PITR |
-| [SHOW PROCESSLIST](./SQL-Reference/Other/SHOW-Statements/show-processlist.md) | ⚠️ Partial | Output differs significantly from MySQL due to different implementation |
+| [SHOW PROCESSLIST](./SQL-Reference/Other/SHOW-Statements/show-processlist.md) | ⚠️ Partial | MO returns 19 columns (node_id, conn_id, session_id, account, user, host, db, session_start, command, info, txn_id, statement_id, statement_type, query_type, sql_source_type, query_start, client_host, role, proxy_host) vs MySQL 8 columns (Id, User, Host, db, Command, Time, State, Info)<br/>MO column names differ completely: conn_id vs Id, session_start vs Time, no State column, MO adds txn_id/statement_id/statement_type/query_type/sql_source_type/query_start/client_host/role/proxy_host<br/>SHOW FULL PROCESSLIST is accepted by MO but returns same columns as SHOW PROCESSLIST (no behavioral difference) |
 | [SHOW PUBLICATIONS](./SQL-Reference/Other/SHOW-Statements/show-publications.md) | 🟣 MatrixOne-only | [MO-only] SHOW PUBLICATIONS |
 | [SHOW ROLES](./SQL-Reference/Other/SHOW-Statements/show-roles.md) | 🟣 MatrixOne-only | [MO-only] SHOW ROLES |
 | [SHOW SEQUENCES](./SQL-Reference/Other/SHOW-Statements/show-sequences.md) | 🟣 MatrixOne-only | [MO-only] SHOW SEQUENCES |
 | [SHOW STAGES](./SQL-Reference/Other/SHOW-Statements/show-stage.md) | 🟣 MatrixOne-only | [MO-only] SHOW STAGES |
 | [SHOW SUBSCRIPTIONS](./SQL-Reference/Other/SHOW-Statements/show-subscriptions.md) | 🟣 MatrixOne-only | [MO-only] SHOW SUBSCRIPTIONS |
-| [SHOW TABLES](./SQL-Reference/Other/SHOW-Statements/show-tables.md) | ⚠️ Partial | Result column is named 'name' rather than MySQL's 'Tables_in_<dbname>'. |
-| [SHOW VARIABLES](./SQL-Reference/Other/SHOW-Statements/show-variables.md) | ⚠️ Partial | System variables are mostly syntactic stubs; actual behaviour differs from MySQL |
+| [SHOW TABLE STATUS](./SQL-Reference/Other/SHOW-Statements/show-table-status.md) | ⚠️ Partial | Result columns differ from MySQL: MO has 19 cols (adds Role_id, Role_name; omits Version); MySQL has 18 cols (includes Version; no Role_id/Role_name)<br/>Engine column always shows Tae instead of InnoDB<br/>MO's Auto_increment defaults to 0 (MySQL shows NULL for tables without auto-increment)<br/>MO shows views in SHOW TABLE STATUS with Engine=NULL and Comment=VIEW (same as MySQL behavior) |
+| [SHOW TABLES](./SQL-Reference/Other/SHOW-Statements/show-tables.md) | ⚠️ Partial | Output column header uses lowercase database name (Tables_in_<db> vs MySQL's Tables_in_<DB>)<br/>MO does not display a parenthesized LIKE pattern in the column header unlike MySQL |
+| [SHOW VARIABLES](./SQL-Reference/Other/SHOW-Statements/show-variables.md) | ⚠️ Partial | System variables are mostly syntactic stubs; actual behaviour differs from MySQL<br/>GLOBAL and SESSION scope modifiers are syntactically accepted for both SET and SHOW; SHOW GLOBAL vs SHOW SESSION return different values when SESSION has been overridden, same as MySQL<br/>MO has a completely different set of variable names (e.g. testbotchvar_nodyn, testbothvar_dyn) alongside MySQL-compatible ones (autocommit, sql_mode)<br/>Variable values use lowercase ('on'/'off') while MySQL uses uppercase ('ON'/'OFF') |
 | [USE](./SQL-Reference/Other/use-database.md) | ✅ Full | — |
 
 ## Functions
 
 | Status | Count |
 |---|---|
-| ✅ Full | 111 |
-| ⚠️ Partial | 17 |
-| 🟣 MatrixOne-only | 36 |
+| ✅ Full | 103 |
+| ⚠️ Partial | 26 |
+| 🟣 MatrixOne-only | 35 |
 | **Total** | **164** |
 
 ### Functions
@@ -210,7 +214,7 @@ mysql_compat: full
 | Function | MySQL Compat | Notes |
 |---|---|---|
 | [ANY_VALUE](./Functions-and-Operators/Aggregate-Functions/any-value.md) | ✅ Full | — |
-| [AVG](./Functions-and-Operators/Aggregate-Functions/avg.md) | ✅ Full | — |
+| [AVG](./Functions-and-Operators/Aggregate-Functions/avg.md) | ⚠️ Partial | AVG() returns DOUBLE for all input types (MySQL returns DECIMAL for exact-value types) |
 | [BIT_AND](./Functions-and-Operators/Aggregate-Functions/bit_and.md) | ✅ Full | — |
 | [BIT_OR](./Functions-and-Operators/Aggregate-Functions/bit_or.md) | ✅ Full | — |
 | [BIT_XOR](./Functions-and-Operators/Aggregate-Functions/bit_xor.md) | ✅ Full | — |
@@ -221,7 +225,7 @@ mysql_compat: full
 | [MEDIAN()](./Functions-and-Operators/Aggregate-Functions/median.md) | 🟣 MatrixOne-only | [MO-only] MEDIAN aggregate is a MatrixOne-specific aggregate (no native MySQL equivalent). |
 | [MIN](./Functions-and-Operators/Aggregate-Functions/min.md) | ✅ Full | — |
 | [STDDEV_POP](./Functions-and-Operators/Aggregate-Functions/stddev_pop.md) | ✅ Full | — |
-| [SUM](./Functions-and-Operators/Aggregate-Functions/sum.md) | ✅ Full | — |
+| [SUM](./Functions-and-Operators/Aggregate-Functions/sum.md) | ⚠️ Partial | SUM() returns the input integer type rather than DECIMAL for exact-value arguments (MySQL returns DECIMAL) |
 | [VAR_POP](./Functions-and-Operators/Aggregate-Functions/var_pop.md) | ✅ Full | — |
 | [VARIANCE](./Functions-and-Operators/Aggregate-Functions/variance.md) | ✅ Full | — |
 
@@ -240,7 +244,7 @@ mysql_compat: full
 | [DATE()](./Functions-and-Operators/Datetime/date.md) | ⚠️ Partial | Date literals accept only 'yyyy-mm-dd' and 'yyyymmdd' formats; MySQL accepts wider variants (yy-mm-dd, yy/mm/dd, yymmdd, etc.). |
 | [DATEDIFF()](./Functions-and-Operators/Datetime/datediff.md) | ✅ Full | — |
 | [DAY()](./Functions-and-Operators/Datetime/day.md) | ✅ Full | — |
-| [DAYOFYEAR()](./Functions-and-Operators/Datetime/dayofyear.md) | ⚠️ Partial | Date literals accept only 'yyyy-mm-dd' and 'yyyymmdd' formats; MySQL accepts wider variants. |
+| [DAYOFYEAR()](./Functions-and-Operators/Datetime/dayofyear.md) | ✅ Full | — |
 | [EXTRACT()](./Functions-and-Operators/Datetime/extract.md) | ⚠️ Partial | Date literals accept only 'yyyy-mm-dd' and 'yyyymmdd' formats; MySQL accepts wider variants. |
 | [FROM_UNIXTIME()](./Functions-and-Operators/Datetime/from-unixtime.md) | ⚠️ Partial | Date literals accept only 'yyyy-mm-dd' and 'yyyymmdd' formats; MySQL accepts wider variants. |
 | [GET_FORMAT()](./Functions-and-Operators/Datetime/get-format.md) | ✅ Full | — |
@@ -254,7 +258,7 @@ mysql_compat: full
 | [SYSDATE()](./Functions-and-Operators/Datetime/sysdate.md) | ✅ Full | — |
 | [TIME()](./Functions-and-Operators/Datetime/time.md) | ✅ Full | — |
 | [TIMEDIFF()](./Functions-and-Operators/Datetime/timediff.md) | ✅ Full | — |
-| [TIMESTAMP()](./Functions-and-Operators/Datetime/timestamp.md) | ⚠️ Partial | MatrixOne TIMESTAMP range is '0001-01-01'–'9999-12-31' vs MySQL '1970-01-01'–'2038-01-19' (compat doc: Data Types). |
+| [TIMESTAMP()](./Functions-and-Operators/Datetime/timestamp.md) | ⚠️ Partial | MatrixOne TIMESTAMP range is '0001-01-01'–'9999-12-31' vs MySQL '1970-01-01'–'2038-01-19' (compat doc: Data Types).<br/>Two-argument form TIMESTAMP(expr1, expr2) is not supported; MO only supports single-argument TIMESTAMP(expr) |
 | [TIMESTAMPADD()](./Functions-and-Operators/Datetime/timestampadd.md) | ✅ Full | — |
 | [TIMESTAMPDIFF()](./Functions-and-Operators/Datetime/timestampdiff.md) | ✅ Full | — |
 | [TO_DATE()](./Functions-and-Operators/Datetime/to-date.md) | 🟣 MatrixOne-only | [MO-only] TO_DATE is a MatrixOne alias for MySQL STR_TO_DATE (compat doc: Date and Time Functions). MySQL's own TO_DATE does not exist. |
@@ -274,7 +278,7 @@ mysql_compat: full
 | [JQ()](./Functions-and-Operators/Json/jq.md) | 🟣 MatrixOne-only | [MO-only] MatrixOne integration of the jq JSON query language; no MySQL equivalent. |
 | [JSON Arrow Operators -> and ->>](./Functions-and-Operators/Json/json-arrow.md) | ✅ Full | — |
 | [JSON_EXTRACT_FLOAT64()](./Functions-and-Operators/Json/json_extract_float64.md) | 🟣 MatrixOne-only | [MO-only] MatrixOne convenience wrapper returning FLOAT64 directly. |
-| [JSON_EXTRACT_FLOAT64()](./Functions-and-Operators/Json/json_extract_string.md) | 🟣 MatrixOne-only | [MO-only] MatrixOne convenience wrapper returning a string result directly. |
+| [JSON_EXTRACT_STRING()](./Functions-and-Operators/Json/json_extract_string.md) | 🟣 MatrixOne-only | [MO-only] MatrixOne convenience wrapper returning a string result directly. |
 | [JSON_EXTRACT()](./Functions-and-Operators/Json/json_extract.md) | ✅ Full | — |
 | [JSON_QUOTE()](./Functions-and-Operators/Json/json_quote.md) | ✅ Full | — |
 | [JSON_ROW()](./Functions-and-Operators/Json/json_row.md) | 🟣 MatrixOne-only | [MO-only] MatrixOne-only; no MySQL equivalent. |
@@ -295,14 +299,14 @@ mysql_compat: full
 | [COT()](./Functions-and-Operators/Mathematical/cot.md) | ✅ Full | — |
 | [CRC32()](./Functions-and-Operators/Mathematical/crc32.md) | ✅ Full | — |
 | [EXP()](./Functions-and-Operators/Mathematical/exp.md) | ✅ Full | — |
-| [FLOOR()](./Functions-and-Operators/Mathematical/floor.md) | ✅ Full | — |
+| [FLOOR()](./Functions-and-Operators/Mathematical/floor.md) | ⚠️ Partial | MatrixOne supports an optional second decimals argument (FLOOR(number, decimals)) to specify decimal places; MySQL 8.0 only supports the single-argument form FLOOR(X)<br/>[MO-only] Two-argument form FLOOR(number, decimals) to specify decimal places |
 | [LN()](./Functions-and-Operators/Mathematical/ln.md) | ✅ Full | — |
 | [LOG()](./Functions-and-Operators/Mathematical/log.md) | ✅ Full | — |
 | [LOG10()](./Functions-and-Operators/Mathematical/log10.md) | ✅ Full | — |
 | [LOG2()](./Functions-and-Operators/Mathematical/log2.md) | ✅ Full | — |
 | [PI()](./Functions-and-Operators/Mathematical/pi.md) | ✅ Full | — |
 | [POWER()](./Functions-and-Operators/Mathematical/power.md) | ✅ Full | — |
-| [RAND()](./Functions-and-Operators/Mathematical/rand.md) | ✅ Full | — |
+| [RAND()](./Functions-and-Operators/Mathematical/rand.md) | ⚠️ Partial | RAND(seed) is not supported; calling RAND(N) with an integer argument produces ERROR 20203 |
 | [ROUND()](./Functions-and-Operators/Mathematical/round.md) | ✅ Full | — |
 | [SIN()](./Functions-and-Operators/Mathematical/sin.md) | ✅ Full | — |
 | [SINH()](./Functions-and-Operators/Mathematical/sinh.md) | 🟣 MatrixOne-only | [MO-only] MySQL 8.0 has no hyperbolic trigonometric functions; SINH() is a MatrixOne extension. |
@@ -312,12 +316,12 @@ mysql_compat: full
 
 | Function | MySQL Compat | Notes |
 |---|---|---|
-| [LOAD_FILE()](./Functions-and-Operators/Other/load_file.md) | 🟣 MatrixOne-only | [MO-only] LOAD_FILE() takes a DATALINK value (file:// or stage:// URL) rather than MySQL's plain filesystem path argument; semantics differ. |
+| [LOAD_FILE()](./Functions-and-Operators/Other/load_file.md) | ⚠️ Partial | LOAD_FILE() takes a DATALINK value (file:// or stage:// URL) rather than MySQL's plain filesystem path argument |
 | [SAMPLE Sampling Function](./Functions-and-Operators/Other/sample.md) | 🟣 MatrixOne-only | [MO-only] SAMPLE() is a MatrixOne sampling operator; no MySQL equivalent. |
 | [SAVE_FILE()](./Functions-and-Operators/Other/save_file.md) | 🟣 MatrixOne-only | [MO-only] SAVE_FILE() writes to a MatrixOne stage; no MySQL equivalent. |
 | [SERIAL_EXTRACT function](./Functions-and-Operators/Other/serial_extract.md) | 🟣 MatrixOne-only | [MO-only] SERIAL_EXTRACT() is a MatrixOne internal serial-column extractor. |
 | [SLEEP()](./Functions-and-Operators/Other/sleep.md) | ✅ Full | — |
-| [STAGE_LIST()](./Functions-and-Operators/Other/stage_list.md) | 🟣 MatrixOne-only | [MO-only] STAGE_LIST() lists MatrixOne stage contents. |
+| [STAGE_LIST()](./Functions-and-Operators/Other/stage_list.md) | 🟣 MatrixOne-only | [MO-only] STAGE_LIST() — MO-specific stage management function (currently unimplemented, returns ERROR 20105) |
 | [UUID()](./Functions-and-Operators/Other/uuid.md) | ✅ Full | — |
 
 ### String
@@ -330,14 +334,14 @@ mysql_compat: full
 | [BIT_LENGTH()](./Functions-and-Operators/String/bit-length.md) | ✅ Full | — |
 | [CHAR_LENGTH()](./Functions-and-Operators/String/char-length.md) | ✅ Full | — |
 | [CONCAT_WS()](./Functions-and-Operators/String/concat-ws.md) | ✅ Full | — |
-| [CONCAT()](./Functions-and-Operators/String/concat.md) | ✅ Full | — |
+| [CONCAT()](./Functions-and-Operators/String/concat.md) | ⚠️ Partial | — |
 | [ELT()](./Functions-and-Operators/String/elt.md) | ✅ Full | — |
 | [EMPTY()](./Functions-and-Operators/String/empty.md) | 🟣 MatrixOne-only | [MO-only] EMPTY() is a MatrixOne helper returning whether a string is empty. |
 | [ENDSWITH()](./Functions-and-Operators/String/endswith.md) | 🟣 MatrixOne-only | [MO-only] ENDSWITH() is a MatrixOne helper; MySQL has no direct equivalent. |
 | [FIELD()](./Functions-and-Operators/String/field.md) | ✅ Full | — |
 | [FIND_IN_SET()](./Functions-and-Operators/String/find-in-set.md) | ✅ Full | — |
 | [FORMAT()](./Functions-and-Operators/String/format.md) | ✅ Full | — |
-| [FROM_BASE64()](./Functions-and-Operators/String/from_base64.md) | ✅ Full | — |
+| [FROM_BASE64()](./Functions-and-Operators/String/from_base64.md) | ⚠️ Partial | FROM_BASE64() may include trailing null bytes in decoded output; MySQL strips them (e.g., FROM_BASE64('YQ==') returns 'a\\0\\0' instead of 'a') |
 | [HEX()](./Functions-and-Operators/String/hex.md) | ✅ Full | — |
 | [INSTR()](./Functions-and-Operators/String/instr.md) | ✅ Full | — |
 | [LCASE()](./Functions-and-Operators/String/lcase.md) | ✅ Full | — |
@@ -349,11 +353,11 @@ mysql_compat: full
 | [LTRIM()](./Functions-and-Operators/String/ltrim.md) | ✅ Full | — |
 | [MD5()](./Functions-and-Operators/String/md5.md) | ✅ Full | — |
 | [NOT REGEXP](./Functions-and-Operators/String/Regular-Expressions/not-regexp.md) | ✅ Full | — |
-| [OCT(N)](./Functions-and-Operators/String/oct.md) | ✅ Full | — |
-| [REGEXP_INSTR()](./Functions-and-Operators/String/Regular-Expressions/regexp-instr.md) | ✅ Full | — |
+| [OCT(N)](./Functions-and-Operators/String/oct.md) | ⚠️ Partial | OCT(N) returns a numeric value rather than MySQL's plain string representation |
+| [REGEXP_INSTR()](./Functions-and-Operators/String/Regular-Expressions/regexp-instr.md) | ⚠️ Partial | match_type parameter not yet supported; passing it causes ERROR 20203 |
 | [REGEXP_LIKE()](./Functions-and-Operators/String/Regular-Expressions/regexp-like.md) | ✅ Full | — |
 | [REGEXP_REPLACE()](./Functions-and-Operators/String/Regular-Expressions/regexp-replace.md) | ✅ Full | — |
-| [REGEXP_SUBSTR()](./Functions-and-Operators/String/Regular-Expressions/regexp-substr.md) | ✅ Full | — |
+| [REGEXP_SUBSTR()](./Functions-and-Operators/String/Regular-Expressions/regexp-substr.md) | ⚠️ Partial | match_type parameter not yet supported; passing it causes ERROR 20203 |
 | [Regular Expressions Overview](./Functions-and-Operators/String/Regular-Expressions/Regular-Expression-Functions-Overview.md) | ✅ Full | — |
 | [REPEAT()](./Functions-and-Operators/String/repeat.md) | ✅ Full | — |
 | [REVERSE()](./Functions-and-Operators/String/reverse.md) | ✅ Full | — |
@@ -380,7 +384,7 @@ mysql_compat: full
 | [CURRENT_ROLE_NAME()](./Functions-and-Operators/system-ops/current_role_name.md) | 🟣 MatrixOne-only | [MO-only] MatrixOne multi-account/role system management function (compat doc: System Management Functions). |
 | [CURRENT_ROLE()](./Functions-and-Operators/system-ops/current_role.md) | ⚠️ Partial | Returns a single active role name; MySQL 8.0 can return multiple comma-separated active roles or 'NONE'. |
 | [CURRENT_USER_NAME()](./Functions-and-Operators/system-ops/current_user_name.md) | 🟣 MatrixOne-only | [MO-only] MatrixOne multi-account/role system management function (compat doc: System Management Functions). |
-| [CURRENT_USER, CURRENT_USER()](./Functions-and-Operators/system-ops/current_user.md) | ⚠️ Partial | Return format is 'username@0.0.0.0' rather than MySQL's 'username@host' with a resolved client host. |
+| [CURRENT_USER, CURRENT_USER()](./Functions-and-Operators/system-ops/current_user.md) | ⚠️ Partial | The host part may be returned as 'localhost' or the resolved client host rather than MySQL's explicit 'username@host' format. |
 | [PURGE_LOG()](./Functions-and-Operators/system-ops/purge_log.md) | 🟣 MatrixOne-only | [MO-only] MatrixOne multi-account/role system management function (compat doc: System Management Functions). |
 | [VERSION](./Functions-and-Operators/system-ops/version.md) | ✅ Full | — |
 
@@ -396,7 +400,7 @@ mysql_compat: full
 | Function | MySQL Compat | Notes |
 |---|---|---|
 | [Arithmetic operators](./Functions-and-Operators/Vector/arithmetic.md) | 🟣 MatrixOne-only | [MO-only] Vector type and related distance/norm/clustering functions are MatrixOne extensions (compat doc: Data Types — \"MatrixOne supports vector types\"). |
-| [CLUSTER_CENTERS](./Functions-and-Operators/Vector/cluster_centers.md) | 🟣 MatrixOne-only | [MO-only] Vector type and related distance/norm/clustering functions are MatrixOne extensions (compat doc: Data Types — \"MatrixOne supports vector types\"). |
+| [CLUSTER_CENTERS](./Functions-and-Operators/Vector/cluster_centers.md) | 🟣 MatrixOne-only | [MO-only] CLUSTER_CENTERS() — MO-specific vector clustering function (currently unimplemented, returns ERROR 20102) |
 | [COSINE_DISTANCE()](./Functions-and-Operators/Vector/cosine_distance.md) | 🟣 MatrixOne-only | [MO-only] Vector type and related distance/norm/clustering functions are MatrixOne extensions (compat doc: Data Types — \"MatrixOne supports vector types\"). |
 | [cosine_similarity()](./Functions-and-Operators/Vector/cosine_similarity.md) | 🟣 MatrixOne-only | [MO-only] Vector type and related distance/norm/clustering functions are MatrixOne extensions (compat doc: Data Types — \"MatrixOne supports vector types\"). |
 | [inner_product()](./Functions-and-Operators/Vector/inner_product.md) | 🟣 MatrixOne-only | [MO-only] Vector type and related distance/norm/clustering functions are MatrixOne extensions (compat doc: Data Types — \"MatrixOne supports vector types\"). |
@@ -422,118 +426,92 @@ mysql_compat: full
 
 | Status | Count |
 |---|---|
-| ✅ Full | 1 |
-| ❓ Unknown | 61 |
+| ✅ Full | 6 |
+| ⚠️ Partial | 4 |
+| 🟣 MatrixOne-only | 5 |
+| ❓ Unknown | 47 |
 | **Total** | **62** |
 
 ### Operators
 
 | Operator | MySQL Compat | Notes |
 |---|---|---|
-| [interval](./Operators/interval.md) | ❓ Unknown | — |
-| [operator-precedence](./Operators/operator-precedence.md) | ❓ Unknown | — |
-| [operators](./Operators/operators.md) | ❓ Unknown | — |
+| [INTERVAL](./Operators/interval.md) | ⚠️ Partial | INTERVAL is internally implemented as a two-argument function rather than as a true SQL keyword; documented syntax INTERVAL(expr,unit) differs from MySQL's INTERVAL expr unit keyword-style notation<br/>Malformed dates in DATE_ADD/DATE_SUB raise errors rather than returning NULL (MySQL 8.0 returns NULL) |
 
-### Arithmetic Operators
+### operators
 
 | Operator | MySQL Compat | Notes |
 |---|---|---|
-| [addition](./Operators/arithmetic-operators/addition.md) | ❓ Unknown | — |
-| [arithmetic-operators-overview](./Operators/arithmetic-operators/arithmetic-operators-overview.md) | ❓ Unknown | — |
-| [div](./Operators/arithmetic-operators/div.md) | ❓ Unknown | — |
-| [division](./Operators/arithmetic-operators/division.md) | ❓ Unknown | — |
-| [minus](./Operators/arithmetic-operators/minus.md) | ❓ Unknown | — |
-| [mod](./Operators/arithmetic-operators/mod.md) | ❓ Unknown | — |
-| [multiplication](./Operators/arithmetic-operators/multiplication.md) | ❓ Unknown | — |
-| [unary-minus](./Operators/arithmetic-operators/unary-minus.md) | ❓ Unknown | — |
-
-### Assignment Operators
-
-| Operator | MySQL Compat | Notes |
-|---|---|---|
-| [assignment-operators-overview](./Operators/assignment-operators/assignment-operators-overview.md) | ❓ Unknown | — |
-| [equal](./Operators/assignment-operators/equal.md) | ❓ Unknown | — |
-
-### Bit Functions and Operators
-
-| Operator | MySQL Compat | Notes |
-|---|---|---|
-| [bit-functions-and-operators-overview](./Operators/bit-functions-and-operators/bit-functions-and-operators-overview.md) | ❓ Unknown | — |
-| [bitwise-and](./Operators/bit-functions-and-operators/bitwise-and.md) | ❓ Unknown | — |
-| [bitwise-inversion](./Operators/bit-functions-and-operators/bitwise-inversion.md) | ❓ Unknown | — |
-| [bitwise-or](./Operators/bit-functions-and-operators/bitwise-or.md) | ❓ Unknown | — |
-| [bitwise-xor](./Operators/bit-functions-and-operators/bitwise-xor.md) | ❓ Unknown | — |
-| [left-shift](./Operators/bit-functions-and-operators/left-shift.md) | ❓ Unknown | — |
-| [right-shift](./Operators/bit-functions-and-operators/right-shift.md) | ❓ Unknown | — |
-
-### Cast Functions and Operators
-
-| Operator | MySQL Compat | Notes |
-|---|---|---|
-| [binary](./Operators/cast-functions-and-operators/binary.md) | ❓ Unknown | — |
-| [cast](./Operators/cast-functions-and-operators/cast.md) | ❓ Unknown | — |
-| [cast-functions-and-operators-overview](./Operators/cast-functions-and-operators/cast-functions-and-operators-overview.md) | ❓ Unknown | — |
-| [convert](./Operators/cast-functions-and-operators/convert.md) | ❓ Unknown | — |
-| [decode](./Operators/cast-functions-and-operators/decode.md) | ❓ Unknown | — |
-| [encode](./Operators/cast-functions-and-operators/encode.md) | ❓ Unknown | — |
-| [serial](./Operators/cast-functions-and-operators/serial.md) | ❓ Unknown | — |
-| [serial_full](./Operators/cast-functions-and-operators/serial_full.md) | ❓ Unknown | — |
-
-### Comparison Functions and Operators
-
-| Operator | MySQL Compat | Notes |
-|---|---|---|
-| [<=>](./Operators/comparison-functions-and-operators/null-safe-equal.md) | ✅ Full | — |
-| [assign-equal](./Operators/comparison-functions-and-operators/assign-equal.md) | ❓ Unknown | — |
-| [between](./Operators/comparison-functions-and-operators/between.md) | ❓ Unknown | — |
-| [coalesce](./Operators/comparison-functions-and-operators/coalesce.md) | ❓ Unknown | — |
-| [comparison-functions-and-operators-overview](./Operators/comparison-functions-and-operators/comparison-functions-and-operators-overview.md) | ❓ Unknown | — |
-| [function_interval](./Operators/comparison-functions-and-operators/function_interval.md) | ❓ Unknown | — |
-| [function_isnull](./Operators/comparison-functions-and-operators/function_isnull.md) | ❓ Unknown | — |
-| [function_least](./Operators/comparison-functions-and-operators/function_least.md) | ❓ Unknown | — |
-| [function_strcmp](./Operators/comparison-functions-and-operators/function_strcmp.md) | ❓ Unknown | — |
-| [greater-than](./Operators/comparison-functions-and-operators/greater-than.md) | ❓ Unknown | — |
-| [greater-than-or-equal](./Operators/comparison-functions-and-operators/greater-than-or-equal.md) | ❓ Unknown | — |
-| [ilike](./Operators/comparison-functions-and-operators/ilike.md) | ❓ Unknown | — |
-| [in](./Operators/comparison-functions-and-operators/in.md) | ❓ Unknown | — |
-| [is](./Operators/comparison-functions-and-operators/is.md) | ❓ Unknown | — |
-| [is-not](./Operators/comparison-functions-and-operators/is-not.md) | ❓ Unknown | — |
-| [is-not-null](./Operators/comparison-functions-and-operators/is-not-null.md) | ❓ Unknown | — |
-| [is-null](./Operators/comparison-functions-and-operators/is-null.md) | ❓ Unknown | — |
-| [less-than](./Operators/comparison-functions-and-operators/less-than.md) | ❓ Unknown | — |
-| [less-than-or-equal](./Operators/comparison-functions-and-operators/less-than-or-equal.md) | ❓ Unknown | — |
-| [like](./Operators/comparison-functions-and-operators/like.md) | ❓ Unknown | — |
-| [not-between](./Operators/comparison-functions-and-operators/not-between.md) | ❓ Unknown | — |
-| [not-equal](./Operators/comparison-functions-and-operators/not-equal.md) | ❓ Unknown | — |
-| [not-in](./Operators/comparison-functions-and-operators/not-in.md) | ❓ Unknown | — |
-| [not-like](./Operators/comparison-functions-and-operators/not-like.md) | ❓ Unknown | — |
-
-### Flow Control Functions
-
-| Operator | MySQL Compat | Notes |
-|---|---|---|
-| [case-when](./Operators/flow-control-functions/case-when.md) | ❓ Unknown | — |
-| [flow-control-functions-overview](./Operators/flow-control-functions/flow-control-functions-overview.md) | ❓ Unknown | — |
-| [function_if](./Operators/flow-control-functions/function_if.md) | ❓ Unknown | — |
-| [function_ifnull](./Operators/flow-control-functions/function_ifnull.md) | ❓ Unknown | — |
-| [function_nullif](./Operators/flow-control-functions/function_nullif.md) | ❓ Unknown | — |
-
-### Logical Operators
-
-| Operator | MySQL Compat | Notes |
-|---|---|---|
-| [and](./Operators/logical-operators/and.md) | ❓ Unknown | — |
-| [logical-operators-overview](./Operators/logical-operators/logical-operators-overview.md) | ❓ Unknown | — |
-| [not](./Operators/logical-operators/not.md) | ❓ Unknown | — |
-| [or](./Operators/logical-operators/or.md) | ❓ Unknown | — |
-| [xor](./Operators/logical-operators/xor.md) | ❓ Unknown | — |
+| [<=>](./Operators/operators/comparison-functions-and-operators/null-safe-equal.md) | ✅ Full | — |
+| [addition](./Operators/operators/arithmetic-operators/addition.md) | ❓ Unknown | — |
+| [and](./Operators/operators/logical-operators/and.md) | ❓ Unknown | — |
+| [arithmetic-operators-overview](./Operators/operators/arithmetic-operators/arithmetic-operators-overview.md) | ❓ Unknown | — |
+| [assign-equal](./Operators/operators/comparison-functions-and-operators/assign-equal.md) | ❓ Unknown | — |
+| [assignment-operators-overview](./Operators/operators/assignment-operators/assignment-operators-overview.md) | ❓ Unknown | — |
+| [between](./Operators/operators/comparison-functions-and-operators/between.md) | ❓ Unknown | — |
+| [binary](./Operators/operators/cast-functions-and-operators/binary.md) | ❓ Unknown | — |
+| [bit-functions-and-operators-overview](./Operators/operators/bit-functions-and-operators/bit-functions-and-operators-overview.md) | ❓ Unknown | — |
+| [bitwise-and](./Operators/operators/bit-functions-and-operators/bitwise-and.md) | ❓ Unknown | — |
+| [bitwise-inversion](./Operators/operators/bit-functions-and-operators/bitwise-inversion.md) | ❓ Unknown | — |
+| [bitwise-or](./Operators/operators/bit-functions-and-operators/bitwise-or.md) | ❓ Unknown | — |
+| [bitwise-xor](./Operators/operators/bit-functions-and-operators/bitwise-xor.md) | ❓ Unknown | — |
+| [CASE WHEN](./Operators/operators/flow-control-functions/case-when.md) | ✅ Full | — |
+| [CAST](./Operators/operators/cast-functions-and-operators/cast.md) | ⚠️ Partial | CAST('non-numeric' AS SIGNED) raises an error instead of returning 0 or NULL (MySQL 8.0 returns 0 with a warning)<br/>CAST(datetime_typed_value AS CHAR) may fail in some cases (MySQL 8.0 supports it universally) |
+| [cast-functions-and-operators-overview](./Operators/operators/cast-functions-and-operators/cast-functions-and-operators-overview.md) | ❓ Unknown | — |
+| [coalesce](./Operators/operators/comparison-functions-and-operators/coalesce.md) | ❓ Unknown | — |
+| [comparison-functions-and-operators-overview](./Operators/operators/comparison-functions-and-operators/comparison-functions-and-operators-overview.md) | ❓ Unknown | — |
+| [CONVERT](./Operators/operators/cast-functions-and-operators/convert.md) | ⚠️ Partial | CONVERT('non-numeric', SIGNED) raises an error instead of returning 0 or NULL<br/>CONVERT(datetime_typed_value, CHAR) may fail in some cases (MySQL 8.0 supports it universally) |
+| [DECODE()](./Operators/operators/cast-functions-and-operators/decode.md) | 🟣 MatrixOne-only | [MO-only] DECODE() was deprecated in MySQL 5.7 and removed in MySQL 8.0; MatrixOne continues to support it |
+| [div](./Operators/operators/arithmetic-operators/div.md) | ❓ Unknown | — |
+| [division](./Operators/operators/arithmetic-operators/division.md) | ❓ Unknown | — |
+| [ENCODE()](./Operators/operators/cast-functions-and-operators/encode.md) | 🟣 MatrixOne-only | [MO-only] ENCODE() was deprecated in MySQL 5.7 and removed in MySQL 8.0; MatrixOne continues to support it |
+| [equal](./Operators/operators/assignment-operators/equal.md) | ❓ Unknown | — |
+| [flow-control-functions-overview](./Operators/operators/flow-control-functions/flow-control-functions-overview.md) | ❓ Unknown | — |
+| [function_ifnull](./Operators/operators/flow-control-functions/function_ifnull.md) | ❓ Unknown | — |
+| [function_interval](./Operators/operators/comparison-functions-and-operators/function_interval.md) | ❓ Unknown | — |
+| [function_isnull](./Operators/operators/comparison-functions-and-operators/function_isnull.md) | ❓ Unknown | — |
+| [function_least](./Operators/operators/comparison-functions-and-operators/function_least.md) | ❓ Unknown | — |
+| [function_nullif](./Operators/operators/flow-control-functions/function_nullif.md) | ❓ Unknown | — |
+| [function_strcmp](./Operators/operators/comparison-functions-and-operators/function_strcmp.md) | ❓ Unknown | — |
+| [greater-than](./Operators/operators/comparison-functions-and-operators/greater-than.md) | ❓ Unknown | — |
+| [greater-than-or-equal](./Operators/operators/comparison-functions-and-operators/greater-than-or-equal.md) | ❓ Unknown | — |
+| [IF()](./Operators/operators/flow-control-functions/function_if.md) | ⚠️ Partial | IF(NULL, expr2, expr3) raises an error instead of returning expr3 (MySQL 8.0 returns expr3) |
+| [ILIKE](./Operators/operators/comparison-functions-and-operators/ilike.md) | 🟣 MatrixOne-only | [MO-only] ILIKE operator for case-insensitive LIKE matching (PostgreSQL extension) |
+| [IN](./Operators/operators/comparison-functions-and-operators/in.md) | ✅ Full | — |
+| [is](./Operators/operators/comparison-functions-and-operators/is.md) | ❓ Unknown | — |
+| [IS NULL](./Operators/operators/comparison-functions-and-operators/is-null.md) | ✅ Full | — |
+| [is-not](./Operators/operators/comparison-functions-and-operators/is-not.md) | ❓ Unknown | — |
+| [is-not-null](./Operators/operators/comparison-functions-and-operators/is-not-null.md) | ❓ Unknown | — |
+| [left-shift](./Operators/operators/bit-functions-and-operators/left-shift.md) | ❓ Unknown | — |
+| [less-than](./Operators/operators/comparison-functions-and-operators/less-than.md) | ❓ Unknown | — |
+| [less-than-or-equal](./Operators/operators/comparison-functions-and-operators/less-than-or-equal.md) | ❓ Unknown | — |
+| [like](./Operators/operators/comparison-functions-and-operators/like.md) | ❓ Unknown | — |
+| [logical-operators-overview](./Operators/operators/logical-operators/logical-operators-overview.md) | ❓ Unknown | — |
+| [minus](./Operators/operators/arithmetic-operators/minus.md) | ❓ Unknown | — |
+| [mod](./Operators/operators/arithmetic-operators/mod.md) | ❓ Unknown | — |
+| [multiplication](./Operators/operators/arithmetic-operators/multiplication.md) | ❓ Unknown | — |
+| [NOT / !](./Operators/operators/logical-operators/not.md) | ✅ Full | — |
+| [NOT IN](./Operators/operators/comparison-functions-and-operators/not-in.md) | ✅ Full | — |
+| [not-between](./Operators/operators/comparison-functions-and-operators/not-between.md) | ❓ Unknown | — |
+| [not-equal](./Operators/operators/comparison-functions-and-operators/not-equal.md) | ❓ Unknown | — |
+| [not-like](./Operators/operators/comparison-functions-and-operators/not-like.md) | ❓ Unknown | — |
+| [operator-precedence](./Operators/operators/operator-precedence.md) | ❓ Unknown | — |
+| [operators](./Operators/operators/operators.md) | ❓ Unknown | — |
+| [or](./Operators/operators/logical-operators/or.md) | ❓ Unknown | — |
+| [right-shift](./Operators/operators/bit-functions-and-operators/right-shift.md) | ❓ Unknown | — |
+| [SERIAL_FULL()](./Operators/operators/cast-functions-and-operators/serial_full.md) | 🟣 MatrixOne-only | [MO-only] SERIAL_FULL() is a MO-specific serialization function variant with NULL preservation, no MySQL 8.0 counterpart |
+| [SERIAL()](./Operators/operators/cast-functions-and-operators/serial.md) | 🟣 MatrixOne-only | [MO-only] SERIAL() is a MO-specific serialization function with no MySQL 8.0 counterpart |
+| [unary-minus](./Operators/operators/arithmetic-operators/unary-minus.md) | ❓ Unknown | — |
+| [xor](./Operators/operators/logical-operators/xor.md) | ❓ Unknown | — |
 
 ## Data Types
 
 | Status | Count |
 |---|---|
-| ⚠️ Partial | 2 |
-| ❓ Unknown | 10 |
+| ✅ Full | 1 |
+| ⚠️ Partial | 7 |
+| 🟣 MatrixOne-only | 3 |
+| ❓ Unknown | 1 |
 | **Total** | **12** |
 
 ### Data Types
@@ -541,33 +519,33 @@ mysql_compat: full
 | Data Type | MySQL Compat | Notes |
 |---|---|---|
 | [blob-text-type](./Data-Types/blob-text-type.md) | ❓ Unknown | — |
-| [data-type-conversion](./Data-Types/data-type-conversion.md) | ❓ Unknown | — |
-| [data-types](./Data-Types/data-types.md) | ❓ Unknown | — |
-| [datalink-type](./Data-Types/datalink-type.md) | ❓ Unknown | — |
+| [Data Type Conversion](./Data-Types/data-type-conversion.md) | ⚠️ Partial | BOOLEAN → DECIMAL cast is not supported; other common conversions are supported |
+| [Data Types Overview](./Data-Types/data-types.md) | ⚠️ Partial | TIMESTAMP range is 0001-01-01 to 9999-12-31 (MySQL: 1970-01-01 to 2038-01-19)<br/>DATETIME lower bound is 0001-01-01 (MySQL: 1000-01-01)<br/>Non-standard type names FLOAT32/FLOAT64 in addition to MySQL's FLOAT/DOUBLE |
+| [DATALINK Type](./Data-Types/datalink-type.md) | 🟣 MatrixOne-only | [MO-only] DATALINK data type with STAGE integration, file:// and stage:// URL schemes<br/>[MO-only] load_file() integration for reading DATALINK values |
 | [ENUM Type](./Data-Types/enum-type.md) | ⚠️ Partial | — |
-| [fixed-point-types](./Data-Types/fixed-point-types.md) | ❓ Unknown | — |
-| [json-type](./Data-Types/json-type.md) | ❓ Unknown | — |
+| [Fixed-Point Types (Exact Value) - DECIMAL](./Data-Types/fixed-point-types.md) | ⚠️ Partial | DECIMAL precision supports up to 65 digits via DECIMAL256 |
+| [JSON Type](./Data-Types/json-type.md) | ✅ Full | — |
 | [SET Type](./Data-Types/set-type.md) | ⚠️ Partial | — |
-| [uuid-type](./Data-Types/uuid-type.md) | ❓ Unknown | — |
-| [vector-type](./Data-Types/vector-type.md) | ❓ Unknown | — |
+| [UUID Type](./Data-Types/uuid-type.md) | 🟣 MatrixOne-only | [MO-only] UUID as a native column type (MySQL 8.0 has UUID() function only, no UUID column type)<br/>[MO-only] DEFAULT uuid() on UUID columns |
+| [Vector Type](./Data-Types/vector-type.md) | 🟣 MatrixOne-only | [MO-only] vecf32 and vecf64 vector data types for embedding storage and similarity search<br/>[MO-only] Binary vector insert via hex encoding<br/>[MO-only] Dimension specification syntax in column definition |
 
 ### Date/Time Data Types
 
 | Data Type | MySQL Compat | Notes |
 |---|---|---|
-| [timestamp-initialization](./Data-Types/date-time-data-types/timestamp-initialization.md) | ❓ Unknown | — |
-| [year-type](./Data-Types/date-time-data-types/year-type.md) | ❓ Unknown | — |
+| [TIMESTAMP Initialization](./Data-Types/date-time-data-types/timestamp-initialization.md) | ⚠️ Partial | TIMESTAMP range is 0001-9999 (MySQL 8.0: 1970-2038); auto-initialization behavior near range boundaries may differ<br/>DATETIME DEFAULT 0 is not supported (MySQL 8.0 supports it)<br/>TIMESTAMP ON UPDATE CURRENT_TIMESTAMP without explicit DEFAULT defaults to NULL (MySQL 8.0 defaults to 0)<br/>DATETIME NOT NULL ON UPDATE CURRENT_TIMESTAMP without explicit DEFAULT rejects NULL insert (MySQL 8.0 defaults to 0) |
+| [YEAR Type](./Data-Types/date-time-data-types/year-type.md) | ⚠️ Partial | — |
 
 ## Language Structure
 
 | Status | Count |
 |---|---|
-| ❓ Unknown | 2 |
+| ⚠️ Partial | 2 |
 | **Total** | **2** |
 
 ### Language Structure
 
 | Element | MySQL Compat | Notes |
 |---|---|---|
-| [comment](./Language-Structure/comment.md) | ❓ Unknown | — |
-| [keywords](./Language-Structure/keywords.md) | ❓ Unknown | — |
+| [Comments](./Language-Structure/comment.md) | ⚠️ Partial | Supports // single-line comments (C++ style); MySQL 8.0 does not support // comments<br/>Does not support /*!...*/ conditional/executable comments (MySQL 8.0 does) |
+| [Keywords](./Language-Structure/keywords.md) | ⚠️ Partial | MatrixOne-specific keywords marked with (M) in the keyword list |

--- a/scripts/generate-compat-matrix.js
+++ b/scripts/generate-compat-matrix.js
@@ -71,19 +71,11 @@ function categoryOf(relPath) {
   return parts[0]
 }
 
-function cleanRelPath(sourceDir, relPath) {
-  if (sourceDir === 'Operators') {
-    const parts = relPath.split('/')
-    if (parts[0] === 'operators') return parts.slice(1).join('/')
-  }
-  return relPath
-}
-
 /** Derive a stable machine-readable ID from a source-relative path. */
 function entryId(sourceDir, relPath) {
   const prefix = SOURCE_ID_PREFIX[sourceDir] || sourceDir.toLowerCase()
   // Strip .md, replace path separators and dashes with dots
-  const slug = cleanRelPath(sourceDir, relPath)
+  const slug = relPath
     .replace(/\.md$/, '')
     .replace(/[\/\\]/g, '.')
     .replace(/-/g, '_')
@@ -158,7 +150,7 @@ async function scanSource(sourceDir) {
     const rel = path.relative(sourceRoot, file)
     const raw = readFileSync(file, 'utf-8')
     const fm = parseFrontmatter(raw) || {}
-    const displayRel = cleanRelPath(sourceDir, rel)
+    const displayRel = rel
     rows.push({
       file,
       rel: displayRel,


### PR DESCRIPTION
## Summary
- Remove `cleanRelPath()` function that incorrectly stripped the `operators/` path prefix from Operator file paths
- Regenerate compat matrix (md + json) with correct file links
- All Operator links now point to actual files under `Operators/operators/`

## Root Cause
The `cleanRelPath()` function was designed to strip a redundant `operators/` prefix from paths, but the actual file structure on every branch has files legitimately nested under `Operators/operators/`. This produced links like `./Operators/operator-precedence.md` that don't exist (should be `./Operators/operators/operator-precedence.md`).

## Test plan
- [ ] Verify `node scripts/generate-compat-matrix.js` completes without error
- [ ] Verify no dead Operator links remain in the generated md file