### PR TITLE
fix: remove cleanRelPath that stripped legitimate operators/ path prefix

### DIFF
--- a/docs/MatrixOne/Reference/mysql-compatibility-matrix.json
+++ b/docs/MatrixOne/Reference/mysql-compatibility-matrix.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-27T10:51:12.013Z",
+  "generated_at": "2026-05-28T07:03:53.444Z",
   "summary": {
     "total": 370,
     "full": 142,
@@ -2557,473 +2557,437 @@
               "path": "docs/MatrixOne/Reference/Operators/interval.md",
               "compat": "unknown",
               "notes": []
-            },
-            {
-              "id": "op.operator_precedence",
-              "title": "operator-precedence",
-              "path": "docs/MatrixOne/Reference/Operators/operator-precedence.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.operators",
-              "title": "operators",
-              "path": "docs/MatrixOne/Reference/Operators/operators.md",
-              "compat": "unknown",
-              "notes": []
             }
           ]
         },
         {
-          "id": "arithmetic_operators",
-          "label": "Arithmetic Operators",
+          "id": "operators",
+          "label": "operators",
           "entries": [
             {
-              "id": "op.arithmetic_operators.addition",
-              "title": "addition",
-              "path": "docs/MatrixOne/Reference/Operators/arithmetic-operators/addition.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.arithmetic_operators.arithmetic_operators_overview",
-              "title": "arithmetic-operators-overview",
-              "path": "docs/MatrixOne/Reference/Operators/arithmetic-operators/arithmetic-operators-overview.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.arithmetic_operators.div",
-              "title": "div",
-              "path": "docs/MatrixOne/Reference/Operators/arithmetic-operators/div.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.arithmetic_operators.division",
-              "title": "division",
-              "path": "docs/MatrixOne/Reference/Operators/arithmetic-operators/division.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.arithmetic_operators.minus",
-              "title": "minus",
-              "path": "docs/MatrixOne/Reference/Operators/arithmetic-operators/minus.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.arithmetic_operators.mod",
-              "title": "mod",
-              "path": "docs/MatrixOne/Reference/Operators/arithmetic-operators/mod.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.arithmetic_operators.multiplication",
-              "title": "multiplication",
-              "path": "docs/MatrixOne/Reference/Operators/arithmetic-operators/multiplication.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.arithmetic_operators.unary_minus",
-              "title": "unary-minus",
-              "path": "docs/MatrixOne/Reference/Operators/arithmetic-operators/unary-minus.md",
-              "compat": "unknown",
-              "notes": []
-            }
-          ]
-        },
-        {
-          "id": "assignment_operators",
-          "label": "Assignment Operators",
-          "entries": [
-            {
-              "id": "op.assignment_operators.assignment_operators_overview",
-              "title": "assignment-operators-overview",
-              "path": "docs/MatrixOne/Reference/Operators/assignment-operators/assignment-operators-overview.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.assignment_operators.equal",
-              "title": "equal",
-              "path": "docs/MatrixOne/Reference/Operators/assignment-operators/equal.md",
-              "compat": "unknown",
-              "notes": []
-            }
-          ]
-        },
-        {
-          "id": "bit_functions_and_operators",
-          "label": "Bit Functions and Operators",
-          "entries": [
-            {
-              "id": "op.bit_functions_and_operators.bit_functions_and_operators_overview",
-              "title": "bit-functions-and-operators-overview",
-              "path": "docs/MatrixOne/Reference/Operators/bit-functions-and-operators/bit-functions-and-operators-overview.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.bit_functions_and_operators.bitwise_and",
-              "title": "bitwise-and",
-              "path": "docs/MatrixOne/Reference/Operators/bit-functions-and-operators/bitwise-and.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.bit_functions_and_operators.bitwise_inversion",
-              "title": "bitwise-inversion",
-              "path": "docs/MatrixOne/Reference/Operators/bit-functions-and-operators/bitwise-inversion.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.bit_functions_and_operators.bitwise_or",
-              "title": "bitwise-or",
-              "path": "docs/MatrixOne/Reference/Operators/bit-functions-and-operators/bitwise-or.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.bit_functions_and_operators.bitwise_xor",
-              "title": "bitwise-xor",
-              "path": "docs/MatrixOne/Reference/Operators/bit-functions-and-operators/bitwise-xor.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.bit_functions_and_operators.left_shift",
-              "title": "left-shift",
-              "path": "docs/MatrixOne/Reference/Operators/bit-functions-and-operators/left-shift.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.bit_functions_and_operators.right_shift",
-              "title": "right-shift",
-              "path": "docs/MatrixOne/Reference/Operators/bit-functions-and-operators/right-shift.md",
-              "compat": "unknown",
-              "notes": []
-            }
-          ]
-        },
-        {
-          "id": "cast_functions_and_operators",
-          "label": "Cast Functions and Operators",
-          "entries": [
-            {
-              "id": "op.cast_functions_and_operators.binary",
-              "title": "binary",
-              "path": "docs/MatrixOne/Reference/Operators/cast-functions-and-operators/binary.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.cast_functions_and_operators.cast",
-              "title": "cast",
-              "path": "docs/MatrixOne/Reference/Operators/cast-functions-and-operators/cast.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.cast_functions_and_operators.cast_functions_and_operators_overview",
-              "title": "cast-functions-and-operators-overview",
-              "path": "docs/MatrixOne/Reference/Operators/cast-functions-and-operators/cast-functions-and-operators-overview.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.cast_functions_and_operators.convert",
-              "title": "convert",
-              "path": "docs/MatrixOne/Reference/Operators/cast-functions-and-operators/convert.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.cast_functions_and_operators.decode",
-              "title": "decode",
-              "path": "docs/MatrixOne/Reference/Operators/cast-functions-and-operators/decode.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.cast_functions_and_operators.encode",
-              "title": "encode",
-              "path": "docs/MatrixOne/Reference/Operators/cast-functions-and-operators/encode.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.cast_functions_and_operators.serial",
-              "title": "serial",
-              "path": "docs/MatrixOne/Reference/Operators/cast-functions-and-operators/serial.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.cast_functions_and_operators.serial_full",
-              "title": "serial_full",
-              "path": "docs/MatrixOne/Reference/Operators/cast-functions-and-operators/serial_full.md",
-              "compat": "unknown",
-              "notes": []
-            }
-          ]
-        },
-        {
-          "id": "comparison_functions_and_operators",
-          "label": "Comparison Functions and Operators",
-          "entries": [
-            {
-              "id": "op.comparison_functions_and_operators.null_safe_equal",
+              "id": "op.operators.comparison_functions_and_operators.null_safe_equal",
               "title": "<=>",
-              "path": "docs/MatrixOne/Reference/Operators/comparison-functions-and-operators/null-safe-equal.md",
+              "path": "docs/MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/null-safe-equal.md",
               "compat": "full",
               "notes": []
             },
             {
-              "id": "op.comparison_functions_and_operators.assign_equal",
-              "title": "assign-equal",
-              "path": "docs/MatrixOne/Reference/Operators/comparison-functions-and-operators/assign-equal.md",
+              "id": "op.operators.arithmetic_operators.addition",
+              "title": "addition",
+              "path": "docs/MatrixOne/Reference/Operators/operators/arithmetic-operators/addition.md",
               "compat": "unknown",
               "notes": []
             },
             {
-              "id": "op.comparison_functions_and_operators.between",
-              "title": "between",
-              "path": "docs/MatrixOne/Reference/Operators/comparison-functions-and-operators/between.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.comparison_functions_and_operators.coalesce",
-              "title": "coalesce",
-              "path": "docs/MatrixOne/Reference/Operators/comparison-functions-and-operators/coalesce.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.comparison_functions_and_operators.comparison_functions_and_operators_overview",
-              "title": "comparison-functions-and-operators-overview",
-              "path": "docs/MatrixOne/Reference/Operators/comparison-functions-and-operators/comparison-functions-and-operators-overview.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.comparison_functions_and_operators.function_interval",
-              "title": "function_interval",
-              "path": "docs/MatrixOne/Reference/Operators/comparison-functions-and-operators/function_interval.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.comparison_functions_and_operators.function_isnull",
-              "title": "function_isnull",
-              "path": "docs/MatrixOne/Reference/Operators/comparison-functions-and-operators/function_isnull.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.comparison_functions_and_operators.function_least",
-              "title": "function_least",
-              "path": "docs/MatrixOne/Reference/Operators/comparison-functions-and-operators/function_least.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.comparison_functions_and_operators.function_strcmp",
-              "title": "function_strcmp",
-              "path": "docs/MatrixOne/Reference/Operators/comparison-functions-and-operators/function_strcmp.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.comparison_functions_and_operators.greater_than",
-              "title": "greater-than",
-              "path": "docs/MatrixOne/Reference/Operators/comparison-functions-and-operators/greater-than.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.comparison_functions_and_operators.greater_than_or_equal",
-              "title": "greater-than-or-equal",
-              "path": "docs/MatrixOne/Reference/Operators/comparison-functions-and-operators/greater-than-or-equal.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.comparison_functions_and_operators.ilike",
-              "title": "ilike",
-              "path": "docs/MatrixOne/Reference/Operators/comparison-functions-and-operators/ilike.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.comparison_functions_and_operators.in",
-              "title": "in",
-              "path": "docs/MatrixOne/Reference/Operators/comparison-functions-and-operators/in.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.comparison_functions_and_operators.is",
-              "title": "is",
-              "path": "docs/MatrixOne/Reference/Operators/comparison-functions-and-operators/is.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.comparison_functions_and_operators.is_not",
-              "title": "is-not",
-              "path": "docs/MatrixOne/Reference/Operators/comparison-functions-and-operators/is-not.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.comparison_functions_and_operators.is_not_null",
-              "title": "is-not-null",
-              "path": "docs/MatrixOne/Reference/Operators/comparison-functions-and-operators/is-not-null.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.comparison_functions_and_operators.is_null",
-              "title": "is-null",
-              "path": "docs/MatrixOne/Reference/Operators/comparison-functions-and-operators/is-null.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.comparison_functions_and_operators.less_than",
-              "title": "less-than",
-              "path": "docs/MatrixOne/Reference/Operators/comparison-functions-and-operators/less-than.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.comparison_functions_and_operators.less_than_or_equal",
-              "title": "less-than-or-equal",
-              "path": "docs/MatrixOne/Reference/Operators/comparison-functions-and-operators/less-than-or-equal.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.comparison_functions_and_operators.like",
-              "title": "like",
-              "path": "docs/MatrixOne/Reference/Operators/comparison-functions-and-operators/like.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.comparison_functions_and_operators.not_between",
-              "title": "not-between",
-              "path": "docs/MatrixOne/Reference/Operators/comparison-functions-and-operators/not-between.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.comparison_functions_and_operators.not_equal",
-              "title": "not-equal",
-              "path": "docs/MatrixOne/Reference/Operators/comparison-functions-and-operators/not-equal.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.comparison_functions_and_operators.not_in",
-              "title": "not-in",
-              "path": "docs/MatrixOne/Reference/Operators/comparison-functions-and-operators/not-in.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.comparison_functions_and_operators.not_like",
-              "title": "not-like",
-              "path": "docs/MatrixOne/Reference/Operators/comparison-functions-and-operators/not-like.md",
-              "compat": "unknown",
-              "notes": []
-            }
-          ]
-        },
-        {
-          "id": "flow_control_functions",
-          "label": "Flow Control Functions",
-          "entries": [
-            {
-              "id": "op.flow_control_functions.case_when",
-              "title": "case-when",
-              "path": "docs/MatrixOne/Reference/Operators/flow-control-functions/case-when.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.flow_control_functions.flow_control_functions_overview",
-              "title": "flow-control-functions-overview",
-              "path": "docs/MatrixOne/Reference/Operators/flow-control-functions/flow-control-functions-overview.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.flow_control_functions.function_if",
-              "title": "function_if",
-              "path": "docs/MatrixOne/Reference/Operators/flow-control-functions/function_if.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.flow_control_functions.function_ifnull",
-              "title": "function_ifnull",
-              "path": "docs/MatrixOne/Reference/Operators/flow-control-functions/function_ifnull.md",
-              "compat": "unknown",
-              "notes": []
-            },
-            {
-              "id": "op.flow_control_functions.function_nullif",
-              "title": "function_nullif",
-              "path": "docs/MatrixOne/Reference/Operators/flow-control-functions/function_nullif.md",
-              "compat": "unknown",
-              "notes": []
-            }
-          ]
-        },
-        {
-          "id": "logical_operators",
-          "label": "Logical Operators",
-          "entries": [
-            {
-              "id": "op.logical_operators.and",
+              "id": "op.operators.logical_operators.and",
               "title": "and",
-              "path": "docs/MatrixOne/Reference/Operators/logical-operators/and.md",
+              "path": "docs/MatrixOne/Reference/Operators/operators/logical-operators/and.md",
               "compat": "unknown",
               "notes": []
             },
             {
-              "id": "op.logical_operators.logical_operators_overview",
+              "id": "op.operators.arithmetic_operators.arithmetic_operators_overview",
+              "title": "arithmetic-operators-overview",
+              "path": "docs/MatrixOne/Reference/Operators/operators/arithmetic-operators/arithmetic-operators-overview.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.comparison_functions_and_operators.assign_equal",
+              "title": "assign-equal",
+              "path": "docs/MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/assign-equal.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.assignment_operators.assignment_operators_overview",
+              "title": "assignment-operators-overview",
+              "path": "docs/MatrixOne/Reference/Operators/operators/assignment-operators/assignment-operators-overview.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.comparison_functions_and_operators.between",
+              "title": "between",
+              "path": "docs/MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/between.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.cast_functions_and_operators.binary",
+              "title": "binary",
+              "path": "docs/MatrixOne/Reference/Operators/operators/cast-functions-and-operators/binary.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.bit_functions_and_operators.bit_functions_and_operators_overview",
+              "title": "bit-functions-and-operators-overview",
+              "path": "docs/MatrixOne/Reference/Operators/operators/bit-functions-and-operators/bit-functions-and-operators-overview.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.bit_functions_and_operators.bitwise_and",
+              "title": "bitwise-and",
+              "path": "docs/MatrixOne/Reference/Operators/operators/bit-functions-and-operators/bitwise-and.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.bit_functions_and_operators.bitwise_inversion",
+              "title": "bitwise-inversion",
+              "path": "docs/MatrixOne/Reference/Operators/operators/bit-functions-and-operators/bitwise-inversion.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.bit_functions_and_operators.bitwise_or",
+              "title": "bitwise-or",
+              "path": "docs/MatrixOne/Reference/Operators/operators/bit-functions-and-operators/bitwise-or.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.bit_functions_and_operators.bitwise_xor",
+              "title": "bitwise-xor",
+              "path": "docs/MatrixOne/Reference/Operators/operators/bit-functions-and-operators/bitwise-xor.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.flow_control_functions.case_when",
+              "title": "case-when",
+              "path": "docs/MatrixOne/Reference/Operators/operators/flow-control-functions/case-when.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.cast_functions_and_operators.cast",
+              "title": "cast",
+              "path": "docs/MatrixOne/Reference/Operators/operators/cast-functions-and-operators/cast.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.cast_functions_and_operators.cast_functions_and_operators_overview",
+              "title": "cast-functions-and-operators-overview",
+              "path": "docs/MatrixOne/Reference/Operators/operators/cast-functions-and-operators/cast-functions-and-operators-overview.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.comparison_functions_and_operators.coalesce",
+              "title": "coalesce",
+              "path": "docs/MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/coalesce.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.comparison_functions_and_operators.comparison_functions_and_operators_overview",
+              "title": "comparison-functions-and-operators-overview",
+              "path": "docs/MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/comparison-functions-and-operators-overview.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.cast_functions_and_operators.convert",
+              "title": "convert",
+              "path": "docs/MatrixOne/Reference/Operators/operators/cast-functions-and-operators/convert.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.cast_functions_and_operators.decode",
+              "title": "decode",
+              "path": "docs/MatrixOne/Reference/Operators/operators/cast-functions-and-operators/decode.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.arithmetic_operators.div",
+              "title": "div",
+              "path": "docs/MatrixOne/Reference/Operators/operators/arithmetic-operators/div.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.arithmetic_operators.division",
+              "title": "division",
+              "path": "docs/MatrixOne/Reference/Operators/operators/arithmetic-operators/division.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.cast_functions_and_operators.encode",
+              "title": "encode",
+              "path": "docs/MatrixOne/Reference/Operators/operators/cast-functions-and-operators/encode.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.assignment_operators.equal",
+              "title": "equal",
+              "path": "docs/MatrixOne/Reference/Operators/operators/assignment-operators/equal.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.flow_control_functions.flow_control_functions_overview",
+              "title": "flow-control-functions-overview",
+              "path": "docs/MatrixOne/Reference/Operators/operators/flow-control-functions/flow-control-functions-overview.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.flow_control_functions.function_if",
+              "title": "function_if",
+              "path": "docs/MatrixOne/Reference/Operators/operators/flow-control-functions/function_if.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.flow_control_functions.function_ifnull",
+              "title": "function_ifnull",
+              "path": "docs/MatrixOne/Reference/Operators/operators/flow-control-functions/function_ifnull.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.comparison_functions_and_operators.function_interval",
+              "title": "function_interval",
+              "path": "docs/MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/function_interval.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.comparison_functions_and_operators.function_isnull",
+              "title": "function_isnull",
+              "path": "docs/MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/function_isnull.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.comparison_functions_and_operators.function_least",
+              "title": "function_least",
+              "path": "docs/MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/function_least.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.flow_control_functions.function_nullif",
+              "title": "function_nullif",
+              "path": "docs/MatrixOne/Reference/Operators/operators/flow-control-functions/function_nullif.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.comparison_functions_and_operators.function_strcmp",
+              "title": "function_strcmp",
+              "path": "docs/MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/function_strcmp.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.comparison_functions_and_operators.greater_than",
+              "title": "greater-than",
+              "path": "docs/MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/greater-than.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.comparison_functions_and_operators.greater_than_or_equal",
+              "title": "greater-than-or-equal",
+              "path": "docs/MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/greater-than-or-equal.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.comparison_functions_and_operators.ilike",
+              "title": "ilike",
+              "path": "docs/MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/ilike.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.comparison_functions_and_operators.in",
+              "title": "in",
+              "path": "docs/MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/in.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.comparison_functions_and_operators.is",
+              "title": "is",
+              "path": "docs/MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/is.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.comparison_functions_and_operators.is_not",
+              "title": "is-not",
+              "path": "docs/MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/is-not.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.comparison_functions_and_operators.is_not_null",
+              "title": "is-not-null",
+              "path": "docs/MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/is-not-null.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.comparison_functions_and_operators.is_null",
+              "title": "is-null",
+              "path": "docs/MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/is-null.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.bit_functions_and_operators.left_shift",
+              "title": "left-shift",
+              "path": "docs/MatrixOne/Reference/Operators/operators/bit-functions-and-operators/left-shift.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.comparison_functions_and_operators.less_than",
+              "title": "less-than",
+              "path": "docs/MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/less-than.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.comparison_functions_and_operators.less_than_or_equal",
+              "title": "less-than-or-equal",
+              "path": "docs/MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/less-than-or-equal.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.comparison_functions_and_operators.like",
+              "title": "like",
+              "path": "docs/MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/like.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.logical_operators.logical_operators_overview",
               "title": "logical-operators-overview",
-              "path": "docs/MatrixOne/Reference/Operators/logical-operators/logical-operators-overview.md",
+              "path": "docs/MatrixOne/Reference/Operators/operators/logical-operators/logical-operators-overview.md",
               "compat": "unknown",
               "notes": []
             },
             {
-              "id": "op.logical_operators.not",
+              "id": "op.operators.arithmetic_operators.minus",
+              "title": "minus",
+              "path": "docs/MatrixOne/Reference/Operators/operators/arithmetic-operators/minus.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.arithmetic_operators.mod",
+              "title": "mod",
+              "path": "docs/MatrixOne/Reference/Operators/operators/arithmetic-operators/mod.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.arithmetic_operators.multiplication",
+              "title": "multiplication",
+              "path": "docs/MatrixOne/Reference/Operators/operators/arithmetic-operators/multiplication.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.logical_operators.not",
               "title": "not",
-              "path": "docs/MatrixOne/Reference/Operators/logical-operators/not.md",
+              "path": "docs/MatrixOne/Reference/Operators/operators/logical-operators/not.md",
               "compat": "unknown",
               "notes": []
             },
             {
-              "id": "op.logical_operators.or",
+              "id": "op.operators.comparison_functions_and_operators.not_between",
+              "title": "not-between",
+              "path": "docs/MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/not-between.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.comparison_functions_and_operators.not_equal",
+              "title": "not-equal",
+              "path": "docs/MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/not-equal.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.comparison_functions_and_operators.not_in",
+              "title": "not-in",
+              "path": "docs/MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/not-in.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.comparison_functions_and_operators.not_like",
+              "title": "not-like",
+              "path": "docs/MatrixOne/Reference/Operators/operators/comparison-functions-and-operators/not-like.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.operator_precedence",
+              "title": "operator-precedence",
+              "path": "docs/MatrixOne/Reference/Operators/operators/operator-precedence.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.operators",
+              "title": "operators",
+              "path": "docs/MatrixOne/Reference/Operators/operators/operators.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.logical_operators.or",
               "title": "or",
-              "path": "docs/MatrixOne/Reference/Operators/logical-operators/or.md",
+              "path": "docs/MatrixOne/Reference/Operators/operators/logical-operators/or.md",
               "compat": "unknown",
               "notes": []
             },
             {
-              "id": "op.logical_operators.xor",
+              "id": "op.operators.bit_functions_and_operators.right_shift",
+              "title": "right-shift",
+              "path": "docs/MatrixOne/Reference/Operators/operators/bit-functions-and-operators/right-shift.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.cast_functions_and_operators.serial",
+              "title": "serial",
+              "path": "docs/MatrixOne/Reference/Operators/operators/cast-functions-and-operators/serial.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.cast_functions_and_operators.serial_full",
+              "title": "serial_full",
+              "path": "docs/MatrixOne/Reference/Operators/operators/cast-functions-and-operators/serial_full.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.arithmetic_operators.unary_minus",
+              "title": "unary-minus",
+              "path": "docs/MatrixOne/Reference/Operators/operators/arithmetic-operators/unary-minus.md",
+              "compat": "unknown",
+              "notes": []
+            },
+            {
+              "id": "op.operators.logical_operators.xor",
               "title": "xor",
-              "path": "docs/MatrixOne/Reference/Operators/logical-operators/xor.md",
+              "path": "docs/MatrixOne/Reference/Operators/operators/logical-operators/xor.md",
               "compat": "unknown",
               "notes": []
             }

--- a/docs/MatrixOne/Reference/mysql-compatibility-matrix.md
+++ b/docs/MatrixOne/Reference/mysql-compatibility-matrix.md
@@ -431,102 +431,72 @@ mysql_compat: full
 | Operator | MySQL Compat | Notes |
 |---|---|---|
 | [interval](./Operators/interval.md) | ❓ Unknown | — |
-| [operator-precedence](./Operators/operator-precedence.md) | ❓ Unknown | — |
-| [operators](./Operators/operators.md) | ❓ Unknown | — |
 
-### Arithmetic Operators
+### operators
 
 | Operator | MySQL Compat | Notes |
 |---|---|---|
-| [addition](./Operators/arithmetic-operators/addition.md) | ❓ Unknown | — |
-| [arithmetic-operators-overview](./Operators/arithmetic-operators/arithmetic-operators-overview.md) | ❓ Unknown | — |
-| [div](./Operators/arithmetic-operators/div.md) | ❓ Unknown | — |
-| [division](./Operators/arithmetic-operators/division.md) | ❓ Unknown | — |
-| [minus](./Operators/arithmetic-operators/minus.md) | ❓ Unknown | — |
-| [mod](./Operators/arithmetic-operators/mod.md) | ❓ Unknown | — |
-| [multiplication](./Operators/arithmetic-operators/multiplication.md) | ❓ Unknown | — |
-| [unary-minus](./Operators/arithmetic-operators/unary-minus.md) | ❓ Unknown | — |
-
-### Assignment Operators
-
-| Operator | MySQL Compat | Notes |
-|---|---|---|
-| [assignment-operators-overview](./Operators/assignment-operators/assignment-operators-overview.md) | ❓ Unknown | — |
-| [equal](./Operators/assignment-operators/equal.md) | ❓ Unknown | — |
-
-### Bit Functions and Operators
-
-| Operator | MySQL Compat | Notes |
-|---|---|---|
-| [bit-functions-and-operators-overview](./Operators/bit-functions-and-operators/bit-functions-and-operators-overview.md) | ❓ Unknown | — |
-| [bitwise-and](./Operators/bit-functions-and-operators/bitwise-and.md) | ❓ Unknown | — |
-| [bitwise-inversion](./Operators/bit-functions-and-operators/bitwise-inversion.md) | ❓ Unknown | — |
-| [bitwise-or](./Operators/bit-functions-and-operators/bitwise-or.md) | ❓ Unknown | — |
-| [bitwise-xor](./Operators/bit-functions-and-operators/bitwise-xor.md) | ❓ Unknown | — |
-| [left-shift](./Operators/bit-functions-and-operators/left-shift.md) | ❓ Unknown | — |
-| [right-shift](./Operators/bit-functions-and-operators/right-shift.md) | ❓ Unknown | — |
-
-### Cast Functions and Operators
-
-| Operator | MySQL Compat | Notes |
-|---|---|---|
-| [binary](./Operators/cast-functions-and-operators/binary.md) | ❓ Unknown | — |
-| [cast](./Operators/cast-functions-and-operators/cast.md) | ❓ Unknown | — |
-| [cast-functions-and-operators-overview](./Operators/cast-functions-and-operators/cast-functions-and-operators-overview.md) | ❓ Unknown | — |
-| [convert](./Operators/cast-functions-and-operators/convert.md) | ❓ Unknown | — |
-| [decode](./Operators/cast-functions-and-operators/decode.md) | ❓ Unknown | — |
-| [encode](./Operators/cast-functions-and-operators/encode.md) | ❓ Unknown | — |
-| [serial](./Operators/cast-functions-and-operators/serial.md) | ❓ Unknown | — |
-| [serial_full](./Operators/cast-functions-and-operators/serial_full.md) | ❓ Unknown | — |
-
-### Comparison Functions and Operators
-
-| Operator | MySQL Compat | Notes |
-|---|---|---|
-| [<=>](./Operators/comparison-functions-and-operators/null-safe-equal.md) | ✅ Full | — |
-| [assign-equal](./Operators/comparison-functions-and-operators/assign-equal.md) | ❓ Unknown | — |
-| [between](./Operators/comparison-functions-and-operators/between.md) | ❓ Unknown | — |
-| [coalesce](./Operators/comparison-functions-and-operators/coalesce.md) | ❓ Unknown | — |
-| [comparison-functions-and-operators-overview](./Operators/comparison-functions-and-operators/comparison-functions-and-operators-overview.md) | ❓ Unknown | — |
-| [function_interval](./Operators/comparison-functions-and-operators/function_interval.md) | ❓ Unknown | — |
-| [function_isnull](./Operators/comparison-functions-and-operators/function_isnull.md) | ❓ Unknown | — |
-| [function_least](./Operators/comparison-functions-and-operators/function_least.md) | ❓ Unknown | — |
-| [function_strcmp](./Operators/comparison-functions-and-operators/function_strcmp.md) | ❓ Unknown | — |
-| [greater-than](./Operators/comparison-functions-and-operators/greater-than.md) | ❓ Unknown | — |
-| [greater-than-or-equal](./Operators/comparison-functions-and-operators/greater-than-or-equal.md) | ❓ Unknown | — |
-| [ilike](./Operators/comparison-functions-and-operators/ilike.md) | ❓ Unknown | — |
-| [in](./Operators/comparison-functions-and-operators/in.md) | ❓ Unknown | — |
-| [is](./Operators/comparison-functions-and-operators/is.md) | ❓ Unknown | — |
-| [is-not](./Operators/comparison-functions-and-operators/is-not.md) | ❓ Unknown | — |
-| [is-not-null](./Operators/comparison-functions-and-operators/is-not-null.md) | ❓ Unknown | — |
-| [is-null](./Operators/comparison-functions-and-operators/is-null.md) | ❓ Unknown | — |
-| [less-than](./Operators/comparison-functions-and-operators/less-than.md) | ❓ Unknown | — |
-| [less-than-or-equal](./Operators/comparison-functions-and-operators/less-than-or-equal.md) | ❓ Unknown | — |
-| [like](./Operators/comparison-functions-and-operators/like.md) | ❓ Unknown | — |
-| [not-between](./Operators/comparison-functions-and-operators/not-between.md) | ❓ Unknown | — |
-| [not-equal](./Operators/comparison-functions-and-operators/not-equal.md) | ❓ Unknown | — |
-| [not-in](./Operators/comparison-functions-and-operators/not-in.md) | ❓ Unknown | — |
-| [not-like](./Operators/comparison-functions-and-operators/not-like.md) | ❓ Unknown | — |
-
-### Flow Control Functions
-
-| Operator | MySQL Compat | Notes |
-|---|---|---|
-| [case-when](./Operators/flow-control-functions/case-when.md) | ❓ Unknown | — |
-| [flow-control-functions-overview](./Operators/flow-control-functions/flow-control-functions-overview.md) | ❓ Unknown | — |
-| [function_if](./Operators/flow-control-functions/function_if.md) | ❓ Unknown | — |
-| [function_ifnull](./Operators/flow-control-functions/function_ifnull.md) | ❓ Unknown | — |
-| [function_nullif](./Operators/flow-control-functions/function_nullif.md) | ❓ Unknown | — |
-
-### Logical Operators
-
-| Operator | MySQL Compat | Notes |
-|---|---|---|
-| [and](./Operators/logical-operators/and.md) | ❓ Unknown | — |
-| [logical-operators-overview](./Operators/logical-operators/logical-operators-overview.md) | ❓ Unknown | — |
-| [not](./Operators/logical-operators/not.md) | ❓ Unknown | — |
-| [or](./Operators/logical-operators/or.md) | ❓ Unknown | — |
-| [xor](./Operators/logical-operators/xor.md) | ❓ Unknown | — |
+| [<=>](./Operators/operators/comparison-functions-and-operators/null-safe-equal.md) | ✅ Full | — |
+| [addition](./Operators/operators/arithmetic-operators/addition.md) | ❓ Unknown | — |
+| [and](./Operators/operators/logical-operators/and.md) | ❓ Unknown | — |
+| [arithmetic-operators-overview](./Operators/operators/arithmetic-operators/arithmetic-operators-overview.md) | ❓ Unknown | — |
+| [assign-equal](./Operators/operators/comparison-functions-and-operators/assign-equal.md) | ❓ Unknown | — |
+| [assignment-operators-overview](./Operators/operators/assignment-operators/assignment-operators-overview.md) | ❓ Unknown | — |
+| [between](./Operators/operators/comparison-functions-and-operators/between.md) | ❓ Unknown | — |
+| [binary](./Operators/operators/cast-functions-and-operators/binary.md) | ❓ Unknown | — |
+| [bit-functions-and-operators-overview](./Operators/operators/bit-functions-and-operators/bit-functions-and-operators-overview.md) | ❓ Unknown | — |
+| [bitwise-and](./Operators/operators/bit-functions-and-operators/bitwise-and.md) | ❓ Unknown | — |
+| [bitwise-inversion](./Operators/operators/bit-functions-and-operators/bitwise-inversion.md) | ❓ Unknown | — |
+| [bitwise-or](./Operators/operators/bit-functions-and-operators/bitwise-or.md) | ❓ Unknown | — |
+| [bitwise-xor](./Operators/operators/bit-functions-and-operators/bitwise-xor.md) | ❓ Unknown | — |
+| [case-when](./Operators/operators/flow-control-functions/case-when.md) | ❓ Unknown | — |
+| [cast](./Operators/operators/cast-functions-and-operators/cast.md) | ❓ Unknown | — |
+| [cast-functions-and-operators-overview](./Operators/operators/cast-functions-and-operators/cast-functions-and-operators-overview.md) | ❓ Unknown | — |
+| [coalesce](./Operators/operators/comparison-functions-and-operators/coalesce.md) | ❓ Unknown | — |
+| [comparison-functions-and-operators-overview](./Operators/operators/comparison-functions-and-operators/comparison-functions-and-operators-overview.md) | ❓ Unknown | — |
+| [convert](./Operators/operators/cast-functions-and-operators/convert.md) | ❓ Unknown | — |
+| [decode](./Operators/operators/cast-functions-and-operators/decode.md) | ❓ Unknown | — |
+| [div](./Operators/operators/arithmetic-operators/div.md) | ❓ Unknown | — |
+| [division](./Operators/operators/arithmetic-operators/division.md) | ❓ Unknown | — |
+| [encode](./Operators/operators/cast-functions-and-operators/encode.md) | ❓ Unknown | — |
+| [equal](./Operators/operators/assignment-operators/equal.md) | ❓ Unknown | — |
+| [flow-control-functions-overview](./Operators/operators/flow-control-functions/flow-control-functions-overview.md) | ❓ Unknown | — |
+| [function_if](./Operators/operators/flow-control-functions/function_if.md) | ❓ Unknown | — |
+| [function_ifnull](./Operators/operators/flow-control-functions/function_ifnull.md) | ❓ Unknown | — |
+| [function_interval](./Operators/operators/comparison-functions-and-operators/function_interval.md) | ❓ Unknown | — |
+| [function_isnull](./Operators/operators/comparison-functions-and-operators/function_isnull.md) | ❓ Unknown | — |
+| [function_least](./Operators/operators/comparison-functions-and-operators/function_least.md) | ❓ Unknown | — |
+| [function_nullif](./Operators/operators/flow-control-functions/function_nullif.md) | ❓ Unknown | — |
+| [function_strcmp](./Operators/operators/comparison-functions-and-operators/function_strcmp.md) | ❓ Unknown | — |
+| [greater-than](./Operators/operators/comparison-functions-and-operators/greater-than.md) | ❓ Unknown | — |
+| [greater-than-or-equal](./Operators/operators/comparison-functions-and-operators/greater-than-or-equal.md) | ❓ Unknown | — |
+| [ilike](./Operators/operators/comparison-functions-and-operators/ilike.md) | ❓ Unknown | — |
+| [in](./Operators/operators/comparison-functions-and-operators/in.md) | ❓ Unknown | — |
+| [is](./Operators/operators/comparison-functions-and-operators/is.md) | ❓ Unknown | — |
+| [is-not](./Operators/operators/comparison-functions-and-operators/is-not.md) | ❓ Unknown | — |
+| [is-not-null](./Operators/operators/comparison-functions-and-operators/is-not-null.md) | ❓ Unknown | — |
+| [is-null](./Operators/operators/comparison-functions-and-operators/is-null.md) | ❓ Unknown | — |
+| [left-shift](./Operators/operators/bit-functions-and-operators/left-shift.md) | ❓ Unknown | — |
+| [less-than](./Operators/operators/comparison-functions-and-operators/less-than.md) | ❓ Unknown | — |
+| [less-than-or-equal](./Operators/operators/comparison-functions-and-operators/less-than-or-equal.md) | ❓ Unknown | — |
+| [like](./Operators/operators/comparison-functions-and-operators/like.md) | ❓ Unknown | — |
+| [logical-operators-overview](./Operators/operators/logical-operators/logical-operators-overview.md) | ❓ Unknown | — |
+| [minus](./Operators/operators/arithmetic-operators/minus.md) | ❓ Unknown | — |
+| [mod](./Operators/operators/arithmetic-operators/mod.md) | ❓ Unknown | — |
+| [multiplication](./Operators/operators/arithmetic-operators/multiplication.md) | ❓ Unknown | — |
+| [not](./Operators/operators/logical-operators/not.md) | ❓ Unknown | — |
+| [not-between](./Operators/operators/comparison-functions-and-operators/not-between.md) | ❓ Unknown | — |
+| [not-equal](./Operators/operators/comparison-functions-and-operators/not-equal.md) | ❓ Unknown | — |
+| [not-in](./Operators/operators/comparison-functions-and-operators/not-in.md) | ❓ Unknown | — |
+| [not-like](./Operators/operators/comparison-functions-and-operators/not-like.md) | ❓ Unknown | — |
+| [operator-precedence](./Operators/operators/operator-precedence.md) | ❓ Unknown | — |
+| [operators](./Operators/operators/operators.md) | ❓ Unknown | — |
+| [or](./Operators/operators/logical-operators/or.md) | ❓ Unknown | — |
+| [right-shift](./Operators/operators/bit-functions-and-operators/right-shift.md) | ❓ Unknown | — |
+| [serial](./Operators/operators/cast-functions-and-operators/serial.md) | ❓ Unknown | — |
+| [serial_full](./Operators/operators/cast-functions-and-operators/serial_full.md) | ❓ Unknown | — |
+| [unary-minus](./Operators/operators/arithmetic-operators/unary-minus.md) | ❓ Unknown | — |
+| [xor](./Operators/operators/logical-operators/xor.md) | ❓ Unknown | — |
 
 ## Data Types
 

--- a/scripts/generate-compat-matrix.js
+++ b/scripts/generate-compat-matrix.js
@@ -71,19 +71,11 @@ function categoryOf(relPath) {
   return parts[0]
 }
 
-function cleanRelPath(sourceDir, relPath) {
-  if (sourceDir === 'Operators') {
-    const parts = relPath.split('/')
-    if (parts[0] === 'operators') return parts.slice(1).join('/')
-  }
-  return relPath
-}
-
 /** Derive a stable machine-readable ID from a source-relative path. */
 function entryId(sourceDir, relPath) {
   const prefix = SOURCE_ID_PREFIX[sourceDir] || sourceDir.toLowerCase()
   // Strip .md, replace path separators and dashes with dots
-  const slug = cleanRelPath(sourceDir, relPath)
+  const slug = relPath
     .replace(/\.md$/, '')
     .replace(/[\/\\]/g, '.')
     .replace(/-/g, '_')
@@ -158,7 +150,7 @@ async function scanSource(sourceDir) {
     const rel = path.relative(sourceRoot, file)
     const raw = readFileSync(file, 'utf-8')
     const fm = parseFrontmatter(raw) || {}
-    const displayRel = cleanRelPath(sourceDir, rel)
+    const displayRel = rel
     rows.push({
       file,
       rel: displayRel,


### PR DESCRIPTION
Remove cleanRelPath() that incorrectly stripped the operators/ path prefix. Fixes CI dead-link errors.