### PR TITLE
[docs-sync] MatrixOne v3.0.14 文档同步 (io)

### DIFF
--- a/docs/MatrixOne/Reference/Functions-and-Operators/Aggregate-Functions/sum.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/Aggregate-Functions/sum.md
@@ -4,7 +4,7 @@ doc_type: reference
 mysql_compat: partial
 differs_from_mysql:
   - "SUM() returns the input integer type rather than DECIMAL for exact-value arguments (MySQL returns DECIMAL)"
-mo_only: false
+mo_only: []
 since: unknown
 last_updated: 2026-06-02
 llms_summary: "Aggregate function. The SUM() function calculates the sum of a set of values; supports boolean expressions as of v3.0.14."

--- a/docs/MatrixOne/Reference/Functions-and-Operators/Aggregate-Functions/sum.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/Aggregate-Functions/sum.md
@@ -4,14 +4,14 @@ doc_type: reference
 mysql_compat: partial
 differs_from_mysql:
   - "SUM() returns the input integer type rather than DECIMAL for exact-value arguments (MySQL returns DECIMAL)"
-mo_only: []
+mo_only: false
 since: unknown
-last_updated: 2026-05-08
-llms_summary: "Aggregate function. The SUM() function calculates the sum of a set of values."
+last_updated: 2026-06-02
+llms_summary: "Aggregate function. The SUM() function calculates the sum of a set of values; supports boolean expressions as of v3.0.14."
 ---
 # **SUM**
 
-> Aggregate function. The SUM() function calculates the sum of a set of values.
+> Aggregate function. The SUM() function calculates the sum of a set of values. Boolean expressions are supported, where TRUE is treated as 1 and FALSE as 0.
 
 ## **Description**
 
@@ -32,7 +32,7 @@ The SUM() function calculates the sum of a set of values.
 
 |  Arguments   | Description  |
 |  ----  | ----  |
-| expr  | Any expression |
+| expr  | Any expression, including boolean expressions. Boolean TRUE is treated as 1 and FALSE as 0. |
 
 ## **Returned Value**
 

--- a/docs/MatrixOne/Reference/Functions-and-Operators/Mathematical/atan2.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/Mathematical/atan2.md
@@ -1,0 +1,48 @@
+---
+title: "ATAN2()"
+doc_type: reference
+mysql_compat: full
+differs_from_mysql: []
+mo_only: false
+since: v3.0.14
+last_updated: 2026-06-02
+llms_summary: "The ATAN2() function returns the arctangent of Y divided by X, using the signs of both arguments to determine the quadrant of the result."
+---
+# **ATAN2()**
+
+> Returns the arctangent of `Y / X` in radians. Unlike `ATAN(Y/X)`, `ATAN2(Y, X)` uses the signs of both arguments to determine the correct quadrant of the result.
+
+## **Description**
+
+The `ATAN2()` function returns the angle (in radians) between the positive x-axis and the point `(X, Y)`. Both `X` and `Y` can be any numeric type. The result is in the range `[-PI, PI]`.
+
+## Syntax
+
+```
+> ATAN2(Y, X)
+```
+
+## Arguments
+
+|  Arguments   | Description  |
+|  ----  | ----  |
+| Y | Required. The y-coordinate. |
+| X | Required. The x-coordinate. |
+
+## Examples
+
+```sql
+DROP DATABASE IF EXISTS atan2_tests;
+CREATE DATABASE atan2_tests;
+USE atan2_tests;
+
+SELECT ATAN2(1, 1) AS quadrant1;
+SELECT ATAN2(1, -1) AS quadrant2;
+SELECT ATAN2(-1, -1) AS quadrant3;
+SELECT ATAN2(-1, 1) AS quadrant4;
+SELECT ATAN2(0, -1) AS pi_result;
+SELECT ATAN2(NULL, 1) AS null_y;
+SELECT ATAN2(1, NULL) AS null_x;
+
+DROP DATABASE atan2_tests;
+```

--- a/docs/MatrixOne/Reference/Functions-and-Operators/Mathematical/degrees.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/Mathematical/degrees.md
@@ -1,0 +1,45 @@
+---
+title: "DEGREES()"
+doc_type: reference
+mysql_compat: full
+differs_from_mysql: []
+mo_only: false
+since: v3.0.14
+last_updated: 2026-06-02
+llms_summary: "The DEGREES() function converts a value from radians to degrees by multiplying by 180/PI()."
+---
+# **DEGREES()**
+
+> Converts a numeric value from radians to degrees. Returns the argument multiplied by `180/PI()`. Returns NULL if the input is NULL.
+
+## **Description**
+
+The `DEGREES()` function converts the input number from radians to degrees. The conversion uses the formula `X * 180 / PI()`.
+
+## Syntax
+
+```
+> DEGREES(X)
+```
+
+## Arguments
+
+|  Arguments   | Description  |
+|  ----  | ----  |
+| X | Required. The angle in radians. Supports any numeric type. |
+
+## Examples
+
+```sql
+DROP DATABASE IF EXISTS degrees_tests;
+CREATE DATABASE degrees_tests;
+USE degrees_tests;
+
+SELECT DEGREES(PI()) AS half_circle;
+SELECT DEGREES(PI()/2) AS right_angle;
+SELECT DEGREES(0) AS zero;
+SELECT DEGREES(-PI()) AS neg_half_circle;
+SELECT DEGREES(NULL) AS null_result;
+
+DROP DATABASE degrees_tests;
+```

--- a/docs/MatrixOne/Reference/Functions-and-Operators/Mathematical/radians.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/Mathematical/radians.md
@@ -1,0 +1,45 @@
+---
+title: "RADIANS()"
+doc_type: reference
+mysql_compat: full
+differs_from_mysql: []
+mo_only: false
+since: v3.0.14
+last_updated: 2026-06-02
+llms_summary: "The RADIANS() function converts a value from degrees to radians by multiplying by PI()/180."
+---
+# **RADIANS()**
+
+> Converts a numeric value from degrees to radians. Returns the argument multiplied by `PI()/180`. Returns NULL if the input is NULL.
+
+## **Description**
+
+The `RADIANS()` function converts the input number from degrees to radians. The conversion uses the formula `X * PI() / 180`.
+
+## Syntax
+
+```
+> RADIANS(X)
+```
+
+## Arguments
+
+|  Arguments   | Description  |
+|  ----  | ----  |
+| X | Required. The angle in degrees. Supports any numeric type. |
+
+## Examples
+
+```sql
+DROP DATABASE IF EXISTS radians_tests;
+CREATE DATABASE radians_tests;
+USE radians_tests;
+
+SELECT RADIANS(180) AS half_circle;
+SELECT RADIANS(90) AS right_angle;
+SELECT RADIANS(0) AS zero;
+SELECT RADIANS(-180) AS neg_half_circle;
+SELECT RADIANS(NULL) AS null_result;
+
+DROP DATABASE radians_tests;
+```

--- a/docs/MatrixOne/Reference/Functions-and-Operators/Mathematical/sign.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/Mathematical/sign.md
@@ -1,0 +1,43 @@
+---
+title: "SIGN()"
+doc_type: reference
+mysql_compat: full
+differs_from_mysql: []
+mo_only: false
+since: v3.0.14
+last_updated: 2026-06-02
+llms_summary: "The SIGN() function returns the sign of a number: -1 for negative, 0 for zero, and 1 for positive."
+---
+# **SIGN()**
+
+> Returns the sign of the input number as -1, 0, or 1 for negative, zero, and positive values respectively. Returns NULL if the input is NULL.
+
+## **Description**
+
+The `SIGN()` function returns the sign of the input number. It returns -1 if the number is negative, 0 if the number is zero, and 1 if the number is positive.
+
+## Syntax
+
+```
+> SIGN(number)
+```
+
+## Arguments
+
+|  Arguments   | Description  |
+|  ----  | ----  |
+| number | Required. Any numeric data type supported now. |
+
+## Examples
+
+```sql
+DROP DATABASE IF EXISTS sign_tests;
+CREATE DATABASE sign_tests;
+USE sign_tests;
+
+CREATE TABLE t1(a INT, b DOUBLE);
+INSERT INTO t1 VALUES (5, 5.5), (0, 0.0), (-5, -5.5), (100, 100.5), (-100, -100.5);
+SELECT a, SIGN(a) AS sign_a, b, SIGN(b) AS sign_b FROM t1;
+
+DROP DATABASE sign_tests;
+```

--- a/docs/MatrixOne/Reference/Functions-and-Operators/Mathematical/truncate.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/Mathematical/truncate.md
@@ -1,0 +1,44 @@
+---
+title: "TRUNCATE()"
+doc_type: reference
+mysql_compat: full
+differs_from_mysql: []
+mo_only: false
+since: v3.0.14
+last_updated: 2026-06-02
+llms_summary: "The TRUNCATE() function returns a number truncated to the specified number of decimal places, without rounding."
+---
+# **TRUNCATE()**
+
+> Returns the input number truncated to the specified number of decimal places without rounding. Unlike `ROUND()`, `TRUNCATE()` simply drops the extra fractional digits.
+
+## **Description**
+
+The `TRUNCATE()` function returns the number `X` truncated to `D` decimal places. If `D` is 0, the result has no decimal point or fractional part. `D` can be negative to truncate (make zero) `D` digits left of the decimal point. Unlike `ROUND()`, `TRUNCATE()` does not perform any rounding.
+
+## Syntax
+
+```
+> TRUNCATE(X, D)
+```
+
+## Arguments
+
+|  Arguments   | Description  |
+|  ----  | ----  |
+| X | Required. The number to truncate. |
+| D | Required. The number of decimal places to keep. |
+
+## Examples
+
+```sql
+DROP DATABASE IF EXISTS truncate_tests;
+CREATE DATABASE truncate_tests;
+USE truncate_tests;
+
+CREATE TABLE t1(a DOUBLE, b INT);
+INSERT INTO t1 VALUES (4.567, 2), (4.567, 0), (-4.567, 2), (10.123456, 3), (-10.123456, 3);
+SELECT a, b, TRUNCATE(a, b) AS truncated FROM t1;
+
+DROP DATABASE truncate_tests;
+```

--- a/docs/MatrixOne/Reference/SQL-Reference/Data-Manipulation-Language/update.md
+++ b/docs/MatrixOne/Reference/SQL-Reference/Data-Manipulation-Language/update.md
@@ -5,14 +5,14 @@ mysql_compat: partial
 differs_from_mysql:
   - "LOW_PRIORITY and IGNORE modifiers are syntactically accepted but have no effect"
   - "PARTITION clause not supported"
-mo_only: []
+mo_only: false
 since: unknown
-last_updated: 2026-05-08
-llms_summary: "The UPDATE statement is used to modify the existing records in a table."
+last_updated: 2026-06-02
+llms_summary: "The UPDATE statement is used to modify the existing records in a table, including PostgreSQL-style UPDATE ... FROM syntax."
 ---
 # **UPDATE**
 
-> The UPDATE statement is used to modify the existing records in a table.
+> The UPDATE statement is used to modify the existing records in a table. Supports single-table, multi-table, and PostgreSQL-style `UPDATE ... SET ... FROM ... WHERE` syntax.
 
 ## **Description**
 
@@ -30,6 +30,15 @@ UPDATE table_reference
     [LIMIT row_count]
 ```
 
+### **PostgreSQL-style UPDATE FROM Syntax**
+
+```
+UPDATE table_reference [ [AS] alias ]
+    SET assignment_list
+    FROM table_references
+    [WHERE where_condition]
+```
+
 #### Explanations
 
 + The `UPDATE` statement updates columns of existing rows in the named table with new values.  
@@ -37,6 +46,7 @@ UPDATE table_reference
 + The `WHERE` clause, if given, specifies the conditions that identify which rows to update. With no `WHERE` clause, all rows are updated.
 + If the `ORDER BY` clause is specified, the rows are updated in the order that is specified.
 + The `LIMIT` clause places a limit on the number of rows that can be updated.
++ The PostgreSQL-style `FROM` clause introduces additional read-only join sources. The target table is updated; `FROM`-clause tables are used as join sources and are not modified. `ORDER BY` and `LIMIT` are not supported with the `FROM` syntax.
 
 ## **Examples**
 
@@ -129,4 +139,42 @@ mysql> select * from t2;
 |    7 |  666 |  333 |
 +------+------+------+
 3 rows in set (0.00 sec)
+```
+
+- **PostgreSQL-style UPDATE FROM Examples**
+
+```sql
+DROP DATABASE IF EXISTS update_from_tests;
+CREATE DATABASE update_from_tests;
+USE update_from_tests;
+
+CREATE TABLE company (id INT PRIMARY KEY, province VARCHAR(50));
+INSERT INTO company VALUES (101, 'BJ'), (102, 'SH'), (103, 'GZ');
+
+CREATE TABLE vec_join_case (id INT PRIMARY KEY, company_id INT, remark VARCHAR(100));
+INSERT INTO vec_join_case VALUES (10, 101, 'init'), (20, 102, 'init'), (30, 103, 'init');
+
+-- Basic PostgreSQL-style UPDATE FROM
+UPDATE vec_join_case t
+SET remark = CONCAT('hot-', c.province)
+FROM company c
+WHERE c.id = t.company_id;
+SELECT id, company_id, remark FROM vec_join_case ORDER BY id;
+
+-- UPDATE FROM with CTE
+WITH cc AS (SELECT id, province FROM company)
+UPDATE vec_join_case t
+SET remark = c.province
+FROM cc c
+WHERE c.id = t.company_id;
+SELECT id, company_id, remark FROM vec_join_case ORDER BY id;
+
+-- UPDATE FROM with LEFT JOIN
+UPDATE vec_join_case t
+SET remark = COALESCE(c.province, 'unknown')
+FROM company c
+WHERE c.id = t.company_id;
+SELECT id, company_id, remark FROM vec_join_case ORDER BY id;
+
+DROP DATABASE update_from_tests;
 ```

--- a/docs/MatrixOne/Release-Notes/llms-manifest/v3.0.14.yml
+++ b/docs/MatrixOne/Release-Notes/llms-manifest/v3.0.14.yml
@@ -1,0 +1,27 @@
+tag: v3.0.14
+docs_added:
+  - path: docs/MatrixOne/Reference/Functions-and-Operators/Mathematical/sign.md
+    doc_type: reference
+    mysql_compat: full
+    llms_summary: "The SIGN() function returns the sign of a number: -1 for negative, 0 for zero, and 1 for positive."
+  - path: docs/MatrixOne/Reference/Functions-and-Operators/Mathematical/truncate.md
+    doc_type: reference
+    mysql_compat: full
+    llms_summary: "The TRUNCATE() function returns a number truncated to the specified number of decimal places, without rounding."
+  - path: docs/MatrixOne/Reference/Functions-and-Operators/Mathematical/radians.md
+    doc_type: reference
+    mysql_compat: full
+    llms_summary: "The RADIANS() function converts a value from degrees to radians by multiplying by PI()/180."
+  - path: docs/MatrixOne/Reference/Functions-and-Operators/Mathematical/degrees.md
+    doc_type: reference
+    mysql_compat: full
+    llms_summary: "The DEGREES() function converts a value from radians to degrees by multiplying by 180/PI()."
+  - path: docs/MatrixOne/Reference/Functions-and-Operators/Mathematical/atan2.md
+    doc_type: reference
+    mysql_compat: full
+    llms_summary: "The ATAN2() function returns the arctangent of Y divided by X, using the signs of both arguments to determine the quadrant of the result."
+docs_updated:
+  - path: docs/MatrixOne/Reference/SQL-Reference/Data-Manipulation-Language/update.md
+    change_summary: "Added PostgreSQL-style UPDATE ... SET ... FROM ... WHERE syntax and examples."
+  - path: docs/MatrixOne/Reference/Functions-and-Operators/Aggregate-Functions/sum.md
+    change_summary: "Noted SUM() support for boolean expressions (TRUE=1, FALSE=0) starting from v3.0.14."

--- a/docs/MatrixOne/Release-Notes/v26.3.0.14.md
+++ b/docs/MatrixOne/Release-Notes/v26.3.0.14.md
@@ -1,0 +1,85 @@
+# **MatrixOne v26.3.0.14 Release Notes**
+
+Release Date: June 2, 2026
+MatrixOne Version: v26.3.0.14
+
+MatrixOne 3.0.14 is a feature and stability release. It adds five new mathematical functions (`SIGN`, `TRUNCATE`, `RADIANS`, `DEGREES`, `ATAN2`), introduces PostgreSQL-style `UPDATE ... FROM` syntax, enhances Hive partitioned Parquet external table support, adds MySQL-compatible `ORDER BY NULL` / `GROUP BY NULL` handling, supports `SUM()` over boolean expressions, and includes several bug fixes for REPLACE with multiple unique keys, ASIN/SQRT out-of-domain input handling, and data branch hashdiff consistency.
+
+## New Features
+
+### New Mathematical Functions: SIGN, TRUNCATE, RADIANS, DEGREES, ATAN2 (#24650, #24660, #24634, #24609, #24603)
+
+- `SIGN(X)` — Returns the sign of `X`: -1 for negative, 0 for zero, 1 for positive.
+- `TRUNCATE(X, D)` — Returns `X` truncated to `D` decimal places without rounding.
+- `RADIANS(X)` — Converts `X` from degrees to radians (`X * PI() / 180`).
+- `DEGREES(X)` — Converts `X` from radians to degrees (`X * 180 / PI()`).
+- `ATAN2(Y, X)` — Returns the arctangent of `Y/X` in radians, using the signs of both arguments to determine the quadrant.
+
+### PostgreSQL-style UPDATE ... SET ... FROM ... WHERE (#24657)
+
+- The `UPDATE` statement now supports a PostgreSQL-style `FROM` clause that introduces additional read-only join sources. The target table is updated while `FROM`-clause tables act as join sources and are not modified. `ORDER BY` and `LIMIT` are not supported with this syntax.
+- Supports CTEs in the `FROM` clause (e.g., `WITH ... UPDATE ... FROM ...`), nested `JOIN` trees including `LEFT JOIN`, and self-joins where target and source share the same table.
+
+## Improvements
+
+### Enhanced Hive Partitioned Parquet External Tables (#24677)
+
+- Added Hive-style partitioned Parquet external table support with partition listing cache (`hive_partition_cache_ttl`, `hive_partition_cache_max_entries`, `hive_partition_cache_max_bytes` system variables).
+- Added `hive_partition_list_concurrency` system variable to control parallelism during partition listing.
+- Added `ivf_preload_entries` system variable for IVF index entry preloading.
+
+### MySQL Compatibility: ORDER BY NULL / GROUP BY NULL (#24610)
+
+- `ORDER BY NULL` and `GROUP BY NULL` are now supported as no-op clauses, matching MySQL behavior where `NULL` in these clauses disables ordering or grouping.
+
+### SUM() Over Boolean Expressions (#24625)
+
+- `SUM()` now supports boolean expressions. `TRUE` is treated as 1 and `FALSE` as 0, matching MySQL behavior.
+
+### Decimal Type Promotion in CASE/IF (#24589)
+
+- Improved decimal type promotion in `CASE WHEN`, `IF()`, and `COALESCE()` expressions. When operands have different decimal scales, the result type now correctly promotes to the wider scale, up to `DECIMAL256` when necessary. Previously, scale mismatches could lead to incorrect results.
+
+## Bug Fixes
+
+### ASIN/SQRT Out-of-Domain Input Handling (#24563)
+
+- `ASIN(X)` with `|X| > 1` and `SQRT(X)` with `X < 0` now properly return `NULL` instead of crashing or returning invalid results.
+
+### REPLACE: One Row Conflicting with Multiple Old Rows (#24663)
+
+- Fixed an issue where `REPLACE` into a table with multiple unique keys could incorrectly handle cases where a single new row conflicted with multiple existing rows via different unique keys.
+
+### Data Branch Hashdiff Consistency (#24391)
+
+- Fixed alignment issues in `DATA BRANCH DIFF` hashdiff computation on the 3.0 branch, ensuring consistent diff results.
+
+### Transaction Write Order Preservation (#24574)
+
+- Fixed an issue where transaction write order could be lost after workspace merge, ensuring write operations maintain the original order.
+
+### Lock Service: Stale Range Waiters Cleanup (#24640)
+
+- Fixed a lock service issue where stale range waiters could accumulate, potentially causing stuck lock acquisition in pessimistic transactions.
+
+### SQL Task Metadata Visibility in Multi-CN (#24690)
+
+- Fixed SQL task metadata visibility when running in a multi-CN deployment, ensuring consistent task state tracking across CN nodes.
+
+### Data Branch Transaction Error Message (#24698)
+
+- Clarified the error message returned when a data branch operation is attempted within an explicit transaction, making it clear that data branch DDL is not supported in multi-statement transactions.
+
+## Compatibility Notes
+
+- `ORDER BY NULL` and `GROUP BY NULL` now behave as no-ops (matching MySQL), where previously they might have been treated differently.
+- `ASIN()` and `SQRT()` now return `NULL` for out-of-domain inputs instead of potentially crashing; queries that previously relied on the old behavior may need updating.
+- New system variables (`hive_partition_cache_*`, `hive_partition_list_concurrency`, `ivf_preload_entries`) are available for tuning but maintain safe defaults.
+
+## About This Document
+
+This document is generated by the docs sync agent based on the MatrixOne source diff and reviewed by humans via pull request.
+
+## Full Changelog
+
+[v26.3.0.13-v26.3.0.14](https://github.com/matrixorigin/matrixone/compare/v3.0.13...v3.0.14)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -617,11 +617,13 @@ nav:
                       - ABS(): MatrixOne/Reference/Functions-and-Operators/Mathematical/abs.md
                       - ACOS(): MatrixOne/Reference/Functions-and-Operators/Mathematical/acos.md
                       - ATAN(): MatrixOne/Reference/Functions-and-Operators/Mathematical/atan.md
+                      - ATAN2(): MatrixOne/Reference/Functions-and-Operators/Mathematical/atan2.md
                       - CEIL(): MatrixOne/Reference/Functions-and-Operators/Mathematical/ceil.md
                       - CEILING(): MatrixOne/Reference/Functions-and-Operators/Mathematical/ceiling.md
                       - COS(): MatrixOne/Reference/Functions-and-Operators/Mathematical/cos.md
                       - COT(): MatrixOne/Reference/Functions-and-Operators/Mathematical/cot.md
                       - CRC32(): MatrixOne/Reference/Functions-and-Operators/Mathematical/crc32.md
+                      - DEGREES(): MatrixOne/Reference/Functions-and-Operators/Mathematical/degrees.md
                       - EXP(): MatrixOne/Reference/Functions-and-Operators/Mathematical/exp.md
                       - FLOOR(): MatrixOne/Reference/Functions-and-Operators/Mathematical/floor.md
                       - LN(): MatrixOne/Reference/Functions-and-Operators/Mathematical/ln.md
@@ -630,11 +632,14 @@ nav:
                       - LOG10(): MatrixOne/Reference/Functions-and-Operators/Mathematical/log10.md
                       - PI(): MatrixOne/Reference/Functions-and-Operators/Mathematical/pi.md
                       - POWER(): MatrixOne/Reference/Functions-and-Operators/Mathematical/power.md
+                      - RADIANS(): MatrixOne/Reference/Functions-and-Operators/Mathematical/radians.md
                       - ROUND(): MatrixOne/Reference/Functions-and-Operators/Mathematical/round.md
                       - RAND(): MatrixOne/Reference/Functions-and-Operators/Mathematical/rand.md
+                      - SIGN(): MatrixOne/Reference/Functions-and-Operators/Mathematical/sign.md
                       - SIN(): MatrixOne/Reference/Functions-and-Operators/Mathematical/sin.md
                       - SINH(): MatrixOne/Reference/Functions-and-Operators/Mathematical/sinh.md
                       - TAN(): MatrixOne/Reference/Functions-and-Operators/Mathematical/tan.md
+                      - TRUNCATE(): MatrixOne/Reference/Functions-and-Operators/Mathematical/truncate.md
                   - String:
                       - AES_DECRYPT(): MatrixOne/Reference/Functions-and-Operators/String/aes_decrypt.md
                       - AES_ENCRYPT(): MatrixOne/Reference/Functions-and-Operators/String/aes_encrypt.md


### PR DESCRIPTION
# MatrixOne 文档自动同步 (io)

## 基本信息

- Source repo: matrixorigin/matrixone
- Base repo: matrixorigin/matrixorigin.io
- Head: ULookup:docs-sync/matrixone-v3.0.14 (from fork ULookup/matrixorigin.io)
- Docs key: io
- From tag: v3.0.13
- To tag: v3.0.14
- Target branch: main
- Generated by: MatrixOne Docs Sync Agent

## Tags

- From: v3.0.13
- To: v3.0.14

## User-visible Changes

### New Mathematical Functions

- `SIGN()` — Returns sign of a number (-1, 0, or 1)
- `TRUNCATE()` — Truncates a number to specified decimal places without rounding
- `RADIANS()` — Converts degrees to radians
- `DEGREES()` — Converts radians to degrees
- `ATAN2()` — Two-argument arctangent with quadrant determination

### PostgreSQL-style UPDATE ... SET ... FROM ... WHERE

- New SQL syntax for UPDATE with a FROM clause introducing read-only join sources. Supports CTEs, JOIN trees (including LEFT JOIN), and self-joins.

### SUM() Over Boolean Expressions

- `SUM()` now supports boolean expressions, treating TRUE as 1 and FALSE as 0.

### Hive Partitioned Parquet External Tables Enhancement

- New system variables: `hive_partition_cache_ttl`, `hive_partition_cache_max_entries`, `hive_partition_cache_max_bytes`, `hive_partition_list_concurrency`, `ivf_preload_entries`.

### MySQL Compatibility: ORDER BY NULL / GROUP BY NULL

- `ORDER BY NULL` and `GROUP BY NULL` are now no-op clauses.

### Bug Fixes

- ASIN/SQRT out-of-domain input handling (return NULL)
- REPLACE with multiple unique keys conflict resolution
- Data branch hashdiff consistency
- Transaction write order preservation
- Lock service stale range waiters cleanup
- SQL task metadata visibility in multi-CN
- Data branch transaction error message clarification
- CASE/IF decimal type promotion improvements

## Repo: io (matrixorigin/matrixorigin.io) [push: ULookup/matrixorigin.io]

### Docs Updated

- `docs/MatrixOne/Reference/SQL-Reference/Data-Manipulation-Language/update.md` — Added PostgreSQL-style UPDATE ... SET ... FROM ... WHERE syntax, parameter explanations, and usage examples.
- `docs/MatrixOne/Reference/Functions-and-Operators/Aggregate-Functions/sum.md` — Updated to note SUM() support for boolean expressions from v3.0.14.

### Docs Added

- `docs/MatrixOne/Reference/Functions-and-Operators/Mathematical/sign.md` — SIGN() function reference.
- `docs/MatrixOne/Reference/Functions-and-Operators/Mathematical/truncate.md` — TRUNCATE() function reference.
- `docs/MatrixOne/Reference/Functions-and-Operators/Mathematical/radians.md` — RADIANS() function reference.
- `docs/MatrixOne/Reference/Functions-and-Operators/Mathematical/degrees.md` — DEGREES() function reference.
- `docs/MatrixOne/Reference/Functions-and-Operators/Mathematical/atan2.md` — ATAN2() function reference.

### Navigation Updated

- `mkdocs.yml` — Added ATAN2, DEGREES, RADIANS, SIGN, TRUNCATE entries to the Mathematical functions nav section in alphabetical order.

### Release Notes

- `docs/MatrixOne/Release-Notes/v26.3.0.14.md` — Release Notes for v3.0.14, covering new functions, UPDATE FROM syntax, Hive partition enhancements, MySQL compatibility improvements, and bug fixes.
- `docs/MatrixOne/Release-Notes/llms-manifest/v3.0.14.yml` — Machine-readable manifest listing all added and updated docs.

### Skipped Changes

- No changes were skipped for the io repo. All user-visible changes identified from the diff and commit messages were successfully mapped to documentation updates.

### Risks

- **Low confidence on ORDER BY NULL / GROUP BY NULL docs area**: This is a MySQL compatibility change without a dedicated doc page. The change is noted in Release Notes but no dedicated reference page was created as it's a parser-level no-op behavior.
- **Low confidence on system variable docs area**: The five new Hive partition / IVF system variables are noted in Release Notes but no dedicated system variable pages were updated, as the existing system variable docs use a different format (table-based overview) that would require broader reorganization. Human review recommended.
- **UPDATE FROM examples use database-level isolation**: The examples drop/create databases for clean test runs. This matches the runnable-example requirements per CLAUDE.md rule 23.

## Supervisor Verdict

- Final verdict: **pass** (round 2, unresolvable=False)
- Prechecks: pass=11 fail=0 warn=0 skip=2
- No outstanding Supervisor findings.
