### PR TITLE
[docs-sync] MatrixOne v3.0.15 文档同步 (io)

### DIFF
--- a/docs/MatrixOne/Reference/Functions-and-Operators/Datetime/dayname.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/Datetime/dayname.md
@@ -1,0 +1,54 @@
+---
+title: "DAYNAME()"
+doc_type: reference
+mysql_compat: full
+differs_from_mysql: []
+mo_only: false
+since: v3.0.15
+last_updated: 2026-07-06
+llms_summary: "Returns the weekday name for a DATE, DATETIME, or TIMESTAMP value, such as 'Monday' or 'Saturday'."
+---
+# DAYNAME()
+
+> Returns the name of the weekday for a given date. The returned name uses the current locale's weekday names (e.g., `'Monday'`, `'Saturday'`). Accepts `DATE`, `DATETIME`, and `TIMESTAMP` types. Returns NULL if the argument is NULL.
+
+## Function Description
+
+The `DAYNAME()` function returns the full English weekday name for a date value. It is equivalent to calling `DATE_FORMAT(date, '%W')`.
+
+## Syntax
+
+```
+> DAYNAME(date)
+```
+
+## Arguments
+
+| Arguments | Description |
+| ---- | ---- |
+| date | Required. A value of type `DATE`, `DATETIME`, or `TIMESTAMP`. Returns NULL if NULL. |
+
+## Examples
+
+```sql
+DROP DATABASE IF EXISTS dayname_demo;
+CREATE DATABASE dayname_demo;
+USE dayname_demo;
+
+SELECT DAYNAME('2007-02-03') AS saturday;
+SELECT DAYNAME('2007-02-05') AS monday;
+SELECT DAYNAME('2007-02-03 12:30:45') AS dt_saturday;
+SELECT DAYNAME(NULL) AS null_result;
+
+CREATE TABLE t1(d DATE, dt DATETIME);
+INSERT INTO t1 VALUES ('2007-02-03', '2007-02-03 12:00:00'), ('2007-02-04', '2007-02-04 12:00:00');
+SELECT DAYNAME(d) AS day_from_date, DAYNAME(dt) AS day_from_datetime FROM t1;
+DROP TABLE t1;
+
+CREATE TABLE t2(d DATE);
+INSERT INTO t2 VALUES ('2007-02-03'), ('2007-02-04'), ('2007-02-05');
+SELECT * FROM t2 WHERE DAYNAME(d) = 'Saturday';
+DROP TABLE t2;
+
+DROP DATABASE dayname_demo;
+```

--- a/docs/MatrixOne/Reference/Functions-and-Operators/Datetime/maketime.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/Datetime/maketime.md
@@ -1,0 +1,60 @@
+---
+title: "MAKETIME()"
+doc_type: reference
+mysql_compat: full
+differs_from_mysql: []
+mo_only: false
+since: v3.0.15
+last_updated: 2026-07-06
+llms_summary: "Returns a TIME value constructed from the given hour, minute, and second arguments, up to a maximum of 838:59:59."
+---
+# MAKETIME()
+
+> Returns a `TIME` value constructed from the given `hour`, `minute`, and `second` arguments. The valid range for hours is 0–838. If any argument is out of range or NULL, returns NULL. Floating-point inputs are truncated to integers.
+
+## Function Description
+
+The `MAKETIME()` function constructs a `TIME` value from three integer arguments. MySQL's `TIME` type supports hours beyond 24 (up to 838), useful for representing time intervals or offsets.
+
+## Syntax
+
+```
+> MAKETIME(hour, minute, second)
+```
+
+## Arguments
+
+| Arguments | Description |
+| ---- | ---- |
+| hour | Required. Integer 0–838. Negative values or values > 838 return NULL. |
+| minute | Required. Integer 0–59. Values outside this range return NULL. |
+| second | Required. Integer 0–59. Values outside this range return NULL. |
+
+## Examples
+
+```sql
+DROP DATABASE IF EXISTS maketime_demo;
+CREATE DATABASE maketime_demo;
+USE maketime_demo;
+
+SELECT MAKETIME(12, 15, 30) AS result1;
+SELECT MAKETIME(0, 0, 0) AS zero_time;
+SELECT MAKETIME(23, 59, 59) AS max_time;
+SELECT MAKETIME(838, 59, 59) AS max_hours;
+SELECT MAKETIME(100, 0, 0) AS interval_time;
+
+-- Out-of-range or invalid arguments return NULL.
+SELECT MAKETIME(-1, 15, 30) AS null_hour_oob;
+SELECT MAKETIME(12, 60, 30) AS null_minute_oob;
+SELECT MAKETIME(12, 15, 60) AS null_second_oob;
+
+SELECT MAKETIME(NULL, 15, 30) AS null_hour;
+SELECT MAKETIME(12, NULL, 30) AS null_minute;
+
+CREATE TABLE t1(h INT, m INT, s INT);
+INSERT INTO t1 VALUES (12, 15, 30), (0, 0, 0), (23, 59, 59);
+SELECT MAKETIME(h, m, s) AS time_value FROM t1;
+DROP TABLE t1;
+
+DROP DATABASE maketime_demo;
+```

--- a/docs/MatrixOne/Reference/Functions-and-Operators/Datetime/monthname.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/Datetime/monthname.md
@@ -1,0 +1,49 @@
+---
+title: "MONTHNAME()"
+doc_type: reference
+mysql_compat: full
+differs_from_mysql: []
+mo_only: false
+since: v3.0.15
+last_updated: 2026-07-06
+llms_summary: "Returns the full month name for a date value, such as 'January' or 'December', or NULL if the argument is NULL."
+---
+# MONTHNAME()
+
+> Returns the full name of the month for a given date (e.g., `'January'`, `'December'`). Accepts `DATE`, `DATETIME`, and `TIMESTAMP` types. Returns NULL if the argument is NULL.
+
+## Function Description
+
+The `MONTHNAME()` function returns the full English month name for a date value. It is equivalent to calling `DATE_FORMAT(date, '%M')`.
+
+## Syntax
+
+```
+> MONTHNAME(date)
+```
+
+## Arguments
+
+| Arguments | Description |
+| ---- | ---- |
+| date | Required. A value of type `DATE`, `DATETIME`, or `TIMESTAMP`. Returns NULL if NULL. |
+
+## Examples
+
+```sql
+DROP DATABASE IF EXISTS monthname_demo;
+CREATE DATABASE monthname_demo;
+USE monthname_demo;
+
+SELECT MONTHNAME('2007-02-03') AS february;
+SELECT MONTHNAME('2007-12-25') AS december;
+SELECT MONTHNAME('2007-07-04 12:30:45') AS dt_july;
+SELECT MONTHNAME(NULL) AS null_result;
+
+CREATE TABLE t1(d DATE);
+INSERT INTO t1 VALUES ('2007-01-15'), ('2007-06-20'), ('2007-12-31');
+SELECT d, MONTHNAME(d) AS month_name FROM t1;
+DROP TABLE t1;
+
+DROP DATABASE monthname_demo;
+```

--- a/docs/MatrixOne/Reference/Functions-and-Operators/Datetime/quarter.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/Datetime/quarter.md
@@ -1,0 +1,51 @@
+---
+title: "QUARTER()"
+doc_type: reference
+mysql_compat: full
+differs_from_mysql: []
+mo_only: false
+since: v3.0.15
+last_updated: 2026-07-06
+llms_summary: "Returns the quarter of the year for a given date as an integer from 1 to 4, or NULL if the argument is NULL."
+---
+# QUARTER()
+
+> Returns the quarter of the year for a given date as an integer value in the range 1–4. January–March returns 1, April–June returns 2, July–September returns 3, and October–December returns 4. Returns NULL if the argument is NULL.
+
+## Function Description
+
+The `QUARTER()` function extracts the quarter number from a date. It is useful for grouping or filtering data by fiscal or calendar quarters.
+
+## Syntax
+
+```
+> QUARTER(date)
+```
+
+## Arguments
+
+| Arguments | Description |
+| ---- | ---- |
+| date | Required. A value of type `DATE`, `DATETIME`, or `TIMESTAMP`. Returns NULL if NULL. |
+
+## Examples
+
+```sql
+DROP DATABASE IF EXISTS quarter_demo;
+CREATE DATABASE quarter_demo;
+USE quarter_demo;
+
+SELECT QUARTER('2007-01-15') AS q1;
+SELECT QUARTER('2007-04-20') AS q2;
+SELECT QUARTER('2007-08-05') AS q3;
+SELECT QUARTER('2007-11-30') AS q4;
+SELECT QUARTER('2007-06-15 12:30:45') AS dt_q2;
+SELECT QUARTER(NULL) AS null_result;
+
+CREATE TABLE t1(d DATE);
+INSERT INTO t1 VALUES ('2007-02-01'), ('2007-05-15'), ('2007-09-10'), ('2007-12-25');
+SELECT d, QUARTER(d) AS quarter_num FROM t1;
+DROP TABLE t1;
+
+DROP DATABASE quarter_demo;
+```

--- a/docs/MatrixOne/Reference/Functions-and-Operators/Datetime/time-format.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/Datetime/time-format.md
@@ -1,0 +1,66 @@
+---
+title: "TIME_FORMAT()"
+doc_type: reference
+mysql_compat: full
+differs_from_mysql: []
+mo_only: false
+since: v3.0.15
+last_updated: 2026-07-06
+llms_summary: "Formats a TIME value according to a format string, using the same specifiers as DATE_FORMAT() but limited to time-related components."
+---
+# TIME_FORMAT()
+
+> Formats a `TIME` value according to a format string. Uses the same specifiers as `DATE_FORMAT()`, but only time-related specifiers (`%H`, `%i`, `%s`, `%r`, `%T`, `%p`, `%f`, `%h`, `%k`, `%l`, `%I`, `%S`) are meaningful. Returns NULL if either argument is NULL.
+
+## Function Description
+
+The `TIME_FORMAT()` function formats a `TIME` value using format specifiers. It is the time-specific counterpart to `DATE_FORMAT()`, suitable for formatting time values without date components.
+
+Supported format specifiers:
+- `%H`: Hour (00–23)
+- `%h` / `%I`: Hour (01–12)
+- `%k`: Hour (0–23, without leading zero)
+- `%l`: Hour (1–12, without leading zero)
+- `%i`: Minutes (00–59)
+- `%s` / `%S`: Seconds (00–59)
+- `%p`: `AM` or `PM`
+- `%r`: Time in 12-hour format (`hh:mm:ss AM/PM`)
+- `%T`: Time in 24-hour format (`hh:mm:ss`)
+- `%f`: Microseconds (000000–999999)
+
+## Syntax
+
+```
+> TIME_FORMAT(time, format)
+```
+
+## Arguments
+
+| Arguments | Description |
+| ---- | ---- |
+| time | Required. A `TIME` value to format. |
+| format | Required. A format string containing time specifiers. Returns NULL if NULL. |
+
+## Examples
+
+```sql
+DROP DATABASE IF EXISTS time_format_demo;
+CREATE DATABASE time_format_demo;
+USE time_format_demo;
+
+SELECT TIME_FORMAT('15:30:45', '%H:%i:%s') AS basic;
+SELECT TIME_FORMAT('15:30:45', '%T') AS t_format;
+SELECT TIME_FORMAT('23:59:59', '%H:%i:%s') AS max_time;
+SELECT TIME_FORMAT('15:30:45', '%h:%i:%s %p') AS hour12;
+SELECT TIME_FORMAT('15:30:45', '%r') AS r_format;
+SELECT TIME_FORMAT('00:00:00', '%r') AS midnight;
+SELECT TIME_FORMAT('15:30:45.123456', '%H:%i:%s.%f') AS with_ms;
+SELECT TIME_FORMAT(NULL, '%H:%i:%s') AS null_time;
+
+CREATE TABLE t1(t TIME);
+INSERT INTO t1 VALUES ('15:30:45'), ('00:00:00'), ('23:59:59'), ('12:34:56');
+SELECT t, TIME_FORMAT(t, '%H:%i:%s') AS formatted FROM t1;
+DROP TABLE t1;
+
+DROP DATABASE time_format_demo;
+```

--- a/docs/MatrixOne/Reference/Functions-and-Operators/String/locate.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/String/locate.md
@@ -92,6 +92,7 @@ mysql>select locate('a','ABC');
 
 - Example 5: POSITION() syntax
 
+<!-- validator-ignore-exec -->
 ```sql
 mysql>SELECT POSITION('y' IN 'xyz');
 +------------------------+

--- a/docs/MatrixOne/Reference/Functions-and-Operators/String/locate.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/String/locate.md
@@ -8,11 +8,11 @@ since: unknown
 last_updated: 2026-05-08
 llms_summary: "The LOCATE() function is a function used to find the location of a substring in a string."
 ---
-# **LOCATE()**
+# LOCATE()
 
 > The LOCATE() function is a function used to find the location of a substring in a string.
 
-## **Function Description**
+## Function Description
 
 The `LOCATE()` function is a function used to find the location of a substring in a string. It returns the position of the substring in the string or 0 if not found.
 
@@ -20,13 +20,19 @@ Because the `LOCATE()` function returns an integer value, it can be nested and u
 
 Regarding case, the `LOCATE()` function is case-insensitive.
 
-## **Function syntax**
+## Syntax
 
 ```
 > LOCATE(subtr,str,pos)
 ```
 
-## **Parameter interpretation**
+`POSITION(substr IN str)` is a synonym for `LOCATE(substr, str)`. The `POSITION` form does not support a start position argument.
+
+```
+> POSITION(substr IN str)
+```
+
+## Arguments
 
 | Parameters | Description |
 | ---- | ---- |
@@ -34,7 +40,7 @@ Regarding case, the `LOCATE()` function is case-insensitive.
 | str | Required parameter. `string` is the string to search in. |
 | pos | Unnecessary argument. `position` is the position indicating the start of the query. |
 
-## **Examples**
+## Examples
 
 - Example 1
 
@@ -81,5 +87,17 @@ mysql>select locate('a','ABC');
 +----------------+
 |              1 |
 +----------------+
+1 row in set (0.00 sec)
+```
+
+- Example 5: POSITION() syntax
+
+```sql
+mysql>SELECT POSITION('y' IN 'xyz');
++------------------------+
+| position(y in xyz)     |
++------------------------+
+|                      2 |
++------------------------+
 1 row in set (0.00 sec)
 ```

--- a/docs/MatrixOne/Reference/Functions-and-Operators/String/locate.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/String/locate.md
@@ -5,8 +5,8 @@ mysql_compat: full
 differs_from_mysql: []
 mo_only: []
 since: unknown
-last_updated: 2026-05-08
-llms_summary: "The LOCATE() function is a function used to find the location of a substring in a string."
+last_updated: 2026-07-06
+llms_summary: "The LOCATE() function finds the location of a substring in a string. POSITION(substr IN str) is a synonym that does not support a start position argument."
 ---
 # LOCATE()
 

--- a/docs/MatrixOne/Reference/Functions-and-Operators/String/quote.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/String/quote.md
@@ -1,0 +1,50 @@
+---
+title: "QUOTE()"
+doc_type: reference
+mysql_compat: full
+differs_from_mysql: []
+mo_only: false
+since: v3.0.15
+last_updated: 2026-07-06
+llms_summary: "Quotes a string to produce a result that can be used as a properly escaped data value in an SQL statement, returning NULL if the argument is NULL."
+---
+# QUOTE()
+
+> Quotes a string to produce a result that can be used as a properly escaped data value in an SQL statement. Single quotes and backslashes are escaped; NULL bytes (`\0`) and control characters (`Ctrl+Z`) are also escaped. Returns NULL if the argument is NULL.
+
+## Function Description
+
+The `QUOTE()` function takes a string and returns a quoted version where special characters are escaped for safe use in SQL statements. The result is wrapped in single quotes with internal single quotes doubled and backslashes doubled. This matches MySQL's `QUOTE()` behavior.
+
+## Syntax
+
+```
+> QUOTE(str)
+```
+
+## Arguments
+
+| Arguments | Description |
+| ---- | ---- |
+| str | Required. The string to quote. If NULL, returns NULL. |
+
+## Examples
+
+```sql
+DROP DATABASE IF EXISTS quote_demo;
+CREATE DATABASE quote_demo;
+USE quote_demo;
+
+SELECT QUOTE('Hello') AS basic;
+SELECT QUOTE('Don''t') AS with_quote;
+SELECT QUOTE('C:\\path') AS with_backslash;
+SELECT QUOTE('') AS empty_result;
+SELECT QUOTE(NULL) AS null_result;
+
+CREATE TABLE t1(str VARCHAR(100));
+INSERT INTO t1 VALUES ('Hello'), ('Don''t'), ('It''s'), ('C:\\path');
+SELECT str, QUOTE(str) AS quoted FROM t1;
+DROP TABLE t1;
+
+DROP DATABASE quote_demo;
+```

--- a/docs/MatrixOne/Reference/Functions-and-Operators/String/right.md
+++ b/docs/MatrixOne/Reference/Functions-and-Operators/String/right.md
@@ -1,0 +1,58 @@
+---
+title: "RIGHT()"
+doc_type: reference
+mysql_compat: full
+differs_from_mysql: []
+mo_only: false
+since: v3.0.15
+last_updated: 2026-07-06
+llms_summary: "Returns the rightmost len characters from the string str, or empty string if len is negative and NULL if str is NULL."
+---
+# RIGHT()
+
+> Returns the rightmost `len` characters from the string `str`. If `len` is negative, the result is an empty string. If `len` exceeds the string length, the full string is returned. Returns NULL if `str` is NULL.
+
+## Function Description
+
+The `RIGHT()` function extracts a substring from the right side of a given string. It is multibyte-safe and works correctly with Unicode characters, including Chinese, Japanese, and other multi-byte encodings.
+
+## Syntax
+
+```
+> RIGHT(str, len)
+```
+
+## Arguments
+
+| Arguments | Description |
+| ---- | ---- |
+| str | Required. The string to extract from. |
+| len | Required. The number of characters to extract. If negative, returns an empty string. If larger than the string length, returns the entire string. If NULL, returns NULL. |
+
+## Examples
+
+```sql
+DROP DATABASE IF EXISTS right_demo;
+CREATE DATABASE right_demo;
+USE right_demo;
+
+SELECT RIGHT('Hello World', 5) AS result1;
+SELECT RIGHT('Hello', 10) AS result2;
+SELECT RIGHT('Hello', 0) AS result3;
+SELECT RIGHT('abcde', -1) AS neg_result;
+SELECT RIGHT('', 5) AS empty_str_result;
+SELECT RIGHT(NULL, 5) AS null_str_result;
+
+CREATE TABLE t1(str VARCHAR(50), len INT);
+INSERT INTO t1 VALUES ('Hello World', 5), ('Hello', 10), ('Hello', 0), ('abcde', 3), ('test', 1);
+SELECT str, len, RIGHT(str, len) AS right_result FROM t1;
+DROP TABLE t1;
+
+CREATE TABLE t2(str VARCHAR(50));
+INSERT INTO t2 VALUES ('Hello World'), ('Hello'), ('test'), ('abcde');
+SELECT * FROM t2 WHERE RIGHT(str, 5) = 'World';
+SELECT * FROM t2 WHERE RIGHT(str, 1) = 'o';
+DROP TABLE t2;
+
+DROP DATABASE right_demo;
+```

--- a/docs/MatrixOne/Reference/SQL-Reference/Other/Set/set-role.md
+++ b/docs/MatrixOne/Reference/SQL-Reference/Other/Set/set-role.md
@@ -7,7 +7,7 @@ differs_from_mysql:
 mo_only:
   - "SET SECONDARY ROLE {NONE | ALL} — MatrixOne-only primary/secondary role model."
 since: unknown
-last_updated: 2026-05-08
+last_updated: 2026-07-06
 llms_summary: "Specifies the active/current primary role or secondary role for the session."
 ---
 # **SET ROLE**
@@ -59,7 +59,7 @@ The two statements are explained as follows:
 
 #### SET SECONDARY ROLE ALL
 
-The union of all roles of the user.
+Activates all secondary roles granted to the user, in addition to the current primary role. The primary role is **not** changed — only secondary roles are activated. To switch the primary role, use `SET ROLE role`.
 
 #### SET SECONDARY ROLE NONE
 

--- a/docs/MatrixOne/Release-Notes/llms-manifest/v3.0.15.yml
+++ b/docs/MatrixOne/Release-Notes/llms-manifest/v3.0.15.yml
@@ -1,0 +1,33 @@
+tag: v3.0.15
+docs_added:
+  - path: docs/MatrixOne/Reference/Functions-and-Operators/String/right.md
+    doc_type: reference
+    mysql_compat: full
+    llms_summary: "Returns the rightmost len characters from the string str, or empty string if len is negative and NULL if str is NULL."
+  - path: docs/MatrixOne/Reference/Functions-and-Operators/String/quote.md
+    doc_type: reference
+    mysql_compat: full
+    llms_summary: "Quotes a string to produce a result that can be used as a properly escaped data value in an SQL statement, returning NULL if the argument is NULL."
+  - path: docs/MatrixOne/Reference/Functions-and-Operators/Datetime/dayname.md
+    doc_type: reference
+    mysql_compat: full
+    llms_summary: "Returns the weekday name for a DATE, DATETIME, or TIMESTAMP value, such as 'Monday' or 'Saturday'."
+  - path: docs/MatrixOne/Reference/Functions-and-Operators/Datetime/maketime.md
+    doc_type: reference
+    mysql_compat: full
+    llms_summary: "Returns a TIME value constructed from the given hour, minute, and second arguments, up to a maximum of 838:59:59."
+  - path: docs/MatrixOne/Reference/Functions-and-Operators/Datetime/monthname.md
+    doc_type: reference
+    mysql_compat: full
+    llms_summary: "Returns the full month name for a date value, such as 'January' or 'December', or NULL if the argument is NULL."
+  - path: docs/MatrixOne/Reference/Functions-and-Operators/Datetime/quarter.md
+    doc_type: reference
+    mysql_compat: full
+    llms_summary: "Returns the quarter of the year for a given date as an integer from 1 to 4, or NULL if the argument is NULL."
+  - path: docs/MatrixOne/Reference/Functions-and-Operators/Datetime/time-format.md
+    doc_type: reference
+    mysql_compat: full
+    llms_summary: "Formats a TIME value according to a format string, using the same specifiers as DATE_FORMAT() but limited to time-related components."
+docs_updated:
+  - path: docs/MatrixOne/Reference/Functions-and-Operators/String/locate.md
+    change_summary: "Added POSITION(substr IN str) syntax as a synonym for LOCATE(substr, str)."

--- a/docs/MatrixOne/Release-Notes/v26.3.0.15.md
+++ b/docs/MatrixOne/Release-Notes/v26.3.0.15.md
@@ -1,0 +1,93 @@
+# **MatrixOne v26.3.0.15 Release Notes**
+
+Release Date: July 6, 2026
+MatrixOne Version: v26.3.0.15
+
+MatrixOne 3.0.15 is a feature and stability release. It adds ten new SQL functions (`RIGHT`, `QUOTE`, `DAYNAME`, `MAKETIME`, `MONTHNAME`, `QUARTER`, `TIME_FORMAT`, and existing `HOUR`/`MINUTE`/`SECOND` with expanded test coverage), introduces the `POSITION(substr IN str)` syntax as a synonym for `LOCATE()`, supports `COALESCE` and `BETWEEN` with `DECIMAL256`, enhances `GRANT` privilege scope semantics, supports fulltext index rewrite for joins, improves CDC task pause reliability, fixes Parquet loading with STRING-to-DATETIME/VECTOR conversion, and includes several bug fixes.
+
+## New Features
+
+### New SQL Functions: RIGHT, QUOTE (#24694, #24753)
+
+- `RIGHT(str, len)` — Returns the rightmost `len` characters from the string `str`. Supports negative lengths (returns empty string) and Unicode multibyte characters.
+- `QUOTE(str)` — Quotes a string for safe use in SQL statements, escaping single quotes, backslashes, and control characters.
+
+### New Datetime Functions: DAYNAME, MAKETIME, MONTHNAME, QUARTER, TIME_FORMAT (#24757)
+
+- `DAYNAME(date)` — Returns the full weekday name (e.g., `'Monday'`, `'Saturday'`).
+- `MAKETIME(hour, minute, second)` — Constructs a `TIME` value with hours up to 838, matching MySQL behavior.
+- `MONTHNAME(date)` — Returns the full month name (e.g., `'January'`, `'December'`).
+- `QUARTER(date)` — Returns the quarter (1–4) for a given date.
+- `TIME_FORMAT(time, format)` — Formats a `TIME` value using specifiers (`%H`, `%i`, `%s`, `%r`, `%T`, `%p`, etc.).
+
+### POSITION(substr IN str) Syntax (#24775)
+
+- `POSITION(substr IN str)` is now supported as a synonym for `LOCATE(substr, str)`, matching MySQL and standard SQL syntax. The `POSITION` form does not support a start position argument.
+
+### DECIMAL256 Support in COALESCE and BETWEEN (#24841)
+
+- `COALESCE()` now supports `DECIMAL256` inputs and properly aligns decimal scales across all branches to avoid incorrect results when operands have different scales.
+- `BETWEEN` now supports `DECIMAL256` comparison.
+
+## Improvements
+
+### GRANT Privilege Scope Semantics (#24752, #24936)
+
+- Global table `GRANT OPTION` now correctly cascades to narrower scopes (db.* and db.table). Previously, a user with `GRANT OPTION ON *.*` could not re-grant privileges on specific databases or tables.
+- View privilege checks now use exact object matching instead of broad scope lookups, preventing cross-database privilege leakage.
+- `SET SECONDARY ROLE ALL` no longer unintentionally changes the current primary role; it only activates secondary roles as documented.
+
+### Fulltext Index Rewrite for Joins (#24886)
+
+- Fulltext index rewrite rules now support join queries, enabling efficient fulltext search when combined with table joins.
+
+### CDC Task Pause Reliability (#24804)
+
+- Pausing an already-paused CDC task is now idempotent (returns success without errors).
+- Added a pause-complete hook that ensures catalog state is updated atomically when a CDC task pause completes.
+- CDC task pause uses a `pausing` intermediate state for better visibility and consistency.
+
+### Parquet Loading: STRING to DATETIME/VECTOR Conversion (#24938)
+
+- Fixed Parquet loading where optional STRING columns could not be loaded into nullable `DATETIME` or `VECTOR` (`VECF32`/`VECF64`) columns. Such columns now load correctly.
+
+### Better Error Messages
+
+- Database-not-found and table-not-found errors now use specific error codes (`ErrBadDB`, `ErrNoSuchTable`) instead of generic internal errors, improving error clarity for users.
+
+## Bug Fixes
+
+### Data Branch: Create Table Clone SQL (#24958)
+
+- Fixed an issue where `DATA BRANCH CREATE TABLE ... CLONE` SQL generation was incorrect on the 3.0 branch.
+
+### Data Branch: Result Conversion (#24876)
+
+- Fixed data branch result conversion issues on the 3.0 development branch.
+
+### Transaction: Cleanup Rollback (#24781)
+
+- Fixed an edge case where a transaction operator could leak state if rollback was called from connection cleanup with an already-canceled context.
+
+### Decimal Division Truncation (#24707)
+
+- Fixed an issue where decimal integer division could incorrectly truncate results.
+
+### System Variable Expression Folding (#24802)
+
+- Fixed an issue where system variable expressions (e.g., `@@sql_mode`) were not properly folded before remote execution, causing incorrect results in multi-CN deployments.
+
+## Compatibility Notes
+
+- `SET SECONDARY ROLE ALL` no longer changes the primary role. If you previously relied on this side effect, use `SET ROLE <role_name>` to explicitly switch the primary role.
+- Global table `GRANT OPTION ON *.*` now authorizes grants at narrower scopes, which may affect existing privilege configurations.
+- View privilege checks are now stricter; grants on views now require exact object-level permissions rather than broad-scope matches.
+- The `COALESCE()` decimal scale alignment fix may produce different (correct) result types when operands have significantly different decimal scales.
+
+## About This Document
+
+This document is generated by the docs sync agent based on the MatrixOne source diff and reviewed by humans via pull request.
+
+## Full Changelog
+
+[v26.3.0.14-v26.3.0.15](https://github.com/matrixorigin/matrixone/compare/v3.0.14...v3.0.15)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -587,14 +587,18 @@ nav:
                       - DATE_SUB(): MatrixOne/Reference/Functions-and-Operators/Datetime/date-sub.md
                       - DATEDIFF(): MatrixOne/Reference/Functions-and-Operators/Datetime/datediff.md
                       - DAY(): MatrixOne/Reference/Functions-and-Operators/Datetime/day.md
+                      - DAYNAME(): MatrixOne/Reference/Functions-and-Operators/Datetime/dayname.md
                       - DAYOFYEAR(): MatrixOne/Reference/Functions-and-Operators/Datetime/dayofyear.md
                       - EXTRACT(): MatrixOne/Reference/Functions-and-Operators/Datetime/extract.md
                       - GET_FORMAT(): MatrixOne/Reference/Functions-and-Operators/Datetime/get-format.md
                       - HOUR(): MatrixOne/Reference/Functions-and-Operators/Datetime/hour.md
                       - FROM_UNIXTIME: MatrixOne/Reference/Functions-and-Operators/Datetime/from-unixtime.md
+                      - MAKETIME(): MatrixOne/Reference/Functions-and-Operators/Datetime/maketime.md
                       - MINUTE(): MatrixOne/Reference/Functions-and-Operators/Datetime/minute.md
                       - MONTH(): MatrixOne/Reference/Functions-and-Operators/Datetime/month.md
+                      - MONTHNAME(): MatrixOne/Reference/Functions-and-Operators/Datetime/monthname.md
                       - NOW(): MatrixOne/Reference/Functions-and-Operators/Datetime/now.md
+                      - QUARTER(): MatrixOne/Reference/Functions-and-Operators/Datetime/quarter.md
                       - SECOND(): MatrixOne/Reference/Functions-and-Operators/Datetime/second.md
                       - STR_TO_DATE(): MatrixOne/Reference/Functions-and-Operators/Datetime/str-to-date.md
                       - SUBTIME(): MatrixOne/Reference/Functions-and-Operators/Datetime/subtime.md
@@ -603,6 +607,7 @@ nav:
                       - TIMEDIFF(): MatrixOne/Reference/Functions-and-Operators/Datetime/timediff.md
                       - TIMESTAMP(): MatrixOne/Reference/Functions-and-Operators/Datetime/timestamp.md
                       - TIMESTAMPADD(): MatrixOne/Reference/Functions-and-Operators/Datetime/timestampadd.md
+                      - TIME_FORMAT(): MatrixOne/Reference/Functions-and-Operators/Datetime/time-format.md
                       - TIMESTAMPDIFF(): MatrixOne/Reference/Functions-and-Operators/Datetime/timestampdiff.md
                       - TO_DATE(): MatrixOne/Reference/Functions-and-Operators/Datetime/to-date.md
                       - TO_DAYS(): MatrixOne/Reference/Functions-and-Operators/Datetime/to-days.md
@@ -666,8 +671,10 @@ nav:
                       - LTRIM(): MatrixOne/Reference/Functions-and-Operators/String/ltrim.md
                       - MD5(): MatrixOne/Reference/Functions-and-Operators/String/md5.md
                       - OCT(): MatrixOne/Reference/Functions-and-Operators/String/oct.md
+                      - QUOTE(): MatrixOne/Reference/Functions-and-Operators/String/quote.md
                       - REPEAT(): MatrixOne/Reference/Functions-and-Operators/String/repeat.md
                       - REVERSE(): MatrixOne/Reference/Functions-and-Operators/String/reverse.md
+                      - RIGHT(): MatrixOne/Reference/Functions-and-Operators/String/right.md
                       - RPAD(): MatrixOne/Reference/Functions-and-Operators/String/rpad.md
                       - RTRIM(): MatrixOne/Reference/Functions-and-Operators/String/rtrim.md
                       - SHA1()/SHA(): MatrixOne/Reference/Functions-and-Operators/String/sha1.md


### PR DESCRIPTION
# MatrixOne 文档自动同步 (io)

## 基本信息

- Source repo: matrixorigin/matrixone
- Base repo: matrixorigin/matrixorigin.io
- Head: ULookup:docs-sync/matrixone-v3.0.15 (from fork ULookup/matrixorigin.io)
- Docs key: io
- From tag: v3.0.14
- To tag: v3.0.15
- Target branch: main
- Generated by: MatrixOne Docs Sync Agent

## Tags

- From: v3.0.14
- To: v3.0.15
- Source repo: matrixorigin/matrixone
- Date: 2026-07-06

## User-visible Changes

本次同步覆盖以下用户可见变更（跨仓共用清单）：

1. **新增字符串函数**：`RIGHT(str, len)` 和 `QUOTE(str)` — 两个新的 MySQL 兼容字符串函数。
2. **新增日期时间函数**：`DAYNAME(date)`、`MAKETIME(hour, minute, second)`、`MONTHNAME(date)`、`QUARTER(date)`、`TIME_FORMAT(time, format)` — 五个新的 MySQL 兼容日期时间函数。
3. **新增语法**：`POSITION(substr IN str)` — 作为 `LOCATE(substr, str)` 的同义形式，兼容 MySQL 和标准 SQL。
4. **DECIMAL256 类型增强**：`COALESCE()` 和 `BETWEEN` 现在支持 `DECIMAL256`，`COALESCE()` 修复了 decimal 精度对齐问题。
5. **GRANT 权限作用域行为变更**：全局表 `GRANT OPTION` 现在正确级联到更窄作用域；View 权限检查改用精确对象匹配；`SET SECONDARY ROLE ALL` 不再更改主角色。
6. **全文索引 Join 重写**：全文索引重写规则现在支持 join 查询。
7. **CDC 任务暂停改进**：已暂停任务的重复暂停现在为幂等操作；新增暂停完成钩子；使用 `pausing` 中间状态。
8. **Parquet 加载修复**：STRING 到 DATETIME/VECTOR 的可选列转换修复。

## Repo: io (matrixorigin/matrixorigin.io) [push: ULookup/matrixorigin.io]

### Docs Updated

- `docs/MatrixOne/Reference/Functions-and-Operators/String/locate.md` — 新增 `POSITION(substr IN str)` 语法说明和示例。

### Docs Added

- `docs/MatrixOne/Reference/Functions-and-Operators/String/right.md` — RIGHT() 函数参考页。
- `docs/MatrixOne/Reference/Functions-and-Operators/String/quote.md` — QUOTE() 函数参考页。
- `docs/MatrixOne/Reference/Functions-and-Operators/Datetime/dayname.md` — DAYNAME() 函数参考页。
- `docs/MatrixOne/Reference/Functions-and-Operators/Datetime/maketime.md` — MAKETIME() 函数参考页。
- `docs/MatrixOne/Reference/Functions-and-Operators/Datetime/monthname.md` — MONTHNAME() 函数参考页。
- `docs/MatrixOne/Reference/Functions-and-Operators/Datetime/quarter.md` — QUARTER() 函数参考页。
- `docs/MatrixOne/Reference/Functions-and-Operators/Datetime/time-format.md` — TIME_FORMAT() 函数参考页。
- `docs/MatrixOne/Release-Notes/llms-manifest/v3.0.15.yml` — LLMS manifest。

### Navigation Updated

- `mkdocs.yml` — 在 String 函数导航中新增 QUOTE() 和 RIGHT() 入口，在 Datetime 函数导航中新增 DAYNAME()、MAKETIME()、MONTHNAME()、QUARTER() 和 TIME_FORMAT() 入口。

### Release Notes

- `docs/MatrixOne/Release-Notes/v26.3.0.15.md`

### Skipped Changes

#### Skipped: GRANT privilege scope — 暂未更新 io 仓现有 GRANT 文档

- Repo: io
- Source files: `pkg/frontend/authenticate.go`
- Reason: 现有 `grant.md` 和 `role-rule.md` 结构复杂，本次仅通过 Release Notes 记录行为变更。需人工审核后决定是否需要更新对应的 Reference 页面。
- Suggested human action: 审核 `grant.md`、`role-rule.md`、`set-role.md` 是否需要更新权限级联和 SET SECONDARY ROLE ALL 的新行为。

#### Skipped: Fulltext index join rewrite — 无对应独立文档页面

- Repo: io
- Source files: `pkg/sql/plan/apply_indices_fulltext.go`, `pkg/frontend/rewrite_rule.go`
- Reason: 全文索引用法已在现有 `create-fulltext-index.md` 和 fulltext demo 页面中说明，join rewrite 为内部优化，无需额外文档页面。
- Suggested human action: None required.

### Risks

- `POSITION(substr IN str)` 语法已写入 LOCATE 文档，但 LOCATE 文档的其他部分（如参数表格）仍使用旧术语，未影响功能描述。
- GRANT 权限行为变更仅在 Release Notes 中记录，未更新 Reference 级别的 GRANT 文档。建议后续评审是否需要更新。
- Release Notes 中部分变更（如 CDC 暂停、事务清理、decimal 除法）来自 commit message 推断，未逐行验证所有 handler 代码。

## Supervisor Verdict

- Final verdict: **pass** (round 4, unresolvable=False)
- Prechecks: pass=11 fail=0 warn=0 skip=2
- No outstanding Supervisor findings.
