### PR TITLE
fix: replace em dash with hyphen in agent_delivery.py to prevent encoding issues

### DIFF
--- a/docs/MatrixOne/Contribution-Guide/How-to-Contribute/preparation.md
+++ b/docs/MatrixOne/Contribution-Guide/How-to-Contribute/preparation.md
@@ -16,7 +16,7 @@ These introductions will help you go through you the key concepts and user detai
 
 ### Roadmap
 
-MatrixOne v26.3.0.13 has been released, you can see [Release Notes](../../Release-Notes/v26.3.0.13.md) know more information.
+MatrixOne v26.3.0.14 has been released, you can see [Release Notes](../../Release-Notes/v26.3.0.14.md) know more information.
 
 For the long-term project roadmap, please refer to [MatrixOne roadmap](https://github.com/matrixorigin/matrixone/issues/613) for a more general overview.
 

--- a/docs/MatrixOne/Deploy/deploy-MatrixOne-cluster.md
+++ b/docs/MatrixOne/Deploy/deploy-MatrixOne-cluster.md
@@ -648,7 +648,7 @@ mysql -h $(kubectl get svc/mo-tp-cn -n mo-hn -o jsonpath='{.spec.clusterIP}') -P
 mysql: [Warning] Using a password on the command line interface can be insecure.
 Welcome to the MySQL monitor.  Commands end with ; or \g.
 Your MySQL connection id is 163
-Server version: 8.0.30-MatrixOne-v3.0.13 MatrixOne
+Server version: 8.0.30-MatrixOne-v3.0.14 MatrixOne
 
 Copyright (c) 2000, 2023, Oracle and/or its affiliates.
 

--- a/docs/MatrixOne/Deploy/deploy-matrixone-single-with-s3.md
+++ b/docs/MatrixOne/Deploy/deploy-matrixone-single-with-s3.md
@@ -289,7 +289,7 @@ github@shpc2-10-222-1-9:/data/mo/main/matrixone/etc/launch$ mo_ctl connect
 2024-08-26 17:44:10.207 UTC+0800    [INFO]    Ok, connecting for user ... 
 Welcome to the MySQL monitor.  Commands end with ; or \g.
 Your MySQL connection id is 10
-Server version: 8.0.30-MatrixOne-v3.0.13 MatrixOne
+Server version: 8.0.30-MatrixOne-v3.0.14 MatrixOne
 
 Copyright (c) 2000, 2024, Oracle and/or its affiliates.
 
@@ -613,7 +613,7 @@ github@VM-32-6-debian:/data/mo/main$ mo_ctl connect
 2024-08-26 18:38:31.124 UTC+0800    [INFO]    Ok, connecting for user ... 
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MySQL connection id is 3
-Server version: 8.0.30-MatrixOne-v3.0.13 MatrixOne
+Server version: 8.0.30-MatrixOne-v3.0.14 MatrixOne
 
 Copyright (c) 2000, 2018, Oracle, MariaDB Corporation Ab and others.
 
@@ -736,7 +736,7 @@ cnservices = [
 
 ```bash
 #Configure cn.toml, tn.toml and log.toml first.
-mo_ctl set_conf MO_CONTAINER_IMAGE=matrixorigin/matrixone/3.0.13 #Setting up mirroring
+mo_ctl set_conf MO_CONTAINER_IMAGE=matrixorigin/matrixone/3.0.14 #Setting up mirroring
 mo_ctl set_conf MO_CONTAINER_NAME=mo # Setting the container name
 mo_ctl set_conf MO_CONTAINER_CONF_HOST_PATH=/data/mo_confs/ # Set the directory on the host machine where the mo configuration file is stored
 mo_ctl set_conf MO_CONTAINER_CONF_CON_FILE="/etc/launch.toml" # Set the path to the configuration file inside the container when the container starts up

--- a/docs/MatrixOne/Deploy/update-MatrixOne-cluster.md
+++ b/docs/MatrixOne/Deploy/update-MatrixOne-cluster.md
@@ -69,7 +69,7 @@ According to the introduction in [MatrixOne Distributed Cluster Deployment](depl
     root@master0 ~]# mysql -h $(kubectl get svc/mo-tp-cn -n mo-hn -o jsonpath='{.spec.clusterIP}') -P 6001 -uroot -p111
     Welcome to the MariaDB monitor.  Commands end with ; or \g.
     Your MySQL connection id is 1005
-    Server version: 8.0.30-MatrixOne-v3.0.13 MatrixOne
+    Server version: 8.0.30-MatrixOne-v3.0.14 MatrixOne
 
     Copyright (c) 2000, 2018, Oracle, MariaDB Corporation Ab and others.
 

--- a/docs/MatrixOne/Develop/connect-mo/configure-mo-ssl-connection.md
+++ b/docs/MatrixOne/Develop/connect-mo/configure-mo-ssl-connection.md
@@ -83,7 +83,7 @@ To test the SSL configuration, perform the following steps:
     Current pager:		stdout
     Using outfile:		''
     Using delimiter:	;
-    Server version:		8.0.30-MatrixOne-v3.0.13 MatrixOne
+    Server version:		8.0.30-MatrixOne-v3.0.14 MatrixOne
     Protocol version:	10
     Connection:		127.0.0.1 via TCP/IP
     Client characterset:	utf8mb4

--- a/docs/MatrixOne/Develop/connect-mo/database-client-tools.md
+++ b/docs/MatrixOne/Develop/connect-mo/database-client-tools.md
@@ -41,7 +41,7 @@ Make sure you have already [installed and launched MatrixOne](../../Get-Started/
 
     ```
     Welcome to the MySQL monitor. Commands end with ; or \g. Your MySQL connection id is 1031
-    Server version: 8.0.30-MatrixOne-v3.0.13 MatrixOne
+    Server version: 8.0.30-MatrixOne-v3.0.14 MatrixOne
     Copyright (c) 2000, 2022, Oracle and/or its affiliates.
 
     Oracle is a registered trademark of Oracle Corporation and/or its affiliates. Other names may be trademarks of their respective owners.

--- a/docs/MatrixOne/Develop/connect-mo/python-connect-to-matrixone.md
+++ b/docs/MatrixOne/Develop/connect-mo/python-connect-to-matrixone.md
@@ -69,7 +69,7 @@ The PyMySQL is a pure-Python MySQL client library.
 
     ```
     > python3 pymysql_connect_matrixone.py
-    Database version : 8.0.30-MatrixOne-v3.0.13
+    Database version : 8.0.30-MatrixOne-v3.0.14
     ```
 
 ## Using sqlalchemy connect to MatrixOne

--- a/docs/MatrixOne/Develop/export-data/select-into-outfile.md
+++ b/docs/MatrixOne/Develop/export-data/select-into-outfile.md
@@ -54,7 +54,7 @@ mysql> SELECT * FROM TEST INTO OUTFILE '/root/test.csv'
     If you installed MatrixOne via `docker`, the export directory is located in the docker image by default. If you need to mount a local directory, see the following code example: the local file system path *${local_data_path}/mo-data*is mounted into the MatrixOne Docker image and mapped to the */mo-data*path. For more information, see the [Docker Mount Volume tutorial](https://www.freecodecamp.org/news/docker-mount-volume-guide-how-to-mount-a-local-directory/).
 
 ```
-sudo docker run --name <name> --privileged -d -p 6001:6001 -v ${local_data_path}/mo-data:/mo-data:rw matrixorigin/matrixone:3.0.13
+sudo docker run --name <name> --privileged -d -p 6001:6001 -v ${local_data_path}/mo-data:/mo-data:rw matrixorigin/matrixone:3.0.14
 ```
 
 ### Steps

--- a/docs/MatrixOne/Develop/import-data/bulk-load/load-csv.md
+++ b/docs/MatrixOne/Develop/import-data/bulk-load/load-csv.md
@@ -104,7 +104,7 @@ __Note__: A `csv`(comma-separated values) file is a delimited text file that use
 ### Example using `Load data` with `docker` version
 
 If you install MatrixOne by `docker`, the file system is inside the docker image by default. To work with local directory, you need to bind a local directory to the container. In the following example, the local file system path `~/tmp/docker_loaddata_demo/` is binded to the MatrixOne docker image, with a mapping to the `/ssb-dbgen-path` path inside the docker.
-We will walk you through the whole process of loading data with MatrixOne 3.0.13 docker version in this example.
+We will walk you through the whole process of loading data with MatrixOne 3.0.14 docker version in this example.
 
 1. Download the dataset file and store the data in *~/tmp/docker_loaddata_demo/*:
 
@@ -122,7 +122,7 @@ We will walk you through the whole process of loading data with MatrixOne 3.0.13
 3. Use Docker to launch MatrixOne, and mount the directory *~/tmp/docker_loaddata_demo/* that stores data files to a directory in the container. The container directory is */sb-dbgen-path* as an example:
 
     ```
-    sudo docker run --name matrixone --privileged -d -p 6001:6001 -v ~/tmp/docker_loaddata_demo/:/ssb-dbgen-path:rw matrixorigin/matrixone:3.0.13
+    sudo docker run --name matrixone --privileged -d -p 6001:6001 -v ~/tmp/docker_loaddata_demo/:/ssb-dbgen-path:rw matrixorigin/matrixone:3.0.14
     ```
 
 4. Connect to MatrixOne server:

--- a/docs/MatrixOne/Develop/import-data/bulk-load/using-source.md
+++ b/docs/MatrixOne/Develop/import-data/bulk-load/using-source.md
@@ -66,6 +66,6 @@ select * from tool;
 
 ## Constraints
 
-MatrixOne v26.3.0.13 version already supports MySQL table creation statements, so you can smoothly migrate MySQL tables to MatrixOne. However, it should be noted that during the migration process, some keywords incompatible with MySQL, such as `engine=`, will be automatically ignored in MatrixOne and will not affect the migration of the table structure.
+MatrixOne v26.3.0.14 version already supports MySQL table creation statements, so you can smoothly migrate MySQL tables to MatrixOne. However, it should be noted that during the migration process, some keywords incompatible with MySQL, such as `engine=`, will be automatically ignored in MatrixOne and will not affect the migration of the table structure.
 
 However, it should be noted that although MatrixOne supports MySQL table creation statements, manual modification is still required if the migrated table contains incompatible data types, triggers, functions, or stored procedures. For more detailed compatibility information, see [MySQL Compatibility](../../../Overview/feature/mysql-compatibility.md).

--- a/docs/MatrixOne/FAQs/product-faqs.md
+++ b/docs/MatrixOne/FAQs/product-faqs.md
@@ -29,7 +29,7 @@ Both MatrixOne 0.8.0 and above can be upgraded directly from a lower version to 
 
 Is MatrixOne stable **now? Which version is recommended?**
 
-MatrixOne is now available in version v26.3.0.13. We've done a lot of optimization work on stability, and it's ready to be used in the production business.
+MatrixOne is now available in version v26.3.0.14. We've done a lot of optimization work on stability, and it's ready to be used in the production business.
 
 **Is there a cloud version of MatrixOne? Want a quick test to see**.
 

--- a/docs/MatrixOne/Get-Started/install-on-linux/install-on-linux-method1.md
+++ b/docs/MatrixOne/Get-Started/install-on-linux/install-on-linux-method1.md
@@ -184,7 +184,7 @@ GCC_VERSION="8.5.0"
 CLANG_VERSION="13.0"
 GO_VERSION="1.22"
 MO_GIT_URL="https://github.com/matrixorigin/matrixone.git"
-MO_DEFAULT_VERSION="v3.0.13"
+MO_DEFAULT_VERSION="v3.0.14"
 GOPROXY="https://goproxy.cn,direct"
 STOP_INTERVAL="5"
 START_INTERVAL="2"
@@ -200,7 +200,7 @@ Generally, the parameters that need to be adjusted are as follows:
 ````
 mo_ctl set_conf MO_PATH="yourpath" # Set custom MatrixOne download path
 mo_ctl set_conf MO_GIT_URL="https://githubfast.com/matrixorigin/matrixone.git" # For the problem of slow downloading from the original GitHub address, set image download address
-mo_ctl set_conf MO_DEFAULT_VERSION="v3.0.13" # Set the version of MatrixOne downloaded
+mo_ctl set_conf MO_DEFAULT_VERSION="v3.0.14" # Set the version of MatrixOne downloaded
 mo_ctl set_conf MO_DEPLOY_MODE=git  # Deployment Configuration
 ````
 
@@ -219,7 +219,7 @@ Depending on your needs, choose whether you want to keep your code up to date, o
 === "Get the MatrixOne(Stable Version) code to build"
 
      ```
-     mo_ctl deploy v3.0.13
+     mo_ctl deploy v3.0.14
      ```
 
 ## Step 4: Launch MatrixOne server
@@ -256,7 +256,7 @@ root@VM-16-2-debian:~# mo_ctl connect
 mysql: [Warning] Using a password on the command line interface can be insecure.
 Welcome to the MySQL monitor.  Commands end with ; or \g.
 Your MySQL connection id is 15
-Server version: 8.0.30-MatrixOne-v3.0.13 MatrixOne
+Server version: 8.0.30-MatrixOne-v3.0.14 MatrixOne
 
 Copyright (c) 2000, 2023, Oracle and/or its affiliates.
 

--- a/docs/MatrixOne/Get-Started/install-on-linux/install-on-linux-method2.md
+++ b/docs/MatrixOne/Get-Started/install-on-linux/install-on-linux-method2.md
@@ -96,16 +96,16 @@ The Debian11.1 version does not have MySQL Client installed by default, so it ne
 
      ```bash
      mkdir -p /root/matrixone & cd /root/
-     wget https://github.com/matrixorigin/matrixone/releases/download/v3.0.13/mo-v3.0.13-linux-x86_64.zip
-     unzip -d matrixone/ mo-v3.0.13-linux-x86_64.zip
+     wget https://github.com/matrixorigin/matrixone/releases/download/v3.0.14/mo-v3.0.14-linux-x86_64.zip
+     unzip -d matrixone/ mo-v3.0.14-linux-x86_64.zip
      ```
 
      Binary for ARM architecture system:
 
      ```bash
      mkdir -p /root/matrixone & cd /root/
-     wget https://github.com/matrixorigin/matrixone/releases/download/v3.0.13/mo-v3.0.13-linux-arm64.zip
-     unzip -d matrixone/ mo-v3.0.13-linux-arm64.zip
+     wget https://github.com/matrixorigin/matrixone/releases/download/v3.0.14/mo-v3.0.14-linux-arm64.zip
+     unzip -d matrixone/ mo-v3.0.14-linux-arm64.zip
      ```
 
 === "**Downloading method 2: Using `curl` to install binary packages**"
@@ -114,21 +114,21 @@ The Debian11.1 version does not have MySQL Client installed by default, so it ne
 
      ```bash
      mkdir -p /root/matrixone & cd /root/
-     curl -OL https://github.com/matrixorigin/matrixone/releases/download/v3.0.13/mo-v3.0.13-linux-x86_64.zip
-     unzip -d matrixone/ mo-v3.0.13-linux-x86_64.zip
+     curl -OL https://github.com/matrixorigin/matrixone/releases/download/v3.0.14/mo-v3.0.14-linux-x86_64.zip
+     unzip -d matrixone/ mo-v3.0.14-linux-x86_64.zip
      ```
 
      Binary for ARM architecture system:
 
      ```bash
      mkdir -p /root/matrixone & cd /root/
-     curl -OL https://github.com/matrixorigin/matrixone/releases/download/v3.0.13/mo-v3.0.13-linux-arm64.zip
-     unzip -d matrixone/ mo-v3.0.13-linux-arm64.zip
+     curl -OL https://github.com/matrixorigin/matrixone/releases/download/v3.0.14/mo-v3.0.14-linux-arm64.zip
+     unzip -d matrixone/ mo-v3.0.14-linux-arm64.zip
      ```
 
 === "**Downloading method 3: Go to the page and download**"
 
-     If you want a more intuitive way to download the page, go to the [version 3.0.13](https://github.com/matrixorigin/matrixone/releases/tag/v3.0.13), pull down to find the **Assets** column, and click the installation package *mo-v3.0.13-linux-x86_64.zip* or *mo-v3.0.13-linux-arm64.zip* can be downloaded.
+     If you want a more intuitive way to download the page, go to the [version 3.0.14](https://github.com/matrixorigin/matrixone/releases/tag/v3.0.14), pull down to find the **Assets** column, and click the installation package *mo-v3.0.14-linux-x86_64.zip* or *mo-v3.0.14-linux-arm64.zip* can be downloaded.
 
 ## Step 3: Install the mo_ctl tool
 
@@ -147,8 +147,8 @@ wget https://raw.githubusercontent.com/matrixorigin/mo_ctl_standalone/main/insta
 The parameters that need to be adjusted are as follows:
 
 ````
-mo_ctl set_conf MO_PATH="/yourpath/mo-v3.0.13-xx-xx" # Set the MO_PATH to the directory where the binary files are extracted
-mo_ctl set_conf MO_CONF_FILE="/yourpath/mo-v3.0.13-xx-xx/etc/launch/launch.toml" # Set the MO_CONF_FILE path
+mo_ctl set_conf MO_PATH="/yourpath/mo-v3.0.14-xx-xx" # Set the MO_PATH to the directory where the binary files are extracted
+mo_ctl set_conf MO_CONF_FILE="/yourpath/mo-v3.0.14-xx-xx/etc/launch/launch.toml" # Set the MO_CONF_FILE path
 mo_ctl set_conf MO_DEPLOY_MODE=binary  #Deployment Configuration
 ````
 
@@ -156,17 +156,17 @@ mo_ctl set_conf MO_DEPLOY_MODE=binary  #Deployment Configuration
 
 Launch the MatrixOne service through the `mo_ctl start` command.
 
-If the operation is regular, the following log will appear. The relevant operation logs of MatrixOne will be in `/yourpath/mo-v3.0.13-xx-xx/matrixone/logs/`.
+If the operation is regular, the following log will appear. The relevant operation logs of MatrixOne will be in `/yourpath/mo-v3.0.14-xx-xx/matrixone/logs/`.
 
 ```
 root@VM-16-2-debian:~# mo_ctl start
 2024-03-07 14:34:04.942 UTC+0800    [INFO]    No mo-service is running
 2024-03-07 14:34:04.998 UTC+0800    [INFO]    Get conf succeeded: MO_DEPLOY_MODE="binary"
 2024-03-07 14:34:05.024 UTC+0800    [INFO]    GO memory limit(Mi): 14745
-2024-03-07 14:34:05.072 UTC+0800    [INFO]    Starting mo-service: cd /Users/admin/mo-v3.0.13-linux-arm64/ && GOMEMLIMIT=14745MiB /Users/admin/mo-v3.0.13-linux-arm64/mo-service -daemon -debug-http :9876 -launch /Users/admin/mo-v3.0.13-linux-arm64/etc/launch/launch.toml >/Users/admin/mo-v3.0.13-linux-arm64/matrixone/logs/stdout-20240307_143405.log 2>/Users/admin/mo-v3.0.13-linux-arm64/matrixone/logs/stderr-20240307_143405.log
+2024-03-07 14:34:05.072 UTC+0800    [INFO]    Starting mo-service: cd /Users/admin/mo-v3.0.14-linux-arm64/ && GOMEMLIMIT=14745MiB /Users/admin/mo-v3.0.14-linux-arm64/mo-service -daemon -debug-http :9876 -launch /Users/admin/mo-v3.0.14-linux-arm64/etc/launch/launch.toml >/Users/admin/mo-v3.0.14-linux-arm64/matrixone/logs/stdout-20240307_143405.log 2>/Users/admin/mo-v3.0.14-linux-arm64/matrixone/logs/stderr-20240307_143405.log
 2024-03-07 14:34:05.137 UTC+0800    [INFO]    Wait for 2 seconds
 2024-03-07 14:34:07.261 UTC+0800    [INFO]    At least one mo-service is running. Process info: 
-  501 27145     1   0  2:34下午 ??         0:00.18 /Users/admin/mo-v3.0.13-linux-arm64/mo-service -daemon -debug-http :9876 -launch /Users/admin/mo-v3.0.13-linux-arm64/etc/launch/launch.toml
+  501 27145     1   0  2:34下午 ??         0:00.18 /Users/admin/mo-v3.0.14-linux-arm64/mo-service -daemon -debug-http :9876 -launch /Users/admin/mo-v3.0.14-linux-arm64/etc/launch/launch.toml
 2024-03-07 14:34:07.284 UTC+0800    [INFO]    List of pid(s): 
 27145
 2024-03-07 14:34:07.308 UTC+0800    [INFO]    Start succeeded
@@ -188,7 +188,7 @@ root@VM-16-2-debian:~# mo_ctl connect
 2024-03-07 14:34:59.942 UTC+0800    [INFO]    Ok, connecting for user ... 
 Welcome to the MySQL monitor.  Commands end with ; or \g.
 Your MySQL connection id is 426
-Server version: 8.0.30-MatrixOne-v3.0.13 MatrixOne
+Server version: 8.0.30-MatrixOne-v3.0.14 MatrixOne
 
 Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
 

--- a/docs/MatrixOne/Get-Started/install-on-linux/install-on-linux-method3.md
+++ b/docs/MatrixOne/Get-Started/install-on-linux/install-on-linux-method3.md
@@ -67,18 +67,18 @@ Create and run the container of MatrixOne
 
 It will pull the image from Docker Hub if not exists. You can choose to pull the stable version image or the develop version image.
 
-=== "Stable Version Image(3.0.13 version)"
+=== "Stable Version Image(3.0.14 version)"
 
       ```bash
-      docker pull matrixorigin/matrixone:3.0.13
-      docker run -d -p 6001:6001 --name matrixone matrixorigin/matrixone:3.0.13
+      docker pull matrixorigin/matrixone:3.0.14
+      docker run -d -p 6001:6001 --name matrixone matrixorigin/matrixone:3.0.14
       ```
 
       If you are using the network in mainland China, you can pull the MatrixOne stable version image on Alibaba Cloud:
 
       ```bash
-      docker pull registry.cn-shanghai.aliyuncs.com/matrixorigin/matrixone:3.0.13
-      docker run -d -p 6001:6001 --name matrixone registry.cn-shanghai.aliyuncs.com/matrixorigin/matrixone:3.0.13
+      docker pull registry.cn-shanghai.aliyuncs.com/matrixorigin/matrixone:3.0.14
+      docker run -d -p 6001:6001 --name matrixone registry.cn-shanghai.aliyuncs.com/matrixorigin/matrixone:3.0.14
       ```
 
 === "Develop Version Image"
@@ -102,7 +102,7 @@ It will pull the image from Docker Hub if not exists. You can choose to pull the
 If your Docker version is lower than 20.10.18 or the Docker client and server versions are inconsistent, upgrading to the latest stable version before attempting is recommended. If you choose to proceed with the current versions, you need to add the parameter `--privileged=true` to the `docker run` command, as shown below:
 
 ```bash
-docker run -d -p 6001:6001 --name matrixone --privileged=true matrixorigin/matrixone:3.0.13
+docker run -d -p 6001:6001 --name matrixone --privileged=true matrixorigin/matrixone:3.0.14
 ```
 
 !!! note
@@ -128,7 +128,7 @@ The parameters that need to be adjusted are as follows:
 
 ```
 mo_ctl set_conf MO_CONTAINER_DATA_HOST_PATH="/yourpath/mo/" # Set the data directory for host
-mo_ctl set_conf MO_CONTAINER_IMAGE="matrixorigin/matrixone:3.0.13" # Set image
+mo_ctl set_conf MO_CONTAINER_IMAGE="matrixorigin/matrixone:3.0.14" # Set image
 mo_ctl set_conf MO_DEPLOY_MODE=docker # Deployment Configuration
 ```
 
@@ -160,7 +160,7 @@ Depending on your needs, choose whether you want to keep your code up to date, o
 === "Get the MatrixOne(Stable Version) code to build"
 
      ```
-     mo_ctl deploy v3.0.13
+     mo_ctl deploy v3.0.14
      ```
 
 - Launch MatrixOne server
@@ -198,7 +198,7 @@ root@VM-16-2-debian:~# mo_ctl connect
 mysql: [Warning] Using a password on the command line interface can be insecure.
 Welcome to the MySQL monitor.  Commands end with ; or \g.
 Your MySQL connection id is 15
-Server version: 8.0.30-MatrixOne-v3.0.13 MatrixOne
+Server version: 8.0.30-MatrixOne-v3.0.14 MatrixOne
 
 Copyright (c) 2000, 2023, Oracle and/or its affiliates.
 

--- a/docs/MatrixOne/Get-Started/install-on-macos/install-on-macos-method1.md
+++ b/docs/MatrixOne/Get-Started/install-on-macos/install-on-macos-method1.md
@@ -170,7 +170,7 @@ GCC_VERSION="8.5.0"
 CLANG_VERSION="13.0"
 GO_VERSION="1.22"
 MO_GIT_URL="https://github.com/matrixorigin/matrixone.git"
-MO_DEFAULT_VERSION="v3.0.13"
+MO_DEFAULT_VERSION="v3.0.14"
 GOPROXY="https://goproxy.cn,direct"
 STOP_INTERVAL="5"
 START_INTERVAL="2"
@@ -186,7 +186,7 @@ Generally, the parameters that need to be adjusted are as follows:
 ````
 mo_ctl set_conf MO_PATH="yourpath" # Set custom MatrixOne download path
 mo_ctl set_conf MO_GIT_URL="https://githubfast.com/matrixorigin/matrixone.git" # For the problem of slow downloading from the original GitHub address, set image download address
-mo_ctl set_conf MO_DEFAULT_VERSION="v3.0.13" # Set the version of MatrixOne downloaded
+mo_ctl set_conf MO_DEFAULT_VERSION="v3.0.14" # Set the version of MatrixOne downloaded
 mo_ctl set_conf MO_DEPLOY_MODE=git  # Deployment Configuration
 ````
 
@@ -205,7 +205,7 @@ Depending on your needs, choose whether you want to keep your code up to date, o
 === "Get the MatrixOne(Stable Version) code to build"
 
      ```
-     mo_ctl deploy v3.0.13
+     mo_ctl deploy v3.0.14
      ```
 
 ## Step 4: Launch MatrixOne server
@@ -242,7 +242,7 @@ This command will invoke the MySQL Client tool to connect to the MatrixOne servi
 mysql: [Warning] Using a password on the command line interface can be insecure.
 Welcome to the MySQL monitor.  Commands end with ; or \g.
 Your MySQL connection id is 15
-Server version: 8.0.30-MatrixOne-v3.0.13 MatrixOne
+Server version: 8.0.30-MatrixOne-v3.0.14 MatrixOne
 
 Copyright (c) 2000, 2023, Oracle and/or its affiliates.
 

--- a/docs/MatrixOne/Get-Started/install-on-macos/install-on-macos-method2.md
+++ b/docs/MatrixOne/Get-Started/install-on-macos/install-on-macos-method2.md
@@ -98,16 +98,16 @@ __Tips__: It is recommended that you download and install one of these two tools
 
      ```bash
      mkdir -p /User/username/mo/matrixone & cd /User/username/mo
-     wget https://github.com/matrixorigin/matrixone/releases/download/v3.0.13/mo-v3.0.13-darwin-x86_64.zip
-     unzip -d matrixone/ mo-v3.0.13-darwin-x86_64.zip
+     wget https://github.com/matrixorigin/matrixone/releases/download/v3.0.14/mo-v3.0.14-darwin-x86_64.zip
+     unzip -d matrixone/ mo-v3.0.14-darwin-x86_64.zip
      ```
 
      Binary for ARM architecture system:
 
      ```bash
      mkdir -p /User/username/mo/matrixone & cd /User/username/mo
-     wget https://github.com/matrixorigin/matrixone/releases/download/v3.0.13/mo-v3.0.13-darwin-arm64.zip
-     unzip -d matrixone/ mo-v3.0.13-darwin-arm64.zip
+     wget https://github.com/matrixorigin/matrixone/releases/download/v3.0.14/mo-v3.0.14-darwin-arm64.zip
+     unzip -d matrixone/ mo-v3.0.14-darwin-arm64.zip
      ```
 
 === "**Downloading method 2: Using `curl` to install binary packages**"
@@ -116,21 +116,21 @@ __Tips__: It is recommended that you download and install one of these two tools
 
      ```bash
      mkdir -p /User/username/mo/matrixone & cd /User/username/mo
-     curl -OL https://github.com/matrixorigin/matrixone/releases/download/v3.0.13/mo-v3.0.13-darwin-x86_64.zip
-     unzip -d matrixone/ mo-v3.0.13-darwin-x86_64.zip
+     curl -OL https://github.com/matrixorigin/matrixone/releases/download/v3.0.14/mo-v3.0.14-darwin-x86_64.zip
+     unzip -d matrixone/ mo-v3.0.14-darwin-x86_64.zip
      ```
 
      Binary for ARM architecture system:
 
      ```bash
      mkdir -p /User/username/mo/matrixone & cd /User/username/mo
-     curl -OL https://github.com/matrixorigin/matrixone/releases/download/v3.0.13/mo-v3.0.13-darwin-arm64.zip
-     unzip -d matrixone/ mo-v3.0.13-darwin-arm64.zip
+     curl -OL https://github.com/matrixorigin/matrixone/releases/download/v3.0.14/mo-v3.0.14-darwin-arm64.zip
+     unzip -d matrixone/ mo-v3.0.14-darwin-arm64.zip
      ```
 
 === "**Downloading method 3: Go to the page and download**"
 
-     If you want a more intuitive way to download the page, go to the [version 3.0.13](https://github.com/matrixorigin/matrixone/releases/tag/v3.0.13), pull down to find the **Assets** column, and click the installation package *mo-v3.0.13-darwin-x86_64.zip* or *mo-v3.0.13-darwin-arm64.zip* can be downloaded.
+     If you want a more intuitive way to download the page, go to the [version 3.0.14](https://github.com/matrixorigin/matrixone/releases/tag/v3.0.14), pull down to find the **Assets** column, and click the installation package *mo-v3.0.14-darwin-x86_64.zip* or *mo-v3.0.14-darwin-arm64.zip* can be downloaded.
 
 ## Step 3: Install the mo_ctl tool
 
@@ -149,8 +149,8 @@ wget https://raw.githubusercontent.com/matrixorigin/mo_ctl_standalone/main/insta
 The parameters that need to be adjusted are as follows:
 
 ````
-mo_ctl set_conf MO_PATH="/yourpath/mo-v3.0.13-xx-xx" # Set the MO_PATH to the directory where the binary files are extracted
-mo_ctl set_conf MO_CONF_FILE="/yourpath/mo-v3.0.13-xx-xx/etc/launch/launch.toml" # Set the MO_CONF_FILE path
+mo_ctl set_conf MO_PATH="/yourpath/mo-v3.0.14-xx-xx" # Set the MO_PATH to the directory where the binary files are extracted
+mo_ctl set_conf MO_CONF_FILE="/yourpath/mo-v3.0.14-xx-xx/etc/launch/launch.toml" # Set the MO_CONF_FILE path
 mo_ctl set_conf MO_DEPLOY_MODE=binary  #Deployment Configuration
 ````
 
@@ -158,17 +158,17 @@ mo_ctl set_conf MO_DEPLOY_MODE=binary  #Deployment Configuration
 
 Launch the MatrixOne service through the `mo_ctl start` command.
 
-If the operation is regular, the following log will appear. The relevant operation logs of MatrixOne will be in `/yourpath/mo-v3.0.13-xx-xx/matrixone/logs/ .
+If the operation is regular, the following log will appear. The relevant operation logs of MatrixOne will be in `/yourpath/mo-v3.0.14-xx-xx/matrixone/logs/ .
 
 ```
 > mo_ctl start
 2024-03-07 14:34:04.942 UTC+0800    [INFO]    No mo-service is running
 2024-03-07 14:34:04.998 UTC+0800    [INFO]    Get conf succeeded: MO_DEPLOY_MODE="binary"
 2024-03-07 14:34:05.024 UTC+0800    [INFO]    GO memory limit(Mi): 14745
-2024-03-07 14:34:05.072 UTC+0800    [INFO]    Starting mo-service: cd /Users/admin/mo-v3.0.13-darwin-arm64/ && GOMEMLIMIT=14745MiB /Users/admin/mo-v3.0.13-darwin-arm64/mo-service -daemon -debug-http :9876 -launch /Users/admin/mo-v3.0.13-darwin-arm64/etc/launch/launch.toml >/Users/admin/mo-v3.0.13-darwin-arm64/matrixone/logs/stdout-20240307_143405.log 2>/Users/admin/mo-v3.0.13-darwin-arm64/matrixone/logs/stderr-20240307_143405.log
+2024-03-07 14:34:05.072 UTC+0800    [INFO]    Starting mo-service: cd /Users/admin/mo-v3.0.14-darwin-arm64/ && GOMEMLIMIT=14745MiB /Users/admin/mo-v3.0.14-darwin-arm64/mo-service -daemon -debug-http :9876 -launch /Users/admin/mo-v3.0.14-darwin-arm64/etc/launch/launch.toml >/Users/admin/mo-v3.0.14-darwin-arm64/matrixone/logs/stdout-20240307_143405.log 2>/Users/admin/mo-v3.0.14-darwin-arm64/matrixone/logs/stderr-20240307_143405.log
 2024-03-07 14:34:05.137 UTC+0800    [INFO]    Wait for 2 seconds
 2024-03-07 14:34:07.261 UTC+0800    [INFO]    At least one mo-service is running. Process info: 
-  501 27145     1   0  2:34下午 ??         0:00.18 /Users/admin/mo-v3.0.13-darwin-arm64/mo-service -daemon -debug-http :9876 -launch /Users/admin/mo-v3.0.13-darwin-arm64/etc/launch/launch.toml
+  501 27145     1   0  2:34下午 ??         0:00.18 /Users/admin/mo-v3.0.14-darwin-arm64/mo-service -daemon -debug-http :9876 -launch /Users/admin/mo-v3.0.14-darwin-arm64/etc/launch/launch.toml
 2024-03-07 14:34:07.284 UTC+0800    [INFO]    List of pid(s): 
 27145
 2024-03-07 14:34:07.308 UTC+0800    [INFO]    Start succeeded
@@ -190,7 +190,7 @@ This command will invoke the MySQL Client tool to connect to the MatrixOne servi
 2024-03-07 14:34:59.942 UTC+0800    [INFO]    Ok, connecting for user ... 
 Welcome to the MySQL monitor.  Commands end with ; or \g.
 Your MySQL connection id is 426
-Server version: 8.0.30-MatrixOne-v3.0.13 MatrixOne
+Server version: 8.0.30-MatrixOne-v3.0.14 MatrixOne
 
 Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
 

--- a/docs/MatrixOne/Get-Started/install-on-macos/install-on-macos-method3.md
+++ b/docs/MatrixOne/Get-Started/install-on-macos/install-on-macos-method3.md
@@ -59,18 +59,18 @@ Create and run the container of MatrixOne
 
 It will pull the image from Docker Hub if not exists. You can choose to pull the stable version image or the develop version image.
 
-=== "Stable Version Image(3.0.13 version)"
+=== "Stable Version Image(3.0.14 version)"
 
       ```bash
-      docker pull matrixorigin/matrixone:3.0.13
-      docker run -d -p 6001:6001 --name matrixone matrixorigin/matrixone:3.0.13
+      docker pull matrixorigin/matrixone:3.0.14
+      docker run -d -p 6001:6001 --name matrixone matrixorigin/matrixone:3.0.14
       ```
 
       If you are using the network in mainland China, you can pull the MatrixOne stable version image on Alibaba Cloud:
 
       ```bash
-      docker pull registry.cn-shanghai.aliyuncs.com/matrixorigin/matrixone:3.0.13
-      docker run -d -p 6001:6001 --name matrixone registry.cn-shanghai.aliyuncs.com/matrixorigin/matrixone:3.0.13
+      docker pull registry.cn-shanghai.aliyuncs.com/matrixorigin/matrixone:3.0.14
+      docker run -d -p 6001:6001 --name matrixone registry.cn-shanghai.aliyuncs.com/matrixorigin/matrixone:3.0.14
       ```
 
 === "Develop Version Image"
@@ -94,7 +94,7 @@ It will pull the image from Docker Hub if not exists. You can choose to pull the
 If your Docker version is lower than 20.10.18 or the Docker client and server versions are inconsistent, upgrading to the latest stable version before attempting is recommended. If you choose to proceed with the current versions, you need to add the parameter `--privileged=true` to the `docker run` command, as shown below:
 
 ```bash
-docker run -d -p 6001:6001 --name matrixone --privileged=true matrixorigin/matrixone:3.0.13
+docker run -d -p 6001:6001 --name matrixone --privileged=true matrixorigin/matrixone:3.0.14
 ```
 
 !!! note
@@ -120,7 +120,7 @@ The parameters that need to be adjusted are as follows:
 
 ```
 mo_ctl set_conf MO_CONTAINER_DATA_HOST_PATH="/yourpath/mo/" # Set the data directory for host
-mo_ctl set_conf MO_CONTAINER_IMAGE="matrixorigin/matrixone:3.0.13" # Set image
+mo_ctl set_conf MO_CONTAINER_IMAGE="matrixorigin/matrixone:3.0.14" # Set image
 mo_ctl set_conf MO_DEPLOY_MODE=docker # Deployment Configuration
 ```
 
@@ -152,7 +152,7 @@ Depending on your needs, choose whether you want to keep your code up to date, o
 === "Get the MatrixOne(Stable Version) code to build"
 
      ```
-     mo_ctl deploy v3.0.13
+     mo_ctl deploy v3.0.14
      ```
 
 - Launch MatrixOne server
@@ -190,7 +190,7 @@ root@VM-16-2-debian:~# mo_ctl connect
 mysql: [Warning] Using a password on the command line interface can be insecure.
 Welcome to the MySQL monitor.  Commands end with ; or \g.
 Your MySQL connection id is 15
-Server version: 8.0.30-MatrixOne-v3.0.13 MatrixOne
+Server version: 8.0.30-MatrixOne-v3.0.14 MatrixOne
 
 Copyright (c) 2000, 2023, Oracle and/or its affiliates.
 

--- a/docs/MatrixOne/Maintain/mount-data-by-docker.md
+++ b/docs/MatrixOne/Maintain/mount-data-by-docker.md
@@ -24,7 +24,7 @@ To ensure the safety of the data directory, mount the local data directory to th
 3. Mount the local **empty directory** to the Docker container directory */mo-data*, execute the following command:
 
      ```shell
-     sudo docker run --name <name> --privileged -d -p 6001:6001 -v ${local_data_path}/mo-data:/mo-data:rw matrixorigin/matrixone:3.0.13
+     sudo docker run --name <name> --privileged -d -p 6001:6001 -v ${local_data_path}/mo-data:/mo-data:rw matrixorigin/matrixone:3.0.14
      ```
 
      | Parameters                          | Description                                                                                                                                                                         |
@@ -46,7 +46,7 @@ If you need to modify the configuration file. In that case, it would be best to 
 2. To launch MatrixOne MatrixOne has not been running in Docker, execute the following command:
 
     ```
-    docker run -d -p 6001:6001 --name matrixone --privileged=true matrixorigin/matrixone:3.0.13
+    docker run -d -p 6001:6001 --name matrixone --privileged=true matrixorigin/matrixone:3.0.14
     ```
 
 3. Check the containerID that MatrixOne has been running in Docker, and copy the configuration file directory to the local directory:
@@ -68,7 +68,7 @@ If you need to modify the configuration file. In that case, it would be best to 
 6. Mount the configuration file to the Docker container directory and launch MatrixOne. Execute the following command:
 
      ```shell
-     sudo docker run --name <name> --privileged -d -p 6001:6001 -v ${local_config_path}/etc:/etc:rw  --entrypoint "/mo-service" matrixorigin/matrixone:3.0.13 -launch /etc/launch/launch.toml
+     sudo docker run --name <name> --privileged -d -p 6001:6001 -v ${local_config_path}/etc:/etc:rw  --entrypoint "/mo-service" matrixorigin/matrixone:3.0.14 -launch /etc/launch/launch.toml
      ```
 
      | Parameters                      | Description                                                                                                   |

--- a/docs/MatrixOne/Overview/whats-new.md
+++ b/docs/MatrixOne/Overview/whats-new.md
@@ -1,5 +1,5 @@
 # **What's New**
 
-The lastest version of MatrixOne is v26.3.0.13, releases on 25th May, 2026. See the following:
+The lastest version of MatrixOne is v26.3.0.14, releases on 2nd June, 2026. See the following:
 
-* [v26.3.0.13 Release Notes](../Release-Notes/v26.3.0.13.md)
+* [v26.3.0.14 Release Notes](../Release-Notes/v26.3.0.14.md)

--- a/docs/MatrixOne/Reference/mo-tools/mo_ctl_standalone.md
+++ b/docs/MatrixOne/Reference/mo-tools/mo_ctl_standalone.md
@@ -161,12 +161,12 @@ mo_ctl deploy help
 Usage         : mo_ctl deploy [mo_version] [force] # deploy mo onto the path configured
   [mo_version]: optional, specify an mo version to deploy
   [force]     : optional, if specified will delete all content under MO_PATH and deploy from beginning
-  e.g.        : mo_ctl deploy             # default, same as mo_ctl deploy 3.0.13
+  e.g.        : mo_ctl deploy             # default, same as mo_ctl deploy 3.0.14
               : mo_ctl deploy main        # deploy development latest version
               : mo_ctl deploy d29764a     # deploy development version d29764a
-              : mo_ctl deploy 3.0.13       # deploy stable version 3.0.13
-              : mo_ctl deploy force       # delete all under MO_PATH and deploy version 3.0.13
-              : mo_ctl deploy 3.0.13 force # delete all under MO_PATH and deploy stable version 3.0.13 from beginning
+              : mo_ctl deploy 3.0.14       # deploy stable version 3.0.14
+              : mo_ctl deploy force       # delete all under MO_PATH and deploy version 3.0.14
+              : mo_ctl deploy 3.0.14 force # delete all under MO_PATH and deploy stable version 3.0.14 from beginning
 ```
 
 ### start - Starts the MatrixOne service
@@ -306,7 +306,7 @@ Using `mo_ctl get_conf` will print a list of all parameters used by the current 
 | GCC_VERSION            | The version of gcc that precheck checks    |default 8.5.0   |
 | GO_VERSION             | The go version of the precheck check    |default 1.22.3  |
 | MO_GIT_URL             | MatrixOne source code pulling address   | default <https://github.com/matrixorigin/matrixone.git> |
-| MO_DEFAULT_VERSION     | The version of MatrixOne that is pulled by default | default 3.0.13    |
+| MO_DEFAULT_VERSION     | The version of MatrixOne that is pulled by default | default 3.0.14    |
 | GOPROXY                | GOPROXY address, generally used for domestic accelerated pull golang dependencies | default <https://goproxy.cn>,direct  |
 | STOP_INTERVAL          | Stop interval, wait time to detect service status after stopping service | default 5 seconds |
 | START_INTERVAL         | Startup interval, wait time to detect service status after starting the service | default 2 seconds   |
@@ -359,11 +359,11 @@ MatrixOne 0.8 and later can use `mo_ctl upgrade version` or `mo_ctl upgrade comm
 ```
 mo_ctl upgrade help
 Usage           : mo_ctl upgrade [version_commitid]   # upgrade or downgrade mo from current version to a target commit id or stable version
- [commitid]     : a commit id such as '38888f7', or a stable version such as '3.0.13'
+ [commitid]     : a commit id such as '38888f7', or a stable version such as '3.0.14'
                 : use 'latest' to upgrade to latest commit on main branch if you don't know the id
   e.g.          : mo_ctl upgrade 38888f7              # upgrade/downgrade to commit id 38888f7 on main branch
                 : mo_ctl upgrade latest               # upgrade/downgrade to latest commit on main branch
-                : mo_ctl upgrade 3.0.13               # upgrade/downgrade to stable version 3.0.13
+                : mo_ctl upgrade 3.0.14               # upgrade/downgrade to stable version 3.0.14
 ```
 
 ### watchdog - Keep MatrixOne alive

--- a/docs/MatrixOne/Release-Notes/release-timeline.md
+++ b/docs/MatrixOne/Release-Notes/release-timeline.md
@@ -4,6 +4,7 @@ This document shows all the released MatrixOne versions in reverse chronological
 
 | **Version**                 | **Release Date** |
 | :-------------------------- | :--------------- |
+| [v26.3.0.14](v26.3.0.14.md)         | 2026/06/02      |
 | [v26.3.0.13](v26.3.0.13.md)         | 2026/05/25      |
 | [v26.3.0.12](v26.3.0.12.md)         | 2026/05/19      |
 | [v26.3.0.11](v26.3.0.11.md)         | 2026/05/08      |

--- a/docs/MatrixOne/Security/TLS-introduction.md
+++ b/docs/MatrixOne/Security/TLS-introduction.md
@@ -109,7 +109,7 @@ After completing the configuration of these two main steps, a TLS secure connect
     Current pager:          stdout
     Using outfile:          ''
     Using delimiter:        ;
-    Server version:         8.0.30-MatrixOne-v3.0.13 MatrixOne
+    Server version:         8.0.30-MatrixOne-v3.0.14 MatrixOne
     Protocol version:       10
     Connection:             127.0.0.1 via TCP/IP
     Server characterset:    utf8mb4
@@ -134,7 +134,7 @@ After completing the configuration of these two main steps, a TLS secure connect
     Current pager:		stdout
     Using outfile:		''
     Using delimiter:	;
-    Server version:		8.0.30-MatrixOne-v3.0.13 MatrixOne
+    Server version:		8.0.30-MatrixOne-v3.0.14 MatrixOne
     Protocol version:	10
     Connection:		127.0.0.1 via TCP/IP
     Server characterset:	utf8mb4

--- a/docs/MatrixOne/Tutorial/dify-mo-demo.md
+++ b/docs/MatrixOne/Tutorial/dify-mo-demo.md
@@ -96,7 +96,7 @@ docker compose up -d
 mysql: [Warning] Using a password on the command line interface can be insecure.
 Welcome to the MySQL monitor. Commands end with ; or \g.
 Your MySQL connection id is 287
-Server version: 8.0.30-MatrixOne-v3.0.13 MatrixOne
+Server version: 8.0.30-MatrixOne-v3.0.14 MatrixOne
 Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
 Oracle is a registered trademark of Oracle Corporation and/or its
 affiliates. Other names may be trademarks of their respective

--- a/docs/MatrixOne/Tutorial/rag-demo.md
+++ b/docs/MatrixOne/Tutorial/rag-demo.md
@@ -140,7 +140,7 @@ documents = [
     "MatrixOne touts significant features, including real-time HTAP, multi-tenancy, stream computation, extreme scalability, cost-effectiveness, enterprise-grade availability, and extensive MySQL compatibility. MatrixOne unifies tasks traditionally performed by multiple databases into one system by offering a comprehensive ultra-hybrid data solution. This consolidation simplifies development and operations, minimizes data fragmentation, and boosts development agility.",
     "MatrixOne is optimally suited for scenarios requiring real-time data input, large data scales, frequent load fluctuations, and a mix of procedural and analytical business operations. It caters to use cases such as mobile internet apps, IoT data applications, real-time data warehouses, SaaS platforms, and more.",
     "Matrix is a collection of complex or real numbers arranged in a rectangular array.",
-    "The lastest version of MatrixOne is v26.3.0.13,released on 2026/05/25.",
+    "The lastest version of MatrixOne is v26.3.0.14,released on 2026/05/25.",
     "We are excited to announce MatrixOne v22.0.8.0 release on 2023/6/30."
 ]
 
@@ -312,7 +312,7 @@ client.disconnect()
 Console output related answer:
 
 ```
-Based on the provided data, the latest version of MatrixOne is v26.3.0.13, which was released on 2026/05/25.
+Based on the provided data, the latest version of MatrixOne is v26.3.0.14, which was released on 2026/05/25.
 ```
 
 After enhancement, the model generates the correct answer.

--- a/docs/hooks/agent_delivery.py
+++ b/docs/hooks/agent_delivery.py
@@ -5,7 +5,7 @@ MCP servers, etc.) can consume the MatrixOne docs without parsing HTML:
 
 1. **Per-page markdown mirror.** Every source `docs/MatrixOne/**/*.md` file
    is copied into `site/` at the same relative location. Frontmatter is
-   preserved as-is — it's cheap metadata for downstream tools.
+   preserved as-is - it's cheap metadata for downstream tools.
 2. **`site/llms.txt`**. A concise llmstxt.org-format index pointing at the
    most load-bearing pages. Section titles come from the page's `title:`
    frontmatter (or first H1); one-line descriptions come from the page's
@@ -45,10 +45,10 @@ OP_REF_ROOT_REL = Path("MatrixOne/Reference/Operators")
 MAX_AUTO_DESC_CHARS = 160
 
 SQL_CATEGORY_ORDER = [
-    ("Data-Definition-Language", "DDL — Data Definition Language"),
-    ("Data-Manipulation-Language", "DML — Data Manipulation Language"),
-    ("Data-Query-Language", "DQL — Data Query Language"),
-    ("Data-Control-Language", "DCL — Data Control Language"),
+    ("Data-Definition-Language", "DDL - Data Definition Language"),
+    ("Data-Manipulation-Language", "DML - Data Manipulation Language"),
+    ("Data-Query-Language", "DQL - Data Query Language"),
+    ("Data-Control-Language", "DCL - Data Control Language"),
     ("Other", "Other"),
 ]
 COMPAT_TAG = {
@@ -90,17 +90,17 @@ FEATURED_PAGES = [
         ("MatrixOne/Overview/matrixone-introduction.md",
          "What MatrixOne is: a hyper-converged cloud-native HSTAP database that unifies OLTP, OLAP, streaming, and vector/full-text workloads in one engine."),
         ("MatrixOne/Overview/matrixone-feature-list.md",
-         "Feature list at a glance — what's supported today vs on the roadmap."),
+         "Feature list at a glance - what's supported today vs on the roadmap."),
         ("MatrixOne/Get-Started/install-standalone-matrixone.md",
-         "Single-node install walkthrough — fastest path to a running instance for trying things out."),
+         "Single-node install walkthrough - fastest path to a running instance for trying things out."),
         ("MatrixOne/Reference/SQL-Reference/SQL-Type.md",
-         "SQL statement taxonomy — entry point for every supported statement."),
+         "SQL statement taxonomy - entry point for every supported statement."),
         (COMPAT_MATRIX_REL,
-         "MySQL 8.0 compatibility status per SQL statement — consult first before assuming syntax works."),
+         "MySQL 8.0 compatibility status per SQL statement - consult first before assuming syntax works."),
         ("MatrixOne/Reference/Data-Types/data-types.md",
          "All supported data types, including MatrixOne-specific `VECF32` / `VECF64` vectors and `DATALINK`."),
         ("MatrixOne/Reference/Variable/system-variables/system-variables-overview.md",
-         "System variables reference — session/global toggles that change SQL behaviour."),
+         "System variables reference - session/global toggles that change SQL behaviour."),
         ("MatrixOne/Reference/System-Parameters/system-parameter.md",
          "Server configuration parameters (static startup-time + dynamic) for tuning the engine."),
     ]),
@@ -108,19 +108,19 @@ FEATURED_PAGES = [
         ("MatrixOne/Overview/feature/key-feature-htap.md",
          "HTAP: run transactional and analytical workloads against the same data without ETL."),
         ("MatrixOne/Tutorial/git4data-demo.md",
-         "Git-for-Data branching workflow: create/diff/merge data branches just like code branches — the MatrixOne differentiator for agent-safe experiments."),
+         "Git-for-Data branching workflow: create/diff/merge data branches just like code branches - the MatrixOne differentiator for agent-safe experiments."),
         ("MatrixOne/Maintain/backup-restore/mobr-backup-restore/mobr-snapshot-backup-restore.md",
-         "Snapshot-based backup & restore — cluster/tenant/database/table scope, copy-on-write semantics."),
+         "Snapshot-based backup & restore - cluster/tenant/database/table scope, copy-on-write semantics."),
         ("MatrixOne/Maintain/backup-restore/mobr-backup-restore/mobr-pitr-backup-restore.md",
-         "Point-in-time recovery (PITR) — restore to an arbitrary timestamp within the configured retention window."),
+         "Point-in-time recovery (PITR) - restore to an arbitrary timestamp within the configured retention window."),
         ("MatrixOne/Tutorial/efficient-clone-demo.md",
          "CREATE CLONE: instant copy-on-write table/database clones, including across tenants."),
         ("MatrixOne/Develop/Vector/vector_search.md",
          "Vector search with `VECF32` / `VECF64`, L2/cosine/IP distance, IVFFLAT and HNSW indexes."),
         ("MatrixOne/Reference/SQL-Reference/Data-Definition-Language/create-fulltext-index.md",
-         "Full-text indexing — natural-language, boolean, and JSON search modes."),
+         "Full-text indexing - natural-language, boolean, and JSON search modes."),
         ("MatrixOne/Tutorial/hybrid-search-demo.md",
-         "Hybrid retrieval: combine vector search with full-text and scalar filters in a single query — the RAG-friendly pattern."),
+         "Hybrid retrieval: combine vector search with full-text and scalar filters in a single query - the RAG-friendly pattern."),
     ]),
     ("SDK & Drivers", [
         ("MatrixOne/Develop/connect-mo/python-connect-to-matrixone.md",
@@ -144,28 +144,28 @@ FEATURED_PAGES = [
         ("MatrixOne/Migrate/migrate-overview.md",
          "Migration overview: tools and workflows for moving from MySQL / PostgreSQL / Oracle / SQL Server to MatrixOne."),
         ("MatrixOne/Migrate/migrate-from-mysql-to-matrixone.md",
-         "MySQL → MatrixOne migration — the most common path, leverages MySQL wire-protocol compatibility."),
+         "MySQL → MatrixOne migration - the most common path, leverages MySQL wire-protocol compatibility."),
     ]),
     ("Operate", [
         ("MatrixOne/Deploy/deploy-MatrixOne-cluster.md",
-         "Distributed cluster deployment on Kubernetes — separates storage, compute, and transaction."),
+         "Distributed cluster deployment on Kubernetes - separates storage, compute, and transaction."),
         ("MatrixOne/Maintain/backup-restore/backup-restore-overview.md",
-         "Backup & restore strategy overview — snapshot, PITR, and `mo_br` tool."),
+         "Backup & restore strategy overview - snapshot, PITR, and `mo_br` tool."),
     ]),
     ("Optional", [
         ("MatrixOne/Overview/architecture/matrixone-architecture-design.md",
-         "HSTAP architecture deep dive — storage/compute/transaction split, TAE engine, log service, proxy."),
+         "HSTAP architecture deep dive - storage/compute/transaction split, TAE engine, log service, proxy."),
         ("MatrixOne/Performance-Tuning/performance-tuning-overview.md",
-         "Performance tuning methods — query plan reading, indexing, statistics, resource controls."),
+         "Performance tuning methods - query plan reading, indexing, statistics, resource controls."),
         ("MatrixOne/Troubleshooting/error-code.md",
-         "Error code taxonomy — look up any 5-character error code."),
+         "Error code taxonomy - look up any 5-character error code."),
     ]),
 ]
 
 SYSTEM_PROMPT_BLOCK = (
     "MatrixOne is a cloud-native HSTAP database unifying OLTP, OLAP, streaming, "
     "vector, and full-text workloads in one engine. It is broadly MySQL 8.0 "
-    "wire-protocol compatible, but not all MySQL features are supported — "
+    "wire-protocol compatible, but not all MySQL features are supported - "
     "always verify against the MySQL Compatibility Matrix. SQL examples on "
     "these pages are executed against the latest 3.0-dev image by "
     "`scripts/doc-validator` on every pull request."
@@ -184,16 +184,16 @@ AGENT_ROUTING = (
 # Behavioural directives kept here so they survive prompt-review sweeps.
 # Each entry should be one actionable line.
 AGENT_HINTS = [
-    "Not all MySQL 8.0 features are supported — consult the compatibility matrix before assuming syntax works.",
+    "Not all MySQL 8.0 features are supported - consult the compatibility matrix before assuming syntax works.",
     "Prefer MatrixOne-native clauses when documented: `CLUSTER BY`, `AS OF TIMESTAMP`, `USING IVFFLAT`/`USING HNSW`, `CLONE`, `PITR`, `SNAPSHOT`.",
     "Use `SHOW CREATE TABLE <name>` to inspect a table before mutating it; system tables differ from MySQL.",
     "Vector indexes (`USING IVFFLAT`, `USING HNSW`) must be declared via `CREATE INDEX`, not `ALTER TABLE ADD INDEX`.",
-    "Secondary indexes are syntactically accepted but do not yet accelerate queries — do not rely on them for performance.",
+    "Secondary indexes are syntactically accepted but do not yet accelerate queries - do not rely on them for performance.",
     "`ALTER TABLE` cannot combine column-level clauses (CHANGE/MODIFY/RENAME COLUMN, ADD/DROP PK) with other clauses; split into separate statements.",
-    "Tables created with `CLUSTER BY` and temporary tables cannot be altered — plan schema shape up front.",
+    "Tables created with `CLUSTER BY` and temporary tables cannot be altered - plan schema shape up front.",
     "`CREATE DATABASE` supports only `utf8mb4` / `utf8mb4_bin`; the `ENCRYPTION` clause is accepted but inert.",
     "Foreign keys do not support `ON CASCADE DELETE`.",
-    "`LOAD DATA INFILE` expects a local absolute path or a stage URL (e.g. `stage://my_stage/file.csv`) — relative paths and MySQL-style secure-file-priv do not apply.",
+    "`LOAD DATA INFILE` expects a local absolute path or a stage URL (e.g. `stage://my_stage/file.csv`) - relative paths and MySQL-style secure-file-priv do not apply.",
     "Use `CREATE SNAPSHOT` / `PITR` / `CREATE CLONE` for point-in-time and copy-on-write workflows rather than MySQL's binlog tooling.",
     "For agent-safe experiments, prefer a data branch (`DATA BRANCH CREATE` → test → `DATA BRANCH DIFF` → `DATA BRANCH MERGE` / delete) over mutating shared tables in place.",
 ]
@@ -260,15 +260,15 @@ def on_post_build(config, **_kwargs):
         llms.append("")
     (site_dir / "llms.txt").write_text("\n".join(llms), encoding="utf-8")
 
-    # 3. llms-sql.txt — flat index of every SQL-Reference page with compat tag.
+    # 3. llms-sql.txt - flat index of every SQL-Reference page with compat tag.
     sql_lines = _build_sql_index(docs_dir, base, built_at)
     (site_dir / "llms-sql.txt").write_text("\n".join(sql_lines), encoding="utf-8")
 
-    # 3b. llms-func.txt — flat index of every Functions-and-Operators page.
+    # 3b. llms-func.txt - flat index of every Functions-and-Operators page.
     func_lines = _build_func_index(docs_dir, base, built_at)
     (site_dir / "llms-func.txt").write_text("\n".join(func_lines), encoding="utf-8")
 
-    # 3c. llms-op.txt — flat index of every Operators page.
+    # 3c. llms-op.txt - flat index of every Operators page.
     op_lines = _build_op_index(docs_dir, base, built_at)
     (site_dir / "llms-op.txt").write_text("\n".join(op_lines), encoding="utf-8")
 
@@ -291,7 +291,7 @@ def on_post_build(config, **_kwargs):
         "MatrixOne/Contribution-Guide",
     ]
     full_parts = [
-        "# MatrixOne — Full Documentation",
+        "# MatrixOne - Full Documentation",
         "",
         "Source: " + base,
         f"Generated: {built_at} (UTC)",
@@ -334,7 +334,7 @@ def _build_sql_index(docs_dir: Path, base: str, built_at: str) -> list[str]:
     """
     root = docs_dir / SQL_REF_ROOT_REL
     lines: list[str] = [
-        "# MatrixOne SQL Reference — Flat Index",
+        "# MatrixOne SQL Reference - Flat Index",
         "",
         f"> Every SQL statement supported by MatrixOne, grouped by category, "
         f"each tagged with its MySQL 8.0 compatibility status. Generated from "
@@ -399,7 +399,7 @@ def _build_func_index(docs_dir: Path, base: str, built_at: str) -> list[str]:
     """
     root = docs_dir / FUNC_REF_ROOT_REL
     lines: list[str] = [
-        "# MatrixOne Functions Reference — Flat Index",
+        "# MatrixOne Functions Reference - Flat Index",
         "",
         f"> Every function supported by MatrixOne, grouped by category, "
         f"each tagged with its MySQL 8.0 compatibility status. Generated from "
@@ -462,7 +462,7 @@ def _build_op_index(docs_dir: Path, base: str, built_at: str) -> list[str]:
     """Emit a flat one-line-per-operator catalogue of every Operators page."""
     root = docs_dir / OP_REF_ROOT_REL
     lines: list[str] = [
-        "# MatrixOne Operators Reference — Flat Index",
+        "# MatrixOne Operators Reference - Flat Index",
         "",
         f"> Every operator supported by MatrixOne, grouped by category, "
         f"each tagged with its MySQL 8.0 compatibility status. Generated from "
@@ -537,7 +537,7 @@ def _read(md_path: Path) -> str | None:
 
 
 def _split_frontmatter(text: str) -> tuple[dict[str, str], str]:
-    """Return (frontmatter_dict, body). Accepts only flat scalar frontmatter —
+    """Return (frontmatter_dict, body). Accepts only flat scalar frontmatter -
     nested lists/dicts (e.g. `differs_from_mysql:`) are ignored.
     """
     m = _FRONTMATTER_RE.match(text)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -777,6 +777,8 @@ nav:
           - SQL FAQs: MatrixOne/FAQs/sql-faqs.md
       - Release Notes:
           - Release Timeline: MatrixOne/Release-Notes/release-timeline.md
+          - v26.3.0.14: MatrixOne/Release-Notes/v26.3.0.14.md
+          - v26.3.0.13: MatrixOne/Release-Notes/v26.3.0.13.md
           - v26.3.0.12: MatrixOne/Release-Notes/v26.3.0.12.md
           - v26.3.0.11: MatrixOne/Release-Notes/v26.3.0.11.md
           - v25.3.0.4: MatrixOne/Release-Notes/v25.3.0.4.md


### PR DESCRIPTION
The em dash (—) character renders as garbled text (鈥�) when UTF-8 content is read with GBK encoding. Replace all em dashes with plain hyphens to ensure correct display across all encodings.