### PR TITLE
refactor: move MySQL Compatibility Matrix to Reference top level

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -311,6 +311,7 @@ nav:
           - Data Transmission Encryption: MatrixOne/Security/TLS-introduction.md
           - Security Audit: MatrixOne/Security/audit.md
       - Reference:
+          - MySQL Compatibility Matrix: MatrixOne/Reference/mysql-compatibility-matrix.md
           - System Variables:
               - System Variables Overview: MatrixOne/Reference/Variable/system-variables/system-variables-overview.md
               - System Variables parameters:
@@ -344,7 +345,6 @@ nav:
               - Fixed-Point Types (Exact Value) - DECIMAL: MatrixOne/Reference/Data-Types/fixed-point-types.md
           - SQL Statements:
               - Type of SQL Statements: MatrixOne/Reference/SQL-Reference/SQL-Type.md
-              - MySQL Compatibility Matrix: MatrixOne/Reference/mysql-compatibility-matrix.md
               - Data Definition Language:
                   - CREATE DATABASE: MatrixOne/Reference/SQL-Reference/Data-Definition-Language/create-database.md
                   - CREATE INDEX: MatrixOne/Reference/SQL-Reference/Data-Definition-Language/create-index.md


### PR DESCRIPTION
Move the compat matrix page from SQL Statements sub-menu to a top-level Reference entry.